### PR TITLE
qaul.net service drafts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,10 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "files"
-version = "0.1.0"
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,10 +59,6 @@ name = "linux-cli"
 version = "0.1.0"
 
 [[package]]
-name = "messaging"
-version = "0.1.0"
-
-[[package]]
 name = "netsim"
 version = "0.1.0"
 
@@ -76,8 +68,25 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "qaul-files"
+version = "0.1.0"
+dependencies = [
+ "libqaul 0.1.0",
+ "ratman-identity 0.1.0",
+]
+
+[[package]]
 name = "qaul-linux"
 version = "0.1.0"
+
+[[package]]
+name = "qaul-messaging"
+version = "0.1.0"
+dependencies = [
+ "libqaul 0.1.0",
+ "qaul-files 0.1.0",
+ "ratman-identity 0.1.0",
+]
 
 [[package]]
 name = "qaul-platform"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,14 @@ name = "linux-cli"
 version = "0.1.0"
 
 [[package]]
+name = "mime"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "netsim"
 version = "0.1.0"
 
@@ -72,6 +80,7 @@ name = "qaul-files"
 version = "0.1.0"
 dependencies = [
  "libqaul 0.1.0",
+ "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratman-identity 0.1.0",
 ]
 
@@ -132,6 +141,19 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicase"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "visn"
 version = "0.1.0"
 
@@ -141,6 +163,9 @@ version = "0.1.0"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/libqaul/service/core/src/lib.rs
+++ b/libqaul/service/core/src/lib.rs
@@ -1,1 +1,9 @@
 //! Provides the core service layer with user management
+//!
+//! The idea behind this crate is to wrap all the "core" functions
+//! of the `libqaul` service API in another layer to make them easier
+//! to consume for the HTTP API.
+//!
+//! Depending on how important this is, this crate might either be
+//! a shim crate, or be removed again in the future because it's redundant.
+

--- a/libqaul/service/files/Cargo.toml
+++ b/libqaul/service/files/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-name = "files"
+name = "qaul-files"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
 
 [dependencies]
+qaul = { path = "../../", package = "libqaul" }
+identity = { path = "../../../ratman/identity", package = "ratman-identity" }

--- a/libqaul/service/files/Cargo.toml
+++ b/libqaul/service/files/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 qaul = { path = "../../", package = "libqaul" }
 identity = { path = "../../../ratman/identity", package = "ratman-identity" }
+mime = "0.3"

--- a/libqaul/service/files/src/lib.rs
+++ b/libqaul/service/files/src/lib.rs
@@ -1,7 +1,32 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+//! `qaul.net` filesharing service
+
+use qaul::{Qaul, QaulResult, UserAuth};
+use identity::Identity;
+
+/// A typed file that can be sent across the network
+pub struct File {
+    mime: String,
+    data: Vec<u8>,
+}
+
+/// Filesharing service state
+pub struct Filesharing<'q> {
+    qaul: &'q Qaul,
+}
+
+impl<'q> Filesharing<'q> {
+    /// Send a single file to a group of people
+    pub fn send_file(
+        &self,
+        user: UserAuth,
+        recipients: Vec<Identity>,
+        file: File,
+    ) -> QaulResult<()> {
+        unimplemented!()
+    }
+
+    /// Get all files that were received since the last poll
+    pub fn poll_files(&self, user: UserAuth) -> QaulResult<Vec<File>> {
+        unimplemented!()
     }
 }

--- a/libqaul/service/files/src/lib.rs
+++ b/libqaul/service/files/src/lib.rs
@@ -2,11 +2,12 @@
 
 use qaul::{Qaul, QaulResult, UserAuth};
 use identity::Identity;
+pub use mime::Mime;
 
 /// A typed file that can be sent across the network
 pub struct File {
-    mime: String,
-    data: Vec<u8>,
+    pub mime: Mime,
+    pub data: Vec<u8>,
 }
 
 /// Filesharing service state

--- a/libqaul/service/messaging/Cargo.toml
+++ b/libqaul/service/messaging/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "messaging"
+name = "qaul-messaging"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
 
 [dependencies]
+qaul = { path = "../../", package = "libqaul" }
+files = { path = "../files", package = "qaul-files" }
+identity = { path = "../../../ratman/identity", package = "ratman-identity" }

--- a/libqaul/service/messaging/src/lib.rs
+++ b/libqaul/service/messaging/src/lib.rs
@@ -1,7 +1,60 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+//! `qaul.net` messaging service
+//!
+//! Provides a simple interface to deliver plain-text
+//! messages, with inline attachments, or optionally
+//! async-delivery links (requires `filesharing` service).
+//! It's basically decentralised e-mail.
+//! It's basically e-mail.
+
+use qaul::{Qaul, QaulResult, UserAuth};
+use identity::Identity;
+use files::File;
+
+/// A plain-text message with optional attachments
+pub struct Message {
+    text: String,
+    attachments: Option<Vec<Vec<u8>>>,
+}
+
+/// Messaging service state
+pub struct Messaging<'q> {
+    async_files: bool,
+    qaul: &'q Qaul,
+}
+
+impl<'q> Messaging<'q> {
+    /// Initialise the messaging service
+    ///
+    /// In order to initialise, a valid and running
+    /// `Qaul` reference needs to be provided.
+    /// This is then used to register this service,
+    /// but also check for the existence of a `filesharing` service.
+    /// Depending on this check, the `async_files` capability
+    /// can be set.
+    pub fn init(qaul: &'q Qaul) -> Self {
+        Self {
+            async_files: false,
+            qaul,
+        }
+    }
+
+    /// Check if the `async_files` capability is set on this service
+    pub fn async_files(&self) -> bool {
+        self.async_files
+    }
+
+    /// Send a plain-text message with optional arbitrary attachments
+    pub fn send_message(
+        &self,
+        user: UserAuth,
+        recipients: Vec<Identity>,
+        msg: Message,
+    ) -> QaulResult<()> {
+        unimplemented!()
+    }
+
+    /// Get all messages that were received since the last poll
+    pub fn poll_messages(&self, user: UserAuth) -> QaulResult<Vec<Message>> {
+        unimplemented!()
     }
 }

--- a/libqaul/service/messaging/src/lib.rs
+++ b/libqaul/service/messaging/src/lib.rs
@@ -10,10 +10,13 @@ use qaul::{Qaul, QaulResult, UserAuth};
 use identity::Identity;
 use files::File;
 
+/// A list of file-attachments
+pub type Attachments = Vec<File>;
+
 /// A plain-text message with optional attachments
 pub struct Message {
     text: String,
-    attachments: Option<Vec<Vec<u8>>>,
+    attachments: Option<Attachments>,
 }
 
 /// Messaging service state


### PR DESCRIPTION
This PR adds two services: messaging and files,
which allow people on a qaul network to exchange
text messages (like e-mail) as well as file-share links.

The API of the `messaging` service is flexible enough
to also allow inlining if a payload isn't too big.
Alternatively, the fallback "share link" will be used,
which mirrors the current behaviour of qaul.net (`<2.0.0`)