### PR TITLE
docs(linux): add protoc to package requirements

### DIFF
--- a/docs/qaul/flutter/flutter-install.md
+++ b/docs/qaul/flutter/flutter-install.md
@@ -55,7 +55,7 @@ Check the following resources:
 
 ## Build & Test qaul App on your System
 
-Open the folder 'flutter' of the qaul repository in Android Studio.
+Open the folder 'qaul_ui' of the qaul repository in Android Studio.
 
 When opening the project for the first time, you need to set the path to your flutter SDK directory in Android Studio.
 To do that run the following steps:

--- a/docs/qaul/flutter/linux.md
+++ b/docs/qaul/flutter/linux.md
@@ -3,11 +3,11 @@
 ## Install Prerequisits
 
 Make sure you have the following tools installed, that you are 
-going to need for the further installation: git, curl
+going to need for the further installation: git, curl, protobuf-compiler
 
 ```sh
 # Debian & Ubuntu
-sudo apt install git curl
+sudo apt install git curl protobuf-compiler
 ```
 
 * [Install Rust](qaul/rust/rust-install.md)


### PR DESCRIPTION
## Description
Cool project! 
- Added `protobuf-compiler` to the required packages for installing qaul on Linux.
- Updated directory name in the flutter install docs to reflect the current repo state.
