### PR TITLE
[#558] disable tab's horizontal scroll on public dialog message write

### DIFF
--- a/qaul_ui/lib/screens/home/home_screen.dart
+++ b/qaul_ui/lib/screens/home/home_screen.dart
@@ -23,6 +23,8 @@ class HomeScreen extends HookConsumerWidget {
 
     final gotoToPubTab = useCallback(() => tabCtrl.goToTab(TabType.public), []);
 
+    final disablePageViewScroll = useState(false);
+
     return WillPopScope(
       onWillPop: () async {
         if (Platform.isAndroid) gotoToPubTab();
@@ -34,10 +36,12 @@ class HomeScreen extends HookConsumerWidget {
             key: key,
             controller: tabCtrl.pageController,
             allowImplicitScrolling: true,
-            physics: _isMobile ? const PageScrollPhysics() : const NeverScrollableScrollPhysics(),
+            physics: !disablePageViewScroll.value && _isMobile
+                ? const PageScrollPhysics()
+                : const NeverScrollableScrollPhysics(),
             children: [
               const UserAccountScreen(),
-              BaseTab.public(),
+              BaseTab.public(disablePageViewScroll: disablePageViewScroll),
               BaseTab.users(),
               BaseTab.chat(),
               const DynamicNetworkScreen(),

--- a/qaul_ui/lib/screens/home/tabs/public_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/public_tab.dart
@@ -1,7 +1,9 @@
 part of 'tab.dart';
 
 class _Public extends BaseTab {
-  const _Public({Key? key}) : super(key: key);
+  const _Public({Key? key, required this.disablePageViewScroll})
+      : super(key: key);
+  final ValueNotifier<bool> disablePageViewScroll;
 
   @override
   _PublicState createState() => _PublicState();
@@ -18,7 +20,8 @@ class _PublicState extends _BaseTabState<_Public> {
         WidgetBuilder builder;
         switch (settings.name) {
           case 'public/main':
-            builder = (BuildContext context) => const _PublicTabView();
+            builder = (BuildContext context) =>
+                _PublicTabView(widget.disablePageViewScroll);
             break;
           default:
             throw Exception('Invalid route: ${settings.name}');
@@ -30,7 +33,9 @@ class _PublicState extends _BaseTabState<_Public> {
 }
 
 class _PublicTabView extends HookConsumerWidget {
-  const _PublicTabView({Key? key}) : super(key: key);
+  const _PublicTabView(this.disablePageViewScroll, {Key? key})
+      : super(key: key);
+  final ValueNotifier<bool> disablePageViewScroll;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -60,7 +65,8 @@ class _PublicTabView extends HookConsumerWidget {
 
     final onCreatePublicMessagePressed = useCallback(
       () async {
-        showModalBottomSheet(
+        disablePageViewScroll.value = true;
+        await showModalBottomSheet(
           context: context,
           isScrollControlled: true,
           barrierColor: Colors.transparent,
@@ -71,6 +77,7 @@ class _PublicTabView extends HookConsumerWidget {
             );
           },
         );
+        disablePageViewScroll.value = false;
       },
       [],
     );
@@ -115,7 +122,8 @@ class _PublicTabView extends HookConsumerWidget {
                   content: Text(msg.content ?? '', style: theme.bodyLarge),
                   trailingMetadata: Text(
                     sentAt,
-                    style: theme.bodySmall!.copyWith(fontStyle: FontStyle.italic),
+                    style:
+                        theme.bodySmall!.copyWith(fontStyle: FontStyle.italic),
                   ),
                   nameTapRoutesToDetailsScreen: true,
                 );

--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -41,7 +41,9 @@ abstract class BaseTab extends StatefulHookConsumerWidget {
 
   factory BaseTab.chat({Key? key}) => _Chat(key: key);
 
-  factory BaseTab.public({Key? key}) => _Public(key: key);
+  factory BaseTab.public(
+          {Key? key, required ValueNotifier<bool> disablePageViewScroll}) =>
+      _Public(key: key, disablePageViewScroll: disablePageViewScroll);
 
   factory BaseTab.network({Key? key}) => _Network(key: key);
 


### PR DESCRIPTION
## Description
Closes #558. Disables home screen's horizontal swipe navigation when writing a public message.