### PR TITLE
Crosscompile libqaul & qauld for Raspberry Pi 64 bit

### DIFF
--- a/docs/qaul/flutter/raspberry64.md
+++ b/docs/qaul/flutter/raspberry64.md
@@ -1,0 +1,68 @@
+# Crosscompile qaul for Raspberry Pi 64 bit
+
+To build qaul for Raspberry Pi's 64 bit ARM architecture on another
+architecture, you can cross-compile it on your development machine 
+and transfer the binaries to the raspberry pi.
+
+## Prerequisites
+
+Install prerequisites to cross-build qaul for raspberry pi.
+
+### Debian, Ubuntu, Mint
+
+Install the gcc linker and the rust target for arm
+
+```sh
+# Install gcc linker for arm
+apt install -y aarch64-unknown-linux-gnu
+
+# Install cross compiler via rustup
+rustup target add aarch64-unknown-linux-gnu
+```
+
+### Arch, Manjaro
+
+Install the gcc linker and the rust target for arm.
+Unfortunately the Arch AUR package has currently compilation problems, 
+WI therefore suggest to install the already compiled toolchain.
+
+```sh
+# Arch
+pacman -S aarch64-linux-gnu-gcc
+
+# Manjaro
+pamac install aarch64-linux-gnu-gcc
+```
+
+Install rust target for arm
+
+```sh
+# Install cross compiler via rustup
+rustup target add aarch64-unknown-linux-gnu
+```
+
+## Configuration of the Linker
+
+In order for cargo to find the linker for the target,
+the linker is referenced and configured in the file `rust/.cargo/config`.
+
+`rust/.cargo/config`
+
+```toml
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+```
+
+## Run Build
+
+Start the build from terminal from within this project folder.
+
+```sh
+# build the debug binaries with cargo
+cargo build --target=aarch64-unknown-linux-gnu
+
+# build the release binaries with cargo
+cargo build --release --target=aarch64-unknown-linux-gnu
+```
+
+The binaries can be found in the `target/aarch64-unknown-linux-gnu` folder.

--- a/rust/.cargo/config
+++ b/rust/.cargo/config
@@ -1,2 +1,5 @@
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/rust/libqaul/build_libqaul_raspberry64.sh
+++ b/rust/libqaul/build_libqaul_raspberry64.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Build libqaul on linux for raspberry pi ARM 64 bit architecture
+#
+# For this script to work, one needs to have installed the
+# target aarch64-unknown-linux-gnu for cargo and also the gcc linker.
+# You may install it using the following commands:
+#
+# On Debian, Ubuntu, Mint
+#
+# ```
+# rustup target add aarch64-unknown-linux-gnu
+# apt install -y gcc-aarch64-linux-gnu
+# ```
+#
+
+cargo build --release --target=aarch64-unknown-linux-gnu


### PR DESCRIPTION
Crosscompile rust targets for Raspberry Pi 64 bit:

* libqaul
* qaul-cli
* qauld
