### PR TITLE
Libp2p upgrade

### DIFF
--- a/rust/libp2p_modules/qaul_info/Cargo.toml
+++ b/rust/libp2p_modules/qaul_info/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["qaul.net community <contact@qaul.net>"]
 license = "AGPL"
 
 [dependencies]
-libp2p = "0.48.0"
+libp2p = { version = "0.49.0", features = ["full"] }
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.21"

--- a/rust/libp2p_modules/qaul_messaging/Cargo.toml
+++ b/rust/libp2p_modules/qaul_messaging/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["qaul.net community <contact@qaul.net>"]
 license = "AGPL"
 
 [dependencies]
-libp2p = "0.48.0"
+libp2p = { version = "0.49.0", features = ["full"] }
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.1"

--- a/rust/libqaul/Cargo.toml
+++ b/rust/libqaul/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 default = []
 
 [dependencies]
-libp2p = { version = "0.48.0" }
+libp2p = { version = "0.49.0", features = ["full"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 futures = "0.3.15"
 serde = {version = "=1.0", features = ["derive"] }
@@ -46,11 +46,11 @@ sled = "0.34.7"
 sled-extensions = { version = "0.2", features = ["bincode"] }
 uuid = { version = "1.1.2", features = ["v4"] }
 ed25519-dalek = "1.0.1"
-x25519-dalek = "1.2.0"
+x25519-dalek = "1.1.0"
 curve25519-dalek = "3.2.0"
 sha2 = "0.10.2"
-noise-protocol = { git = "https://github.com/MathJud/noise-rust.git", branch = "libp2p-45" }
-noise-rust-crypto = { git = "https://github.com/MathJud/noise-rust.git", branch = "libp2p-45", features = ["use-x25519", "use-chacha20poly1305", "use-sha2"] }
+noise-protocol = { git = "https://github.com/qaul/noise-rust.git" }
+noise-rust-crypto = { git = "https://github.com/qaul/noise-rust.git", features = ["use-x25519", "use-chacha20poly1305", "use-sha2"] }
 crc = "^1.0.0"
 
 # only for desktop platforms: Linux, Mac, Windows
@@ -62,7 +62,6 @@ qaul_messaging = { path = "../libp2p_modules/qaul_messaging" }
 
 [build-dependencies]
 prost-build = "0.11.1"
-
 
 # special setting for android
 [target.'cfg(target_os = "android")'.dependencies]

--- a/rust/libqaul/src/connections/lan.rs
+++ b/rust/libqaul/src/connections/lan.rs
@@ -216,7 +216,7 @@ impl Lan {
 
             // create MDNS behaviour
             // TODO create MdnsConfig {ttl: Duration::from_secs(300), query_interval: Duration::from_secs(30) }
-            let mdns = task::block_on(Mdns::new(MdnsConfig::default())).unwrap();
+            let mdns = Mdns::new(MdnsConfig::default()).unwrap();
 
             log::trace!("Lan::init() swarm mdns module created");
 


### PR DESCRIPTION
- upgrades `libp2p` to `0.49.0`
- cloned, `noise-rust` to `qaul` and made necessary changes for versions of some dependencies to avoid version conflicts (`zeroize`, `x25519-dalek` namely)