### PR TITLE
[#510] Loading system default's language on first screen

### DIFF
--- a/qaul_ui/lib/qaul_app.dart
+++ b/qaul_ui/lib/qaul_app.dart
@@ -136,6 +136,19 @@ class QaulApp extends PlatformAwareBuilder {
                   Intl.defaultLocale = locale.toLanguageTag();
                   return locale;
                 }
+
+                final List<Locale> systemLocales = WidgetsBinding.instance.window.locales;
+                for (final systemLocale in systemLocales) {
+                  final lang = Locale.fromSubtags(languageCode: systemLocale.languageCode);
+                  if (supportedLocales.contains(systemLocale)) {
+                    Intl.defaultLocale = systemLocale.toLanguageTag();
+                    return systemLocale;
+                  } else if (supportedLocales.contains(lang)) {
+                    Intl.defaultLocale = systemLocale.toLanguageTag();
+                    return lang;
+                  }
+                }
+
                 return const Locale.fromSubtags(languageCode: 'en');
               },
               builder: (context, child) {


### PR DESCRIPTION
## Description
Fixes #510 by checking the system default's whenever the internal default is null.