### PR TITLE
Changed filesharing to chat file in README

### DIFF
--- a/rust/clients/cli/README.md
+++ b/rust/clients/cli/README.md
@@ -64,7 +64,7 @@ The following commands are available:
 * chat
   * `chat send {Group ID} {Chat Message}` - sends the {Chat Message} to the user with the ID {Group ID}
   * `chat conversation {Group ID}` - displays all messages of the conversation with the ID {Group ID}
-* file sharing
+* chat files
   * `file send {Group ID} {File Path} {File Description}` - sends a file to the user with the ID {Group ID} and a {File Description} text.
   * `file history [{offset} {limit}]` - displays a paginated file history
     * The page {offset} and {limit} values are optional. The default values are an offset of 0 and 10 results.


### PR DESCRIPTION
## Description
Changed CLI README naming mistake: filesharing -> chat file