### PR TITLE
Adding proper `license` tag to all qaul.net crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,10 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core"
-version = "0.1.0"
-
-[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +311,10 @@ dependencies = [
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "qaul-core"
+version = "0.1.0"
 
 [[package]]
 name = "qaul-files"

--- a/libqaul/Cargo.toml
+++ b/libqaul/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libqaul"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
+license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]

--- a/libqaul/http-api/Cargo.toml
+++ b/libqaul/http-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "qaul-http"
 version = "0.1.0"
 authors = ["Jess 3Jane <me@jess.coffee>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 iron = "0.6"

--- a/libqaul/platform/Cargo.toml
+++ b/libqaul/platform/Cargo.toml
@@ -4,6 +4,7 @@ description = "Platform specific abstraction utilities"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [features]
 pc_linux = []

--- a/libqaul/service/core/Cargo.toml
+++ b/libqaul/service/core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "core"
+name = "qaul-core"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]

--- a/libqaul/service/files/Cargo.toml
+++ b/libqaul/service/files/Cargo.toml
@@ -3,6 +3,7 @@ name = "qaul-files"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 qaul = { path = "../../", package = "libqaul" }

--- a/libqaul/service/messaging/Cargo.toml
+++ b/libqaul/service/messaging/Cargo.toml
@@ -3,6 +3,7 @@ name = "qaul-messaging"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 qaul = { path = "../../", package = "libqaul" }

--- a/netmod-sim/Cargo.toml
+++ b/netmod-sim/Cargo.toml
@@ -3,5 +3,6 @@ name = "netsim"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]

--- a/ratman/identity/Cargo.toml
+++ b/ratman/identity/Cargo.toml
@@ -4,6 +4,7 @@ description = "A small crate that provides an identity abstraction for RATMAN"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [features]
 digest = []

--- a/ratman/netmod/Cargo.toml
+++ b/ratman/netmod/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "ratman-netmod"
 version = "0.1.0"
-authors = ["Katharina Fey <kookie@spacekookie.de>",
-    "Leonora Tindall <nora@nora.codes>"]
+authors = [
+  "Katharina Fey <kookie@spacekookie.de>",
+  "Leonora Tindall <nora@nora.codes>"
+]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 identity = { path = "../identity", package = "ratman-identity" }

--- a/service-sim/Cargo.toml
+++ b/service-sim/Cargo.toml
@@ -3,5 +3,6 @@ name = "qaul-sim"
 version = "0.1.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]

--- a/visn/Cargo.toml
+++ b/visn/Cargo.toml
@@ -3,6 +3,7 @@ name = "visn"
 version = "0.1.0"
 authors = ["Leonora Tindall <nora@nora.codes>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 


### PR DESCRIPTION
So far a lot of qaul.net crates were wrongly picked up as
being MIT/Apache-2.0 licensed. Since the entire repo is
currently under the GPL-3.0, I added that license to all
of the `Cargo.toml` files. Running `cargo-license` will
now list all licenses correctly