### PR TITLE
WIP: libqaul API sketch

### DIFF
--- a/libqaul/common/src/lib.rs
+++ b/libqaul/common/src/lib.rs
@@ -5,6 +5,9 @@ use generic_array::typenum::U64;
 use generic_array::GenericArray;
 mod message;
 mod payload;
+mod service;
+
+pub use message::Message;
 
 pub type HashBytes = GenericArray<u8, U64>;
 

--- a/libqaul/common/src/service.rs
+++ b/libqaul/common/src/service.rs
@@ -1,0 +1,22 @@
+//! Defines a basic interface for a Qaul service
+use crate::Message;
+use std::error::Error;
+
+/// The interface through which communication with a service occurs
+pub trait ServiceConnect<E: Error> {
+    /// The ID of the service this ServiceConnect is connected to
+    fn service_id(&self) -> String;
+    /// Send a Message to the service. Calls to this method must not block.
+    fn send_msg(&mut self) -> Result<(), E>;
+    /// Check for Messages received from the service. Calls to this message may block,
+    /// but not if the last call to poll_messages() returned true (if ServiceConnectAsync
+    /// is implemented for this type).
+    fn messages(&mut self) -> Result<Vec<Message>, E>;
+}
+
+/// Add-on interface for async communication with a service
+pub trait ServiceConnectAsync<E: Error>: ServiceConnect<E> {
+    /// Check whether or not the next call to messages() will block.
+    fn poll_messages(&mut self) -> Result<bool, E>;
+}
+


### PR DESCRIPTION
Add a basic outline for communicating with services. This can be used for "internal" services or those exposed over some kind of network, or more exotic things. Service connectors that implement only the synchronous version are very easy to implement, but there is an extended trait that provides a polling method for async implementations.

I'd like to wait to merge this PR until it contains at least a dummy service so we can try out async-ifying things and such. However, I'm not sure _precisely_ where this interface fits in, in terms of libqaul. Specifically, I'm not sure if we should implement the services like user management and local file management in-process (libqaul), in the qaul.net node process, or in external processes which communicate over the network.

This PR is called "API sketch" because I would really like to have a "sketch" of the basic services, as presented in https://cryptpad.open-communication.net/code/#/2/code/edit/HlymzFA07d+XvUcHXxj2mcI0/ , so I can work on simulating them.