### PR TITLE
fix: revert confinement and change grade of snapcraft.yaml

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -280,8 +280,7 @@ jobs:
             - install-flutter-deps
             - run:
                 command: |
-                    SNAP_PATH=$(cd ../utilities/installers/linux && bash snapbuild | tail -n1 )
-                    echo "Resulting snap file can be found at: $SNAP_PATH"
+                    cd ../utilities/installers/linux && bash snapbuild
                 name: Build Flutter Application for Linux
             - persist_to_workspace:
                 paths:
@@ -1006,6 +1005,7 @@ workflows:
         jobs:
             - test-flutter
             - analyze-flutter
+            - build-flutter-linux
             - integration-test-flutter-macos:
                 filters:
                     branches:

--- a/circleci_config/config-continuation/jobs/build-flutter-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-flutter-linux.yml
@@ -21,9 +21,7 @@ steps:
   - install-flutter-deps
   - run:
       name: Build Flutter Application for Linux
-      command: |
-        SNAP_PATH=$(cd ../utilities/installers/linux && bash snapbuild | tail -n1 )
-        echo "Resulting snap file can be found at: $SNAP_PATH"
+      command: cd ../utilities/installers/linux && bash snapbuild
   - persist_to_workspace:
       root: ~/qaul-libp2p
       paths:

--- a/qaul_ui/snap/snapcraft.yaml
+++ b/qaul_ui/snap/snapcraft.yaml
@@ -3,9 +3,9 @@ version: 2.0.0-beta.5
 summary: qaul - Internet Independent Wireless Mesh Communication App
 description: Communicate directly from device to device via your local wifi network, or via the shared wifi network of your phone. Mesh local clouds together via manually added static nodes. Use this peer to peer communication method to communicate internet independently and completely off-the-grid.
 
-confinement: classic
+confinement: strict
 base: core18
-grade: beta
+grade: devel
 
 slots:
   dbus-qaul:

--- a/utilities/installers/linux/snapbuild
+++ b/utilities/installers/linux/snapbuild
@@ -4,12 +4,13 @@
 echo "Updating dependencies..."
 
 sed -i "s/xenial/focal/g" /etc/apt/sources.list
-apt update -qq
-apt install -y -qq wget tar unzip zip lib32stdc++6 lib32z1 git clang cmake ninja-build pkg-config libgtk-3-dev curl
+apt-get -qq update
+apt-get -qq install -y wget tar unzip zip lib32stdc++6 lib32z1 git clang cmake ninja-build pkg-config libgtk-3-dev curl apt-utils
 
 echo ""
 
 flutter config --enable-linux-desktop
+flutter doctor --verbose
 
 echo ""
 echo "Retrieving application version..."
@@ -36,7 +37,7 @@ sed -i "s/version\:\W\+[0-9]\+\.[0-9]\+\.[0-9]\+/version: $VERSION/g" snapcraft.
 mkdir local
 echo "$SNAPCRAFT_LOGIN_FILE" | base64 --decode --ignore-garbage > local/snapcraft.login
 snapcraft login --with local/snapcraft.login
-set +o pipefail
+#set +o pipefail
 
 # shellcheck disable=SC2103
 cd ..
@@ -47,6 +48,7 @@ echo "Building Flutter application..."
 git config --global --add safe.directory /root/development/flutter
 
 snapcraft
+
 mv ./*.snap "qaul-app-$VERSION.snap"
 # TODO cannot upload via CircleCI due to the directive:
 #     - human review required due to 'deny-connection' constraint (interface attributes)


### PR DESCRIPTION
@MathJud I found out that the issue on the Flutter CD pipeline was in the following configuration:

* `qaul_ui/snap/snapcraft.yaml:6`: `confinement` was set to `classic`, which is not supported by the Flutter snap extension - reverted back to [strict](https://snapcraft.io/docs/snap-confinement)
* `qaul_ui/snap/snapcraft.yaml:8`: `grade` was set to `beta`, which is an (invalid option)[https://snapcraft.io/docs/snapcraft-yaml-reference] - changed it to `devel`

With these options the job succeeds.