### PR TITLE
[#567] Fix Ahead of time messages in Feed

### DIFF
--- a/qaul_ui/packages/utils/lib/utils.dart
+++ b/qaul_ui/packages/utils/lib/utils.dart
@@ -56,10 +56,22 @@ String initials(String name) {
 
 /// If [clock] is provided, timestamp is in relation to [clock] (Should only be useful for testing).
 ///
-/// Will throw if [date] is in the future (When [clock] is provided, *future* represents time after it).
-String describeFuzzyTimestamp(DateTime date,
-    {DateTime? clock, Locale? locale}) {
-  if (date.isAfter(clock ?? DateTime.now())) throw ArgumentError.value(date);
+/// Will throw if [date] is in the future and [allowFutureDate] is true.
+/// Otherwise, replaces date with `DateTime.now()` for convenience.
+///
+/// Defaults [allowFutureDate] to `false`.
+String describeFuzzyTimestamp(
+  DateTime date, {
+  DateTime? clock,
+  Locale? locale,
+  bool allowFutureDate = false,
+}) {
+  if (date.isAfter(clock ?? DateTime.now())) {
+    if (allowFutureDate) {
+      throw ArgumentError.value(date);
+    }
+    return timeago.format(DateTime.now(), clock: null);
+  }
   if ((clock ?? DateTime.now())
       .subtract(const Duration(days: 50))
       .isAfter(date)) {

--- a/qaul_ui/packages/utils/test/utils_test.dart
+++ b/qaul_ui/packages/utils/test/utils_test.dart
@@ -92,14 +92,14 @@ void main() {
 
   group('initials', () {
     const names = <MapEntry<String, String>>[
-      MapEntry('Name', 'NA'),
+      MapEntry('Name', 'N'),
       MapEntry('Na Me', 'NM'),
       MapEntry('na me ye be', 'NB'),
-      MapEntry('nameyebe', 'NA'),
+      MapEntry('nameyebe', 'N'),
       MapEntry('NAME NAME MENA ANEM', 'NA'),
       MapEntry('  NAME NAME MENA ANEM', 'NA'),
       MapEntry('   NAME NAME MENA ANEM   ', 'NA'),
-      MapEntry('NE ', 'NE'),
+      MapEntry('NE ', 'N'),
       MapEntry('l🤣h😌o🙄😪😓😳ggasdf', '🤣'),
       MapEntry('😌🤣h😌o🙄😪😓😳ggasdf', '😌'),
       MapEntry('😳🤣h😌🙄😪😓😳ggasdf', '😳'),
@@ -109,11 +109,7 @@ void main() {
       test('${tc.key} becomes ${tc.value}', () => expect(tc.value, initials(tc.key)));
     }
 
-    test('empty string throws', () => expect(() => initials(''), throwsArgumentError));
-    test('string with less than 2 chars (besides space) throws', () => expect(() => initials('A '), throwsArgumentError));
-    test('string with less than 2 chars (besides space) throws', () => expect(() => initials('A  '), throwsArgumentError));
-    test('string with less than 2 chars (besides space) throws', () => expect(() => initials('A        '), throwsArgumentError));
-    test('string with less than 2 chars (besides space) throws', () => expect(() => initials(' A '), throwsArgumentError));
+    test('empty string throws', () => expect(() => initials(''), throwsAssertionError));
   });
 
   group('describeFuzzyTimestamp', () {
@@ -131,6 +127,7 @@ void main() {
       MapEntry(origin.subtract(const Duration(days: 51)), '25 Apr 2000'),
       MapEntry(origin.subtract(const Duration(days: 60)), '16 Apr 2000'),
       MapEntry(origin.subtract(const Duration(days: 365)), '16 Jun 1999'),
+      MapEntry(origin.add(const Duration(days: 1000)), 'a moment ago'),
     ];
 
     for (final t in testcases) {


### PR DESCRIPTION
## Description
Applying a fix for #567 by accounting for the possibility of receiving a `DateTime` in the future and handling accordingly.