### PR TITLE
added pub to libqaul/identity

### DIFF
--- a/libqaul/src/lib.rs
+++ b/libqaul/src/lib.rs
@@ -9,7 +9,7 @@ mod storage;
 mod api;
 pub use api::*;
 
-use identity::Identity;
+pub use identity::Identity;
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},

--- a/scripts/publish_api.sh
+++ b/scripts/publish_api.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# build qaul rust documentation
+cargo doc
+
+# create index file
+cp ../target/doc/settings.html ../target/doc/index.html
+
+# upload documentation to api.qaul.net
+rsync -azhe "ssh -p 2224" ../target/doc/ admin@qaul.net:/home/admin


### PR DESCRIPTION
the http-api needs identity to be pub, otherwise it doesn't compile
needed to build rust documentation