### PR TITLE
Users Protobuf show Online State & Connectivity

### DIFF
--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -49,7 +49,8 @@ class User with EquatableMixin implements Comparable<User> {
 
   String get idBase58 => Base58Encode(id);
 
-  bool get isConnected => status == ConnectionStatus.online;
+  bool get isConnected =>
+      availableTypes?.isNotEmpty ?? status == ConnectionStatus.online;
 
   User copyWith({required Map<ConnectionType, ConnectionInfo> availableTypes}) {
     return User(

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -49,8 +49,7 @@ class User with EquatableMixin implements Comparable<User> {
 
   String get idBase58 => Base58Encode(id);
 
-  bool get isConnected =>
-      availableTypes?.isNotEmpty ?? status == ConnectionStatus.online;
+  bool get isConnected => status == ConnectionStatus.online;
 
   User copyWith({required Map<ConnectionType, ConnectionInfo> availableTypes}) {
     return User(

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -34,18 +34,6 @@ class UsersTranslator extends RpcModuleTranslator {
           securityNumberBlocks: res.securityNumberBlocks,
         );
         return RpcTranslatorResponse(type, secNo);
-      case Users_Message.userUpdate:
-        final userEntry = message.ensureUserUpdate();
-        final user = User(
-          name: userEntry.name,
-          id: Uint8List.fromList(userEntry.id),
-          conversationId: Uint8List.fromList(userEntry.groupId),
-          keyBase58: userEntry.keyBase58,
-          isBlocked: userEntry.blocked,
-          isVerified: userEntry.verified,
-          status: _mapFrom(userEntry.connectivity),
-        );
-        return RpcTranslatorResponse(type, user);
       default:
         return super.decodeMessageBytes(data, reader);
     }


### PR DESCRIPTION
The users.proto functionality has been enhanced to show the users online state & connectivity:

* UserRequest: returns the user list with online state set as an enum called connectivity
  * connectivit field is set either to `online` or `offline`
* UserOnlineRequest: returns a list with all currently online users
  * each user has the connectivity & connections information set