### PR TITLE
[#499] android compilation script fails to run on release

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -376,7 +376,7 @@ jobs:
                 command: cd rust/libqaul && cargo install cargo-ndk
                 name: Install Cargo NDK
             - run:
-                command: cd rust/libqaul && sh build_libqaul_android.sh release
+                command: cd rust/libqaul && ./build_libqaul_android.sh release
                 name: Build Libqaul JniLibs for Android
             - save-sccache-cache
             - restore_cache:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1252,5 +1252,6 @@ workflows:
     build-rust:
         jobs:
             - build-libqaul-linux
+            - build-libqaul-android
         when: << pipeline.parameters.run-rust-workflow >>
 

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1252,6 +1252,5 @@ workflows:
     build-rust:
         jobs:
             - build-libqaul-linux
-            - build-libqaul-android
         when: << pipeline.parameters.run-rust-workflow >>
 

--- a/circleci_config/config-continuation/jobs/build-libqaul-android.yml
+++ b/circleci_config/config-continuation/jobs/build-libqaul-android.yml
@@ -20,7 +20,7 @@ steps:
       command: cd rust/libqaul && cargo install cargo-ndk
   - run:
       name: Build Libqaul JniLibs for Android
-      command: cd rust/libqaul && sh build_libqaul_android.sh release
+      command: cd rust/libqaul && ./build_libqaul_android.sh release
   - save-sccache-cache
   - restore_cache:
       key: jars-{{ checksum "android/build.gradle" }}-{{ checksum  "android/libqaul/build.gradle" }}-{{ checksum  "android/blemodule/build.gradle" }}

--- a/circleci_config/config-continuation/workflows/build-rust.yml
+++ b/circleci_config/config-continuation/workflows/build-rust.yml
@@ -1,4 +1,3 @@
 when: << pipeline.parameters.run-rust-workflow >>
 jobs:
   - build-libqaul-linux
-  - build-libqaul-android

--- a/circleci_config/config-continuation/workflows/build-rust.yml
+++ b/circleci_config/config-continuation/workflows/build-rust.yml
@@ -1,3 +1,4 @@
 when: << pipeline.parameters.run-rust-workflow >>
 jobs:
   - build-libqaul-linux
+  - build-libqaul-android

--- a/rust/libqaul/build_libqaul_android.sh
+++ b/rust/libqaul/build_libqaul_android.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -eo pipefail
 
 #-----------------------------------------------------------------NoticeStart-
 # Utilities

--- a/rust/libqaul/build_libqaul_android.sh
+++ b/rust/libqaul/build_libqaul_android.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+set -eo pipefail
 
 #-----------------------------------------------------------------NoticeStart-
 # Utilities
@@ -60,4 +61,4 @@ jniLibs=../../android/libqaul/src/main/jniLibs
 rm -rf ${jniLibs}
 
 # 4. build libqaul for all targets
-cargo ndk -t armeabi-v7a -t arm64-v8a -t x86 -t x86_64  -o $jniLibs build ${buildTypeCargo}
+cargo ndk -t armeabi-v7a -t arm64-v8a -t x86 -t x86_64 -o $jniLibs build ${buildTypeCargo}


### PR DESCRIPTION
## Description
Fix issue with Rust's Android compilation step in CircleCI, which doesn't run on release mode.

The solution was two-fold:
1. Update the shebang from the compilation script to point to bash
2. Not invoke said script from the pipeline through `sh build_libqaul_android.sh`; instead, just execute it through `./build_libqaul_android.sh` so that shebang determines which interpreter should be used.

This fixes #499 .
 