### PR TITLE
ci: improve release-notes generation

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -808,35 +808,15 @@ jobs:
 
                     cd artifacts
 
-                    AAB_FILE=$(filename aab | cut -f1)
-                    DMG_FILE=$(filename dmg | cut -f1)
-                    EXE_FILE=$(filename exe | cut -f1)
-                    IPA_FILE=$(filename ipa | cut -f1)
-                    SNAP_FILE=$(filename snap | cut -f1)
-                    ARCH_FILE=$(filename xcarchive | cut -f1)
-
-                    DESCRIPTION=$(cat ../../utilities/release-templates/release-template.md \
-                      | sed "s/TAGNAME/${TAG}/g" \
-                      | sed "s/SNAPVERSION/${SNAP_FILE}/g" \
-                      | sed "s/ANDROIDVERSION/${AAB_FILE}/g" \
-                      | sed "s/IPAVERSION/${IPA_FILE}/g" \
-                      | sed "s/XCAVERSION/${ARCH_FILE}/g" \
-                      | sed "s/MACOSVERSION/${DMG_FILE}/g" \
-                      | sed "s/WINDOWSVERSION/${EXE_FILE}/g" \
-                    )
-
                     echo "Version Found: $VERSION"
                     echo "Tag built:     $TAG"
-                    echo "Description built:"
-                    echo "$DESCRIPTION"
                     echo ""
 
                     ghr -t "${GITHUB_TOKEN}" \
                       -u "${CIRCLE_PROJECT_USERNAME}" \
                       -r "${CIRCLE_PROJECT_REPONAME}" \
                       -c "${CIRCLE_SHA1}" \
-                      -n "qaul App - ${VERSION}" \
-                      -b "${DESCRIPTION}" \
+                      -n "qaul - v${RUST_VERSION}" \
                       -replace \
                       "${TAG}" .
                 name: Publish Release on GitHub
@@ -894,21 +874,33 @@ jobs:
                 name: Add utilities/bin to PATH
             - run:
                 command: |
-                    VERSION=$(cd rust/libqaul && cargo generate-lockfile -q && cargo pkgid | cut -d# -f2 | cut -d: -f2)
-                    TAG="v${VERSION}"
+                    RUST_VERSION=$(cd rust/libqaul && cargo generate-lockfile -q && cargo pkgid | cut -d# -f2 | cut -d: -f2)
+                    TAG="v${RUST_VERSION}"
 
                     cd artifacts
 
                     AMD64_FILE=$(filename deb | grep "amd64" | cut -f1)
                     ARMHF_FILE=$(filename deb | grep "armhf" |cut -f1)
 
+                    # Flutter Filenames make use of Flutter's App Version
+                    FLUTTER_VERSION=$(grep "version:" qaul_ui/pubspec.yaml | awk '{ print $2 }')
+
+                    APK_FILE="qaul-$(echo "$FLUTTER_VERSION" | sed 's/+.*$//')"
+                    LINUX_FILE="qaul-$VERSION.snap"
+                    MACOS_FILE="qaul-$VERSION.dmg"
+                    WINDOWS_FILE="qaul_installer_$FLUTTER_VERSION.exe"
+
                     DESCRIPTION=$(cat ../utilities/release-templates/release-template.md \
                       | sed "s/TAGNAME/${TAG}/g" \
                       | sed "s/DEB_AMD/${AMD64_FILE}/g" \
                       | sed "s/DEB_ARM/${ARMHF_FILE}/g" \
+                      | sed "s/APKVERSION/${APK_FILE}/g" \
+                      | sed "s/SNAPVERSION/${LINUX_FILE}/g" \
+                      | sed "s/MACOSVERSION/${MACOS_FILE}/g" \
+                      | sed "s/WINDOWSVERSION/${WINDOWS_FILE}/g" \
                     )
 
-                    echo "Version Found: $VERSION"
+                    echo "Version Found: $RUST_VERSION"
                     echo "Tag built:     $TAG"
                     echo "Description:"
                     echo "$DESCRIPTION"
@@ -918,7 +910,7 @@ jobs:
                       -u "${CIRCLE_PROJECT_USERNAME}" \
                       -r "${CIRCLE_PROJECT_REPONAME}" \
                       -c "${CIRCLE_SHA1}" \
-                      -n "Libqaul and CLI - v${VERSION}" \
+                      -n "qaul - v${RUST_VERSION}" \
                       -b "${DESCRIPTION}" \
                       -replace \
                       "${TAG}" .

--- a/circleci_config/config-continuation/jobs/publish-flutter-github-release.yml
+++ b/circleci_config/config-continuation/jobs/publish-flutter-github-release.yml
@@ -44,34 +44,14 @@ steps:
 
         cd artifacts
 
-        AAB_FILE=$(filename aab | cut -f1)
-        DMG_FILE=$(filename dmg | cut -f1)
-        EXE_FILE=$(filename exe | cut -f1)
-        IPA_FILE=$(filename ipa | cut -f1)
-        SNAP_FILE=$(filename snap | cut -f1)
-        ARCH_FILE=$(filename xcarchive | cut -f1)
-
-        DESCRIPTION=$(cat ../../utilities/release-templates/release-template.md \
-          | sed "s/TAGNAME/${TAG}/g" \
-          | sed "s/SNAPVERSION/${SNAP_FILE}/g" \
-          | sed "s/ANDROIDVERSION/${AAB_FILE}/g" \
-          | sed "s/IPAVERSION/${IPA_FILE}/g" \
-          | sed "s/XCAVERSION/${ARCH_FILE}/g" \
-          | sed "s/MACOSVERSION/${DMG_FILE}/g" \
-          | sed "s/WINDOWSVERSION/${EXE_FILE}/g" \
-        )
-
         echo "Version Found: $VERSION"
         echo "Tag built:     $TAG"
-        echo "Description built:"
-        echo "$DESCRIPTION"
         echo ""
 
         ghr -t "${GITHUB_TOKEN}" \
           -u "${CIRCLE_PROJECT_USERNAME}" \
           -r "${CIRCLE_PROJECT_REPONAME}" \
           -c "${CIRCLE_SHA1}" \
-          -n "qaul App - ${VERSION}" \
-          -b "${DESCRIPTION}" \
+          -n "qaul - v${RUST_VERSION}" \
           -replace \
           "${TAG}" .

--- a/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
+++ b/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
@@ -52,21 +52,33 @@ steps:
   - run:
       name: Publish Release on GitHub
       command: |
-        VERSION=$(cd rust/libqaul && cargo generate-lockfile -q && cargo pkgid | cut -d# -f2 | cut -d: -f2)
-        TAG="v${VERSION}"
+        RUST_VERSION=$(cd rust/libqaul && cargo generate-lockfile -q && cargo pkgid | cut -d# -f2 | cut -d: -f2)
+        TAG="v${RUST_VERSION}"
 
         cd artifacts
 
         AMD64_FILE=$(filename deb | grep "amd64" | cut -f1)
         ARMHF_FILE=$(filename deb | grep "armhf" |cut -f1)
 
+        # Flutter Filenames make use of Flutter's App Version
+        FLUTTER_VERSION=$(grep "version:" qaul_ui/pubspec.yaml | awk '{ print $2 }')
+
+        APK_FILE="qaul-$(echo "$FLUTTER_VERSION" | sed 's/+.*$//')"
+        LINUX_FILE="qaul-$VERSION.snap"
+        MACOS_FILE="qaul-$VERSION.dmg"
+        WINDOWS_FILE="qaul_installer_$FLUTTER_VERSION.exe"
+
         DESCRIPTION=$(cat ../utilities/release-templates/release-template.md \
           | sed "s/TAGNAME/${TAG}/g" \
           | sed "s/DEB_AMD/${AMD64_FILE}/g" \
           | sed "s/DEB_ARM/${ARMHF_FILE}/g" \
+          | sed "s/APKVERSION/${APK_FILE}/g" \
+          | sed "s/SNAPVERSION/${LINUX_FILE}/g" \
+          | sed "s/MACOSVERSION/${MACOS_FILE}/g" \
+          | sed "s/WINDOWSVERSION/${WINDOWS_FILE}/g" \
         )
 
-        echo "Version Found: $VERSION"
+        echo "Version Found: $RUST_VERSION"
         echo "Tag built:     $TAG"
         echo "Description:"
         echo "$DESCRIPTION"
@@ -76,7 +88,7 @@ steps:
           -u "${CIRCLE_PROJECT_USERNAME}" \
           -r "${CIRCLE_PROJECT_REPONAME}" \
           -c "${CIRCLE_SHA1}" \
-          -n "Libqaul and CLI - v${VERSION}" \
+          -n "qaul - v${RUST_VERSION}" \
           -b "${DESCRIPTION}" \
           -replace \
           "${TAG}" .

--- a/utilities/release-templates/release-template.md
+++ b/utilities/release-templates/release-template.md
@@ -7,17 +7,17 @@ Download and install qaul on your device and share the app with others.
 * [Linux Snap Package](https://github.com/qaul/qaul.net/releases/download/TAGNAME/SNAPVERSION.snap)
 * [Android Universal APK](https://github.com/qaul/qaul.net/releases/download/TAGNAME/APKVERSION.apk)
 
-## CLI Tools (qaul-cli & qauld)
+## Command-line tools (qaul-cli & qauld)
 
-The CLI tools can be used to run qaul from the terminal. For example on an embedded computer without a screen such as a Raspberry Pi or on a Server in the Internet.
+The Command-line tools can be used to run qaul from the terminal. For example on an embedded computer without a screen such as a Raspberry Pi or on a Server in the internet.
 
 **qaul-cli** is the interactive qaul CLI client for communicating over the qaul net via the terminal.
 
 **qauld** is the qaul daemon to be run in the background and work as a _Community Node_ in the network.
 
-* [Windows CLI Tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/windows-cli-binaries.zip)
-* [MacOS CLI Tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/macos-cli-binaries.zip)
+* [Windows Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/windows-cli-binaries.zip)
+* [MacOS Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/macos-cli-binaries.zip)
 * Linux
-    * [Linux CLI Tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/linux-cli-binaries.zip)
+    * [Linux Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/linux-cli-binaries.zip)
     * [qauld Debian Installer - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_AMD.deb)
     * [qauld Debian Installer - armhf (for Raspberry Pi)](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_ARM.deb)

--- a/utilities/release-templates/release-template.md
+++ b/utilities/release-templates/release-template.md
@@ -5,7 +5,7 @@ Download and install qaul on your device and share the app with others.
 * [Windows Installer](https://github.com/qaul/qaul.net/releases/download/TAGNAME/WINDOWSVERSION.exe)
 * [MacOS Installer](https://github.com/qaul/qaul.net/releases/download/TAGNAME/MACOSVERSION.dmg)
 * [Linux Snap Package](https://github.com/qaul/qaul.net/releases/download/TAGNAME/SNAPVERSION.snap)
-* [Android Universal APK](https://github.com/qaul/qaul.net/releases/download/TAGNAME/MACOSVERSION.apk)
+* [Android Universal APK](https://github.com/qaul/qaul.net/releases/download/TAGNAME/APKVERSION.apk)
 
 ## CLI Tools (qaul-cli & qauld)
 


### PR DESCRIPTION
## Description
Make an assumption of what the App filenames will be at the time of creation of the release - which happens in the rust pipeline - to improve its usability.