### PR TITLE
[#540] Chat Menu not updating

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -131,17 +131,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    var l10n = AppLocalizations.of(context)!;
-    if (room.isGroupChatRoom) {
-      _overflowMenuOptions.addAll({'groupSettings': l10n.groupSettings});
-    }
+    _updateMenuOptionsBasedOnRoomType();
   }
 
   @override
   void didUpdateWidget(covariant ChatScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.room == room) return;
+    _updateMenuOptionsBasedOnRoomType();
     _scheduleUpdateCurrentOpenChat();
   }
 
@@ -198,20 +195,21 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         ),
         titleSpacing: 0,
         actions: [
-          PopupMenuButton<String>(
-            onSelected: _handleClick,
-            iconSize: 36,
-            splashRadius: 20,
-            icon: const Icon(Icons.more_vert),
-            itemBuilder: (BuildContext context) {
-              return _overflowMenuOptions.keys.map((String key) {
-                return PopupMenuItem<String>(
-                  value: key,
-                  child: Text(_overflowMenuOptions[key]!),
-                );
-              }).toList();
-            },
-          ),
+          if (_overflowMenuOptions.isNotEmpty)
+            PopupMenuButton<String>(
+              onSelected: _handleClick,
+              iconSize: 36,
+              splashRadius: 20,
+              icon: const Icon(Icons.more_vert),
+              itemBuilder: (BuildContext context) {
+                return _overflowMenuOptions.keys.map((String key) {
+                  return PopupMenuItem<String>(
+                    value: key,
+                    child: Text(_overflowMenuOptions[key]!),
+                  );
+                }).toList();
+              },
+            ),
         ],
       ),
       body: CronTaskDecorator(
@@ -468,6 +466,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       isReceiving = s == MessageState.receiving;
     }
     return isReceiving;
+  }
+
+  void _updateMenuOptionsBasedOnRoomType() {
+    var l10n = AppLocalizations.of(context)!;
+    if (room.isGroupChatRoom && _overflowMenuOptions.isEmpty) {
+      _overflowMenuOptions.addAll({'groupSettings': l10n.groupSettings});
+    }
+    if (room.isDirectChat && _overflowMenuOptions.isNotEmpty) {
+      _overflowMenuOptions.clear();
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Fixes #540.
The issue occurred when the user had a direct chat open (which has no menu options, thus no menu to open), and then opened a group chat (new or not).
Closing the current open direct chat prior to opening a group chat would remedy the bug, since the chat screen state was built anew.
Likewise, opening a group chat from an already-opened group chat would remedy the bug, as the menu options are the same.

## Solution
Update the overflow menu options on every chat state change ensures this bug no longer occurs.
As an UX improvement, I've also removed the menu button (three vertical dots) from the direct chats, as currently no menu options are there.