### PR TITLE
change router middleware to allow hotplugging handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,6 @@ dependencies = [
  "libqaul 0.1.0",
  "persistent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratman-identity 0.1.0",
- "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -601,21 +600,6 @@ dependencies = [
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "route-recognizer"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "router"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ryu"
@@ -861,8 +845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3255338088df8146ba63d60a9b8e3556f1146ce2973bc05a75181a42ce2256"
-"checksum router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc63b6f3b8895b0d04e816b2b1aa58fdba2d5acca3cbb8f0ab8e017347d57397"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"

--- a/docs/http-api/src/SUMMARY.md
+++ b/docs/http-api/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Topics](./topics/_intro.md)
 	- [Authentication](./topics/authentication.md)
 	- [JSON:API](./topics/jsonapi.md)
+	- [Services](./topics/services.md)
 - [Entities](./entities/_intro.md)
 	- [`success`](./entities/success.md)
 	- [`user`](./entities/user.md)

--- a/docs/http-api/src/endpoints/login.md
+++ b/docs/http-api/src/endpoints/login.md
@@ -1,6 +1,9 @@
 # `login`
 Allows a user to authenticate with qaul.
 
+## Methods
+- `POST`
+
 ## Arguments
 Expects a [`user_auth`](/entities/user_auth.html) entity
 
@@ -24,6 +27,12 @@ value. Check the `detail` field of the error for more information.
 The id field of the primary data failed to decode, check the 
 [`user_auth`](/entities/user_auth.html) entity for information about its contents.
 
+### Method Not Allowed
+**Status:** 405 _Method Not Allowed_
+
+This endpoint expects a `POST` request and what it was provided was not a `POST`
+request
+
 ### Multiple Data 
 **Status:** 400 _Bad Request_
 
@@ -38,6 +47,7 @@ The primary data had no attributes at all
 **Status:** 401 _Unauthorized_
 
 This likely occured because the secret is wrong
+
 ### No Data
 **Status:** 400 _Bad Request_
 

--- a/docs/http-api/src/endpoints/logout.md
+++ b/docs/http-api/src/endpoints/logout.md
@@ -1,6 +1,9 @@
 # `logout`
 Logs a user out. It is important to do this so qaul can lock the user's data.
 
+## Methods
+- `GET`
+
 ## Arguments
 None
 
@@ -8,6 +11,11 @@ None
 [`success`](/entities/success.html)
 
 ## Errors
+
+### Method Not Allowed
+**Status:** 405 _Method Not Allowed_
+
+This endpoint only accepts `GET` requests and this request was of a different type
 
 ### Not Logged In
 **Status:** 401 _Unauthorized_

--- a/docs/http-api/src/topics/services.md
+++ b/docs/http-api/src/topics/services.md
@@ -1,0 +1,34 @@
+# Services
+At its core qaul.net provides relatively little user facing functionality, it
+is a tool from which other things a built. Most of this functionality comes in 
+the form of services, pluggable extensions that leverage qual.net's networking
+capabilities.
+
+## Service Apis
+Services can expose their own HTTP Apis which may, like the core service, use
+JSON:API or may use something completely different. These apis are mounted under
+the service name. So for example, consider a service `foo` that exposes an
+endpoint `/bar`. When using the api you would access this endpoint like
+`/foo/bar`.
+
+## Errors
+There are a few errors associated with the mounting of services that it is 
+important to be aware of.
+
+### No Path
+**Status:** 400 _Bad Request_
+
+This error occurs when you request the root endpoint, `/`. To use the api
+please specifiy what endpoint you intend to access.
+
+### No Service
+**Status:** 404 _Not Found_
+
+The service you're requesting does not exist. If you're pretty sure it should
+exist, check that the service is registered.
+
+### Service Not Authorized
+**Status:** 403 _Forbidden_
+
+The user you're representing does not run this service and as such the service
+cannot be allowed to access that users data.

--- a/libqaul/http-api/Cargo.toml
+++ b/libqaul/http-api/Cargo.toml
@@ -14,7 +14,6 @@ serde_derive = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 lazy_static = "1.3"
-router = "0.6"
 chrono = "0.4"
 
 libqaul = { path = ".." } 

--- a/libqaul/http-api/src/lib.rs
+++ b/libqaul/http-api/src/lib.rs
@@ -45,10 +45,6 @@ lazy_static! {
         Vec::new()); 
 }
 
-fn core_route_blackhole(_: &mut Request) -> IronResult<Response> {
-    Ok(Response::with(Status::MethodNotAllowed))
-}
-
 /// The core of the qaul.net HTTP API
 pub struct ApiServer {
     authenticator: Authenticator,

--- a/libqaul/http-api/src/lib.rs
+++ b/libqaul/http-api/src/lib.rs
@@ -85,17 +85,30 @@ impl ApiServer {
         })
     }
 
-    /// According to https://github.com/hyperium/hyper/issues/338 this _probably_
-    /// does nothing, but i'm providing it in the hope that in the future
-    /// someone will figure out how to shutdown a webserver without crashing it
+    /// According to
+    /// [https://github.com/hyperium/hyper/issues/338](https://github.com/hyperium/hyper/issues/338) 
+    /// this _probably_ does nothing, but i'm providing it in the hope that in the 
+    /// future someone will figure out how to shutdown a webserver without crashing it
     pub fn close(&mut self) -> HttpResult<()> {
         self.listening.close()
     }
 
+    /// Mount a service's handler under `/{name}`
+    ///
+    /// Errors when you try to replace a core route like `/login`
+    ///
+    /// Returns `true` when a this service replaces a previous service mounted
+    /// under the same path and `false` otherwise
     pub fn mount_service<T: Handler>(&self, name: String, handler: T) -> Result<bool, HotPlugError> {
         self.mount.mount(name, handler)
     }
 
+    /// Unmount a service's handler
+    ///
+    /// Errors when you try to unmount a core route like `/login`
+    ///
+    /// Returns `true` when a service with that name existed and was unmounted, 
+    /// `false` when no service of that name was found 
     pub fn unmount_service(&self, name: &str) -> Result<bool, HotPlugError> {
         self.mount.unmount(name)
     }

--- a/libqaul/http-api/src/lib.rs
+++ b/libqaul/http-api/src/lib.rs
@@ -26,6 +26,8 @@ pub use auth::CurrentUser;
 
 pub mod models;
 
+mod mount;
+
 mod jsonapi;
 pub use jsonapi::{JsonApi, JsonApiGaurd};
 

--- a/libqaul/http-api/src/method.rs
+++ b/libqaul/http-api/src/method.rs
@@ -1,0 +1,144 @@
+use crate::JSONAPI_MIME;
+use iron::{
+    prelude::*,
+    method::Method,
+    middleware::BeforeMiddleware,
+    status::Status,
+};
+use json_api::{
+    Document,
+    Error,
+};
+use std::{
+    error::Error as StdError,
+    fmt::{
+        Display,
+        Formatter,
+        Result,
+    },
+};
+
+#[derive(Debug)]
+struct MethodGaurdError {
+    expected: Vec<Method>,
+    got: Method,
+}
+
+impl MethodGaurdError {
+    fn into_error(&self) -> (Error, Status) {
+        let status = Status::MethodNotAllowed;
+        let title = Some("Method Not Allowed".into());
+
+        let mut method_string = String::new();
+        for (i, method) in self.expected.iter().enumerate() {
+            if i != 0 { 
+                method_string.push(',');
+                method_string.push(' ');
+            }
+
+            method_string.push_str(match method {
+                Method::Options => "Options",
+                Method::Get => "Get",
+                Method::Post => "Post",
+                Method::Put => "Put",
+                Method::Delete => "Delete",
+                Method::Head => "Head",
+                Method::Trace => "Trace",
+                Method::Connect => "Connect",
+                Method::Patch => "Patch",
+                Method::Extension(s) => &s,
+            });
+        }
+
+        let detail = Some(format!("Request method was {} but endpoint only supports {}", 
+            self.got, method_string));
+
+        (
+            Error {
+                status: Some(format!("{}", status.to_u16())),
+                title,
+                detail,
+                ..Default::default()
+            },
+            status
+        )
+    }
+}
+
+impl Display for MethodGaurdError {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "Method Gaurd Error: expected {:?}, got {}", &self.expected[..], self.got)
+    }
+}
+
+impl StdError for MethodGaurdError {}
+
+impl From<MethodGaurdError> for IronError {
+    fn from(e: MethodGaurdError) -> IronError {
+        let (err, status) = e.into_error();
+
+        let document = Document {
+            errors: Some(vec![err]),
+            ..Default::default()
+        };
+
+        Self::new(e, (status, serde_json::to_string(&document).unwrap(), JSONAPI_MIME.clone()))
+    }
+}
+
+pub struct MethodGaurd {
+    methods: Vec<Method>,
+}
+
+impl MethodGaurd {
+    pub fn new(methods: Vec<Method>) -> Self {
+        Self { methods }
+    }
+    
+    pub fn options() -> Self {
+        Self { methods: vec![Method::Options] }
+    }
+
+    pub fn get() -> Self {
+        Self { methods: vec![Method::Get] }
+    }
+
+    pub fn post() -> Self {
+        Self { methods: vec![Method::Post] }
+    }
+
+    pub fn put() -> Self {
+        Self { methods: vec![Method::Put] }
+    }
+
+    pub fn delete() -> Self {
+        Self { methods: vec![Method::Delete] }
+    }
+
+    pub fn head() -> Self {
+        Self { methods: vec![Method::Head] }
+    }
+
+    pub fn trace() -> Self {
+        Self { methods: vec![Method::Trace] }
+    }
+
+    pub fn connect() -> Self {
+        Self { methods: vec![Method::Connect] }
+    }
+
+    pub fn patch() -> Self {
+        Self { methods: vec![Method::Patch] }
+    }
+
+}
+
+impl BeforeMiddleware for MethodGaurd {
+    fn before(&self, req: &mut Request) -> IronResult<()> {
+        if self.methods.iter().fold(false, |c, m| c || *m == req.method) {
+            Ok(())
+        } else {
+            Err(MethodGaurdError{ got: req.method.clone(), expected: self.methods.clone() }.into())
+        }
+    }
+}

--- a/libqaul/http-api/src/method.rs
+++ b/libqaul/http-api/src/method.rs
@@ -86,6 +86,10 @@ impl From<MethodGaurdError> for IronError {
     }
 }
 
+/// Aborts requests made with incorrect methods
+///
+/// Add this to a request chain to deny all requests that do not use the 
+/// required methods
 pub struct MethodGaurd {
     methods: Vec<Method>,
 }

--- a/libqaul/http-api/src/mount.rs
+++ b/libqaul/http-api/src/mount.rs
@@ -23,8 +23,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+/// An error generated during plugging or unplugging routes
 #[derive(Debug)]
 pub enum HotPlugError {
+    /// Method would have modified a core route
     CoreRoute,
 }
 
@@ -46,7 +48,7 @@ enum Route {
 }
 
 #[derive(Clone)]
-pub struct HotPlugMount {
+pub (crate) struct HotPlugMount {
     routes: Arc<Mutex<BTreeMap<String, Route>>>,
 }
 

--- a/libqaul/http-api/src/mount.rs
+++ b/libqaul/http-api/src/mount.rs
@@ -1,0 +1,207 @@
+use crate::{
+    CurrentUser,
+    JSONAPI_MIME,
+    QaulCore,
+};
+use libqaul::QaulError;
+use iron::{
+    middleware::Handler,
+    prelude::*,
+    Url,
+    typemap,
+    status::Status,
+};
+use json_api::{
+    Document,
+    Error,
+    ErrorSource,
+};
+use std::{
+    collections::BTreeMap,
+    error::Error as StdError,
+    fmt::{Display, Formatter, Result as FmtResult},
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug)]
+pub enum HotPlugError {
+    CoreRoute,
+}
+
+impl Display for HotPlugError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Hot Plug Error: ")?;
+        match self {
+            HotPlugError::CoreRoute => write!(f, "Tried to replace a core route"),
+        }
+    }
+}
+
+impl StdError for HotPlugError {}
+
+#[derive(Clone)]
+enum Route {
+    Service(Arc<Box<dyn Handler>>),
+    Core(Arc<Box<dyn Handler>>),
+}
+
+pub struct HotPlugMount {
+    routes: Arc<Mutex<BTreeMap<String, Route>>>,
+}
+
+impl HotPlugMount {
+    pub fn new() -> Self {
+        Self { routes: Default::default(), } 
+    }
+
+    pub fn mount<T: Handler>(&self, path: String, handler: T) -> Result<bool, HotPlugError> {
+        let mut routes = self.routes.lock().unwrap();
+
+        if let Some(Route::Core(_)) = routes.get(&path) {
+            return Err(HotPlugError::CoreRoute);
+        }
+
+        Ok(routes.insert(path, Route::Service(Arc::new(Box::new(handler)))).is_some())
+    }
+
+    pub fn unmount(&self, path: &str) -> Result<bool, HotPlugError> {
+        let mut routes = self.routes.lock().unwrap();
+
+        if let Some(Route::Core(_)) = routes.get(path) {
+            return Err(HotPlugError::CoreRoute);
+        }
+
+        Ok(routes.remove(path).is_some())
+    }
+
+    pub fn mount_core<T: Handler>(&self, path: String, handler: T) -> bool {
+        let mut routes = self.routes.lock().unwrap();
+
+        routes.insert(path, Route::Core(Arc::new(Box::new(handler)))).is_some()
+    }
+
+    pub fn unmount_core(&self, path: &str) -> bool {
+        let mut routes = self.routes.lock().unwrap();
+
+        routes.remove(path).is_some()
+    }
+}
+
+pub struct OriginalUrl;
+impl typemap::Key for OriginalUrl { type Value = Url; }
+
+#[derive(Debug)]
+enum HotPlugHandlerError {
+    NoPath,
+    NoService(String),
+    ServiceNotAuthorized(String),
+    QaulError(QaulError),
+}
+
+impl HotPlugHandlerError {
+    fn detail(&self) -> String {
+        match self {
+            HotPlugHandlerError::NoPath => "Url provided no path to a service".into(),
+            HotPlugHandlerError::NoService(s) => format!("No mounted service named {}", s),
+            HotPlugHandlerError::ServiceNotAuthorized(s) =>
+                format!("Current user has not authorized service {}", s),
+            HotPlugHandlerError::QaulError(e) => format!("Qaul Error: {:?}", e),
+        }
+    }
+
+    fn into_error(&self) -> (Error, Status) {
+        let status = match self {
+            HotPlugHandlerError::ServiceNotAuthorized(_) => Status::Forbidden,
+            HotPlugHandlerError::QaulError(_) => Status::InternalServerError,
+            _ => Status::BadRequest,
+        };
+
+        let title = match self {
+            HotPlugHandlerError::NoPath => Some("No Path".into()),
+            HotPlugHandlerError::NoService(_) => Some("No Service".into()),
+            HotPlugHandlerError::ServiceNotAuthorized(_) => Some("Service Not Authorized".into()),
+            HotPlugHandlerError::QaulError(_) => None,
+        };
+
+        let detail = match self {
+            HotPlugHandlerError::QaulError(_) => None,
+            _ => Some(self.detail()),
+        };
+
+        (
+            Error {
+                status: Some(format!("{}", status.to_u16())),
+                title,
+                detail,
+                ..Default::default()
+            },
+            status
+        )
+    }
+}
+
+impl StdError for HotPlugHandlerError {}
+
+impl Display for HotPlugHandlerError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Hot Plug Hander World: {}", self.detail())
+    }
+}
+
+impl From<HotPlugHandlerError> for IronError {
+    fn from(e: HotPlugHandlerError) -> Self {
+        let (err, status) = e.into_error();
+
+        let document = Document {
+            errors: Some(vec![err]),
+            ..Default::default()
+        };
+
+        Self::new(e, (status, serde_json::to_string(&document).unwrap(), JSONAPI_MIME.clone()))
+    }
+}
+
+impl Handler for HotPlugMount {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let mut path = req.url.path();
+
+        // is there a service name in the path?
+        let service = match path.first() {
+            Some(p) => p.to_string(),
+            None => { return Err(HotPlugHandlerError::NoPath.into()); },
+        };
+
+        // if a user is logged in, do they have the service enabled?
+        match req.extensions.get::<CurrentUser>()
+                .map(|user| req.extensions.get::<QaulCore>().unwrap().user_get(user.clone())) {
+            Some(Ok(user)) => {
+                if !user.data.services.iter().fold(false, |c, s| c || *s == service) {
+                    return Err(HotPlugHandlerError::ServiceNotAuthorized(service).into());
+                }
+            },
+            Some(Err(e)) => {
+                return Err(HotPlugHandlerError::QaulError(e).into());
+            },
+            None => {},
+        }
+
+        // does the path point to a real handler? 
+        let handler = {
+            match self.routes.lock().unwrap().get(&service) {
+                Some(Route::Core(h)) => h.clone(),
+                Some(Route::Service(h)) => h.clone(),
+                None => { return Err(HotPlugHandlerError::NoService(service).into()); },
+            }
+        };
+
+        // stash the original url
+        req.extensions.insert::<OriginalUrl>(req.url.clone());
+
+        // remove the prefix from the url
+        let path = path[1..].join("/");
+        req.url.as_mut().set_path(&path);
+
+
+        handler.handle(req)
+    }
+}

--- a/libqaul/http-api/src/mount.rs
+++ b/libqaul/http-api/src/mount.rs
@@ -114,9 +114,14 @@ impl HotPlugHandlerError {
 
     fn into_error(&self) -> (Error, Status) {
         let status = match self {
+            // TODO: Should NoPath provide a landing page?
+            // it's like you'd end up there because you don't know how the
+            // api works, we could potentially provide some guidence to the
+            // documentation
+            HotPlugHandlerError::NoPath => Status::BadRequest,
+            HotPlugHandlerError::NoService(s) => Status::NotFound,
             HotPlugHandlerError::ServiceNotAuthorized(_) => Status::Forbidden,
             HotPlugHandlerError::QaulError(_) => Status::InternalServerError,
-            _ => Status::BadRequest,
         };
 
         let title = match self {

--- a/libqaul/http-api/src/mount.rs
+++ b/libqaul/http-api/src/mount.rs
@@ -45,6 +45,7 @@ enum Route {
     Core(Arc<Box<dyn Handler>>),
 }
 
+#[derive(Clone)]
 pub struct HotPlugMount {
     routes: Arc<Mutex<BTreeMap<String, Route>>>,
 }


### PR DESCRIPTION
the biggest things this pull request adds is a new router named `HotPlugMount` this does most of the same things that [mount](https://crates.io/crates/mount) does except it routes
can be hotplugged

due to the way it stores routes it is worthy of note that when a service is unloaded the handler will
continue to process any requests that had already been dispatched. if service authors are not careful
and throw `unwrap` everywhere this could potentially cause crashes but there's relatively little we can
do about this.

one question which should be answered is how do services provide handlers to the http api. 
the best way i've come up with thusfar has been for services to have a callback to optionally provide a handler under a feature flag but this requires giving the http api some special privilege in qaul. alternately,
a handler could be written which proxies requests through messages to services. this would be a lot of 
effort for not much gain but theoretically would be possible.

currently when a request hits the root path `/` a `400 Bad Request` response is generated however
i think it may be good to instead return some sort of landing page pointing the user to documentation
on how to use the api. however i don't know what this should point to. it could simply redirect to 
the online documentation, but that's probably not the most helpful behavior in the wild. the api could
serve a local copy of the documentation or even embed one but both of these options potentially 
substantially increase binary size.

the way the `/login` and `/logout` routes are mounted prevents services with those names 
mounting apis. i think this is probably fine but this is worthy of note. another option would be
moving them under the `/core` service but i feel that as user authentication has more to do with
the api itself than the `core` service that it feels more natural here.