### PR TITLE
[#502] snap permission-denied error

### DIFF
--- a/docs/qaul/flutter/linux.md
+++ b/docs/qaul/flutter/linux.md
@@ -2,8 +2,16 @@
 
 ## Install Prerequisits
 
+Make sure you have the following tools installed, that you are 
+going to need for the further installation: git, curl
+
+```sh
+# Debian & Ubuntu
+sudo apt install git curl
+```
+
 * [Install Rust](qaul/rust/rust-install.md)
-* [Install Flutter](qaul//flutterflutter-install.md)
+* [Install Flutter](qaul/flutter/flutter-install.md)
 
 ## Clone Repository
 

--- a/docs/qaul/rust/rust-install.md
+++ b/docs/qaul/rust/rust-install.md
@@ -7,12 +7,16 @@ on your computer.
 
 Easiest install is via rustup: <https://rustup.rs/>
 
+## Further Tools needed for Rust Compilation
 
-## On Linux
+Install the following additional tools:
 
-Install compiler tool chain for C code
+* compiler tool chain for C code
+* protobuf compiler: protoc
+
+### On Linux
 
 ```sh
 # Debian, Ubuntu, Mint
-sudo apt install build-essential
+sudo apt install build-essential protobuf-compiler
 ```

--- a/qaul_ui/lib/coordinators/email_logging_coordinator/log_storage_manager.dart
+++ b/qaul_ui/lib/coordinators/email_logging_coordinator/log_storage_manager.dart
@@ -56,6 +56,10 @@ class _LogStorageManager {
   String get titlePrefix => 'qaul_log';
 
   Future<String> get _storeDirectory async {
+    if (Platform.isLinux && Platform.environment.containsKey('SNAP_COMMON')) {
+      return Future.value('${Platform.environment['SNAP_COMMON']}/Logs');
+    }
+
     final dir = (Platform.isAndroid)
         ? (await getExternalStorageDirectory())!.path
         : (await getApplicationSupportDirectory()).path;

--- a/qaul_ui/lib/coordinators/email_logging_coordinator/log_storage_manager.dart
+++ b/qaul_ui/lib/coordinators/email_logging_coordinator/log_storage_manager.dart
@@ -57,14 +57,14 @@ class _LogStorageManager {
 
   Future<String> get _storeDirectory async {
     if (Platform.isLinux && Platform.environment.containsKey('SNAP_COMMON')) {
-      return Future.value('${Platform.environment['SNAP_COMMON']}/Logs');
+      return Future.value('${Platform.environment['SNAP_COMMON']}/ui_logs');
     }
 
     final dir = (Platform.isAndroid)
         ? (await getExternalStorageDirectory())!.path
         : (await getApplicationSupportDirectory()).path;
-    if (Platform.isWindows) return '$dir\\Logs';
-    return '$dir/Logs';
+    if (Platform.isWindows) return '$dir\\ui_logs';
+    return '$dir/ui_logs';
   }
 
   Future<bool> get isEmpty async => (await logs).map((e) => e.path).isEmpty;

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul/fii_function_types.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul/fii_function_types.dart
@@ -5,9 +5,9 @@ part of 'libqaul.dart';
 
 // start function
 // C function definition:
-//   void start();
-typedef StartFunctionRust = Void Function();
-typedef StartFunctionDart = void Function();
+//   void start(const char *s);
+typedef StartFunctionRust = Void Function(Pointer<Uint8>);
+typedef StartFunctionDart = void Function(Pointer<Uint8>);
 
 // start libqaul function on a desktop OS
 // C function definition:

--- a/qaul_ui/snap/snapcraft.yaml
+++ b/qaul_ui/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ apps:
     command: qaul
     extensions: [ flutter-stable ]
     plugs:
+      - home
       - network
     slots:
       - dbus-qaul


### PR DESCRIPTION
## Description
Find a fix for the #502 issue.
* Added `home` into the list of `Plugs`
* Added if clause to attempt to expand the `SNAP_COMMON` env var inside the Flutter app, and use that to store the Logs.

### Reasoning
Essentially, this happens because of the application running on it's own sandbox and not having access to the home directory [1].
We can add it as a required permission by adding `home` into our list of plugs, but that doesn't give us access to read/write hidden files [2].
Instead, we may want to use snap-specific paths, such as `SNAP_COMMON` [3].


### Testing
@MathJud Would you be able to run locally? You should be able to run it by doing this:
```bash
# compile for linux in release mode
cd rust
cargo build --release

# bundle the application into snap file
cd ../qaul_ui
snapcraft

# install snap locally
# We add the --dangerous flag to the end, as the snap file won't be signed at this point
sudo snap install qaul.snap --dangerous
```

I couldn't run locally as I'm having issues bundling the snap package. If you're not able either, we can always try running a release pipeline and testing the output.

### Misc
A useful tool to debug snap files is the `snappy-debug` snap.
You should install and run the `snappy-debug` command in a second terminal while running qaul, as it will print out issues that may arise, such as things blocked by confinement and how to solve them.


#### References
[1] https://snapcraft.io/docs/home-interface
[2] https://snapcraft.io/docs/permission-requests
[3] https://snapcraft.io/docs/data-locations
[4] https://forum.snapcraft.io/t/use-of-home-and-network-plugs/2587