### PR TITLE
only include used features of libp2p

### DIFF
--- a/rust/libqaul/Cargo.toml
+++ b/rust/libqaul/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 default = []
 
 [dependencies]
-libp2p = { version = "0.49.0", features = ["full"] }
+libp2p = { version = "0.49.0", features = ["async-std", "floodsub", "identify", "mdns", "mplex", "noise", "ping", "tcp", "yamux"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 futures = "0.3.15"
 serde = {version = "=1.0", features = ["derive"] }


### PR DESCRIPTION
Instead of including all features of libp2p, only include the necessary ones.
