### PR TITLE
chore/improve macos documentation

### DIFF
--- a/docs/qaul/flutter/macos.md
+++ b/docs/qaul/flutter/macos.md
@@ -108,23 +108,37 @@ flutter run -d macos
 
 ## Build Distributable (*.dmg) MacOS Application
 
-You can build the qaul flutter app from the terminal:
+_**Step 1: Archiving the App**_:
+
+To manually create a release archive, you can do the following:
+
+1. Open the project in XCode: `open qaul_ui/macos/Runner.xcworkspace`;
+2. Press `Product >> Archive`;
+3. Once done, the **Organizer** window should open by itself (if not, open it via `Window >> Organizer`):
+    1. Select the `Archives` sub-menu over the left panel;
+    2. Select the archive you've just created in the middle panel and;
+    3. Select the `Distribute App` option in the right panel to upload the archive to be notarized.
+
+_**Step 2: Notarizing**_:
+
+The steps below outline what to do in each screen of the "Distribute App" dialog:
+
+1. **Select a method of distribution**
+   > select the "Developer ID" option and press *Next*;
+2. **Select a destination**
+   > select "Upload" and press *Next*;
+3. **Select certificate and Developer ID profiles**
+   > select your **Developer ID Application** certificate; No profile is required. Press *Next*;
+
+Once this is done, wait until the app is properly notarized - you should receive an email confirming the process is complete.
+
+After that, you can export the newly-notarized app from the Organizer window itself (you may need to `View >> Reload Organizer`).
+> Export it onto `utilities/installers/macos`.
+
+_**Step 3: Generating the dmg**_:
 
 ```sh
-# move into the flutter directory
-cd qaul_ui
-
-# build the release version of the app
-flutter build macos
-```
-
-To build the dmg file, we'll make use of [appdmg](https://www.npmjs.com/package/appdmg):
-
-```sh
-# Install appdmg
-npx appdmg --version
-
 # Build dmg file
-cd ../utilities/installers/macos
-npx appdmg ./config.json ./qaul.dmg
+cd ../utilities/installers/macos/bin
+./dmgbuild
 ```

--- a/utilities/installers/macos/bin/dmgbuild
+++ b/utilities/installers/macos/bin/dmgbuild
@@ -1,63 +1,94 @@
 #! /bin/bash
 set -eo pipefail
 
-# Pre-step: assert that the script is being run from rust/libqaul
+function printHelp() {
+  echo "script usage: $(basename "$0") [-f]"
+  echo '-f'
+  echo '     [Full-mode] Compile Flutter app, notarize and create the dmg'
+  echo ''
+  echo 'By default, will only create the dmg'
+}
+
+# Pre-step: assert that the script is being run from the correct path
 PATTERN="^.*/installers/macos/bin\$"
 if [[ ! $(pwd) =~ $PATTERN ]]; then
   echo "This script uses relative paths. Please run directly from it's directory."
   exit 1
 fi
 
+# Initialize variables
+while getopts 'hf' OPTION; do
+  case "$OPTION" in
+  f)
+    TYPE="full"
+    ;;
+  h)
+    printHelp
+    exit 0
+    ;;
+  \?)
+    printHelp >&2
+    exit 1
+    ;;
+  esac
+done
+shift "$((OPTIND - 1))"
+
 PRODUCT_NAME="qaul.net – قول.app"
 EXPORT_PATH="build/macos/Build/Products/Release"
 APP_PATH="$EXPORT_PATH/$PRODUCT_NAME"
 
-# -------------------------------------------------------------------------------
-# STEP 1 - Compile Signed MacOS App
-echo ""
-echo "Building MacOS Flutter App..."
-
 cd ../../../../qaul_ui || exit 1
-flutter build macos --release
 
-#codesign --force --verbose --timestamp --options=runtime \
-#  --sign "Developer ID Application: Verein zur Forderung von offenen Community-Projekten" \
-#  "$APP_PATH"
+if [ "$TYPE" == 'full' ]; then
+  # -------------------------------------------------------------------------------
+  # STEP 1 - Compile Signed MacOS App
+  echo ""
+  echo "Building MacOS Flutter App..."
 
-# -------------------------------------------------------------------------------
-# STEP 2 - Validate and Notarize App
-# See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
-echo ""
-echo "Validating App signature..."
-# use codesign -vvv for extra verbosity
-# See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087735
-codesign -vv --deep --strict "$APP_PATH"
-codesign -dvv "$APP_PATH"
+  flutter build macos --release
 
-echo ""
-echo "Submitting the application for notarization..."
+  #codesign --force --verbose --timestamp --options=runtime \
+  #  --sign "Developer ID Application: Verein zur Forderung von offenen Community-Projekten" \
+  #  "$APP_PATH"
 
-ZIP_PATH="$EXPORT_PATH/$PRODUCT_NAME.zip"
-ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+  # -------------------------------------------------------------------------------
+  # STEP 2 - Validate and Notarize App
+  # See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
+  echo ""
+  echo "Validating App signature..."
+  # use codesign -vvv for extra verbosity
+  # See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087735
+  codesign -vv --deep --strict "$APP_PATH"
+  codesign -dvv "$APP_PATH"
 
-# This assumes that a valid profile named "NOTARY_PASSWORD" is available in the Keychain.
-# The following command creates such profile:
-# xcrun notarytool store-credentials "NOTARY_PASSWORD" \
-#               --apple-id "AC_USERNAME" \
-#               --team-id <WWDRTeamID> \
-#               --password <secret_2FA_password>
-# See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow
-# See: https://support.apple.com/en-us/HT204397
-xcrun notarytool submit "$ZIP_PATH" --keychain-profile "NOTARY_PASSWORD" --wait
+  echo ""
+  echo "Submitting the application for notarization..."
 
-xcrun stapler staple "$APP_PATH"
+  ZIP_PATH="$EXPORT_PATH/$PRODUCT_NAME.zip"
+  ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
 
-#echo ""
-#echo "Validating the Notarized App..."
-# add the --raw option to generate a more detailed output
-# See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721
-#spctl -vvv --assess --type exec <NOTARIZED APP PATH>
-#xcrun stapler validate <NOTARIZED APP PATH>
+  # This assumes that a valid profile named "NOTARY_PASSWORD" is available in the Keychain.
+  # The following command creates such profile:
+  # xcrun notarytool store-credentials "NOTARY_PASSWORD" \
+  #               --apple-id "AC_USERNAME" \
+  #               --team-id <WWDRTeamID> \
+  #               --password <secret_2FA_password>
+  # See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow
+  # See: https://support.apple.com/en-us/HT204397
+  xcrun notarytool submit "$ZIP_PATH" --keychain-profile "NOTARY_PASSWORD" --wait
+
+  xcrun stapler staple "$APP_PATH"
+
+  #echo ""
+  #echo "Validating the Notarized App..."
+  # add the --raw option to generate a more detailed output
+  # See: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721
+  #spctl -vvv --assess --type exec <NOTARIZED APP PATH>
+  #xcrun stapler validate <NOTARIZED APP PATH>
+
+  #sed -i sed "s/\"qaul.net – قول.app\"/\"<NOTARIZED APP PATH>\"/g" config.json
+fi
 
 # -------------------------------------------------------------------------------
 # STEP 3 - Build and sign *.dmg

--- a/utilities/installers/macos/config.json
+++ b/utilities/installers/macos/config.json
@@ -3,7 +3,7 @@
   "icon": "app_icon.icns",
   "contents": [
     { "x": 448, "y": 344, "type": "link", "path": "/Applications" },
-    { "x": 192, "y": 344, "type": "file", "path": "../../../qaul_ui/build/macos/Build/Products/Release/qaul.net – قول.app" }
+    { "x": 192, "y": 344, "type": "file", "path": "qaul.net – قول.app" }
   ],
   "code-sign": {
     "signing-identity": "Developer ID Application: Verein zur Forderung von offenen Community-Projekten (VVYZ2Q8TUK)",


### PR DESCRIPTION
## Description
Improved documentation on how to create a notarized dmg for MacOS, as well as updated the `dmgbuild` script to facilitate the process of creating one manually - instead of through the pipeline.
