### PR TITLE
Fix Network tab regression

### DIFF
--- a/qaul_ui/analysis_options.yaml
+++ b/qaul_ui/analysis_options.yaml
@@ -14,6 +14,10 @@ analyzer:
     - "**/*generated/**"
     - "**/*.pb*.dart"
 
+  errors:
+
+    deprecated_member_use: ignore
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
@@ -55,7 +55,7 @@ class DynamicNetworkScreen extends HookConsumerWidget {
 }
 
 class _DynamicNetworkGameEngine extends Forge2DGame
-    with HasTappablesBridge, HasDraggables {
+    with HasTappables, HasDraggables {
   _DynamicNetworkGameEngine({required this.root})
       : super(gravity: Vector2(0, 0));
   final NetworkNode root;

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -373,18 +373,18 @@ packages:
     dependency: "direct main"
     description:
       name: flame
-      sha256: "6954277d14731fa497a7a878bb34cf01c090b20e3ffe5c6e093a7c1f823bfac5"
+      sha256: "12db9de3cd31b86465b0c1ea173020fb71b15df424ca01b665fa5300b24864c8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   flame_forge2d:
     dependency: "direct main"
     description:
       name: flame_forge2d
-      sha256: fa209e5c3e87e4d6959b59acac47074a2592ad1e6694e018b64122135350ce9a
+      sha256: "939f221ab7fe1819fcc0452720e2a4fa47ba1474733a1dfe1f328055cb004b1d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   fluent_ui:
     dependency: "direct main"
     description:

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   filesize: ^2.0.1
   fixnum: ^1.0.1
   flame: ^1.2.1
-  flame_forge2d: ^0.14.0
+  flame_forge2d: ^0.14.1
   fluent_ui: ^4.2.0
   flutter_chat_types: ^3.4.5
   flutter_chat_ui: ^1.6.6


### PR DESCRIPTION
## Description
After migrating to Flutter 3.10 and updating flame and flame_forge2d, a few deprecations made us attempt to update the Network tab.

The problem, however, is that flame_forge2d is behind when it comes to supporting the replacements for the deprecated instances, namely:
- https://github.com/flame-engine/flame/issues/2547
- https://github.com/flame-engine/flame/issues/2587
- https://github.com/flame-engine/flame/issues/2491

This means that, until Forge2D catches up with Flame and the new APIs, we can’t update the code and fix the deprecation warnings.

This is why I’ve temporarily set the analyzer rule deprecated_member_use to be ignored, as unless the analyzer success all Flutter pipelines fail.

I'll be on the lookout so we can revert this hotfix as soon as possible.