### PR TITLE
Cookies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +398,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json-api 0.1.0 (git+https://github.com/qaul/json-api)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,6 +819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"

--- a/docs/http-api/src/SUMMARY.md
+++ b/docs/http-api/src/SUMMARY.md
@@ -2,6 +2,7 @@
 [Introduction](./intro.md)
 - [Topics](./topics/_intro.md)
 	- [Authentication](./topics/authentication.md)
+	- [Cookies](./topics/cookies.md)
 	- [JSON:API](./topics/jsonapi.md)
 - [Entities](./entities/_intro.md)
 	- [`success`](./entities/success.md)

--- a/docs/http-api/src/topics/authentication.md
+++ b/docs/http-api/src/topics/authentication.md
@@ -40,12 +40,25 @@ If included authentication information in the request will be checked for EVERY
 request, even to endpoints that don't require authentication. These errors can
 therefore occur on any endpoint.
 
-### Invalid Token
+### Differing Logins
 **Status:** 400 _Bad Request_
 
-The request contained a login token, either in an `Authoization` header or in
-a cookie, which is currently invalid.
+There is both an `Authorization` header and a `bearer` token which both contain
+valid auth tokens but the auth tokens they contain differ. Probably you should only
+be sending one or the other but if you want to use both authentication schemes they both
+need to contain the same token.
 
+### Invalid Login Cookie
+**Status:** 400 _Bad Request_
+
+The `bearer` cookie contains an auth token which is either not currently or
+never was valid.
+
+### Invalid Login Token 
+**Status:** 400 _Bad Request_
+
+The `Authorization` header provided an auth token which is either not currently 
+or never was valid.
 
 ## Returning a grant
 To return a grant simply visit the [`logout`](/endpoints/logout.html) endpoint.

--- a/docs/http-api/src/topics/cookies.md
+++ b/docs/http-api/src/topics/cookies.md
@@ -1,0 +1,11 @@
+# Cookies
+
+There are a number of errors related to the processing of cookies. As these errors 
+can appear on any endpoint they are documented here.
+
+## Errors
+
+### Cookie Parse Error
+**Status:** 400 _Bad Request_
+
+There are three reasons this can happen: There could be a cookie in the header that is simple a name with no value, there could be a cookie with not name, or there could be a cookie that failed to decode as valid UTF-8. The detail field will help you tell which of these has occured. If this happened in normal operation (as in if you have not messed with your cookies), it is a bug, please report it. Clearing your cookies will resolve the issue, though note that this will leave any users logged in with a cookie grant unlocked.

--- a/libqaul/http-api/Cargo.toml
+++ b/libqaul/http-api/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 lazy_static = "1.3"
 router = "0.6"
 chrono = "0.4"
+cookie = "0.12"
 
 libqaul = { path = ".." } 
 identity = { path = "../../ratman/identity", package = "ratman-identity" }

--- a/libqaul/http-api/src/auth/login.rs
+++ b/libqaul/http-api/src/auth/login.rs
@@ -1,4 +1,5 @@
 use crate::{
+    Cookies,
     JsonApi,
     models::{
         UserAuth,
@@ -9,6 +10,7 @@ use crate::{
     QaulCore,
     JSONAPI_MIME,
 };
+use cookie::Cookie;
 use chrono::{ DateTime, offset::Utc };
 use libqaul::UserAuth as QaulUserAuth;
 use iron::{
@@ -87,7 +89,11 @@ pub fn login(req: &mut Request) -> IronResult<Response> {
     // return the grant
     let obj = match grant_type {
         GrantType::Token => ResourceObject::<UserGrant>::new(token, None).into(),
-        GrantType::Cookie => { unimplemented!() },
+        GrantType::Cookie => { 
+            // TODO: what should we do when a user is already logged in?
+            req.extensions.get_mut::<Cookies>().unwrap().add(Cookie::new("bearer", token));
+            Success::from_message("Successfully logged in".into()).into()
+        },
     };
 
     let doc = Document {

--- a/libqaul/http-api/src/auth/logout.rs
+++ b/libqaul/http-api/src/auth/logout.rs
@@ -1,4 +1,5 @@
 use crate::{
+    Cookies,
     QaulCore,
     JSONAPI_MIME,
     models::Success,
@@ -39,6 +40,12 @@ pub fn logout(req: &mut Request) -> IronResult<Response> {
         req.extensions.get::<Authenticator>().unwrap()
             .tokens.lock().unwrap()
             .remove(token);
+    }
+
+    // if an auth cookie had been set mark it for removal
+    let mut cookies = req.extensions.get_mut::<Cookies>().unwrap();
+    if let Some(cookie) = cookies.get("bearer") {
+        cookies.remove(cookie.clone());
     }
 
     // return a little success message

--- a/libqaul/http-api/src/cookie.rs
+++ b/libqaul/http-api/src/cookie.rs
@@ -1,0 +1,128 @@
+use cookie::{CookieJar, Cookie, ParseError}; 
+use crate::JSONAPI_MIME;
+use iron::{
+    headers::{
+        Cookie as CookieHeader,
+        SetCookie,
+    },
+    prelude::*,
+    middleware::{
+        BeforeMiddleware,
+        AfterMiddleware,
+    },
+    typemap::Key,
+    status::Status,
+};
+use json_api::{
+    Document,
+    Error,
+};
+use std::{
+    error::Error as StdError,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+#[derive(Debug)]
+struct CookieJarError(ParseError); 
+
+impl CookieJarError {
+    fn detail(&self) -> String {
+        format!("Error parsing cookies ({})", self.0)
+    }
+
+    fn into_error(&self) -> (Error, Status) {
+        let status = Status::BadRequest;
+        let title = Some("Cookie Parse Error".into());
+        let detail = Some(self.detail());
+
+        (
+            Error {
+                status: Some(format!("{}", status.to_u16())),
+                title,
+                detail,
+                ..Default::default()
+            },
+            status
+        )
+    }
+}
+
+impl Display for CookieJarError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Cookie jar error: {}", self.detail())
+    }
+}
+
+impl StdError for CookieJarError {}
+
+impl From<CookieJarError> for IronError {
+    fn from(e: CookieJarError) -> Self {
+        let (err, status) = e.into_error();
+
+        let document = Document {
+            errors: Some(vec![err]),
+            ..Default::default()
+        };
+
+        Self::new(e, (status, serde_json::to_string(&document).unwrap(), JSONAPI_MIME.clone()))
+    }
+}
+
+impl From<ParseError> for CookieJarError {
+    fn from(e: ParseError) -> Self {
+        CookieJarError(e)
+    }
+}
+
+/// User this key to get the CookieJar for the request
+/// 
+/// Any changes performed on the cookie jar will be sent back to the 
+/// client in the response
+///
+/// ```
+/// fn handler(req: &mut Request) -> IronResult<Response> {
+///     let cookie_jar = req.extensions.get::<CookieJar>().unwrap();
+/// }
+/// ```
+pub struct Cookies;
+
+impl Key for Cookies { type Value = CookieJar; }
+
+pub (crate) struct CookieManager;
+
+impl CookieManager {
+    fn build_jar(req: &mut Request) -> Result<CookieJar, CookieJarError> {
+        let mut jar = CookieJar::new();
+
+        if let Some(cookies) = req.headers.get::<CookieHeader>() {
+            for cookie in cookies.iter() {
+                jar.add_original(Cookie::parse(cookie)?.into_owned());
+            }
+        }
+
+        Ok(jar)
+    }
+
+    pub fn new() -> (Self, Self) { (Self, Self) }
+}
+
+impl BeforeMiddleware for CookieManager {
+    fn before(&self, req: &mut Request) -> IronResult<()> {
+        let jar = Self::build_jar(req)?;
+        req.extensions.insert::<Cookies>(jar);
+        Ok(())
+    }
+}
+
+impl AfterMiddleware for CookieManager {
+    fn after(&self, req: &mut Request, mut res: Response) -> IronResult<Response> {
+        let cookies : Vec<String> = req.extensions.get::<Cookies>().unwrap()
+            .delta()
+            .map(|c| c.to_string())
+            .collect();
+
+        if cookies.len() != 0 { res.headers.set::<SetCookie>(SetCookie(cookies)); }
+
+        Ok(res)
+    }
+}

--- a/libqaul/http-api/src/lib.rs
+++ b/libqaul/http-api/src/lib.rs
@@ -29,6 +29,9 @@ pub mod models;
 mod jsonapi;
 pub use jsonapi::{JsonApi, JsonApiGaurd};
 
+mod cookie;
+pub use crate::cookie::Cookies;
+
 lazy_static! { 
     /// A static `Mime` object representing `application/vnd.api+json`
     pub static ref JSONAPI_MIME : mime::Mime = mime::Mime(
@@ -60,6 +63,7 @@ impl ApiServer {
         router.any("/logout", core_route_blackhole, "logout");
 
         let mut chain = Chain::new(router);
+        chain.link(crate::cookie::CookieManager::new());
         chain.link_before(QaulCore::new(qaul)); 
         chain.link_before(jsonapi::JsonApi); 
 

--- a/libqaul/src/api/models.rs
+++ b/libqaul/src/api/models.rs
@@ -21,7 +21,7 @@ pub enum QaulError {
 }
 
 /// A wrapper around user authentication state
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UserAuth {
     /// A user ID which has not been verified
     Untrusted(Identity),


### PR DESCRIPTION
i have added the aforementioned cookie authentication.

one question that needs to be answered before we merge is what is the correct behavior when a user logs in with a cookie grant while they already have a cookie grant
there's three options:
1) return an error and refuse to log in
2) log out the old cookie and replace it with the new
3) replace without logging out

with tokens i decided that there are valid reasons to get another token while you are currently providing a token (such as if your application is grabbing a token to pass to some other application) but i don't think there's any reasonable case in which you should need to grab a new login cookie while you have an active older one. 3) is the current behavior but will leave that token hanging forever, never closing the session properly, which doesn't seem like a great thing. 2) is easy but might be unexpected as logging out the user is kind of a side effect instead of an intended effect.