### PR TITLE
Fix Android BLE Connection Issues

### DIFF
--- a/qaul_ui/android/app/build.gradle
+++ b/qaul_ui/android/app/build.gradle
@@ -54,6 +54,8 @@ android {
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+
+
     }
 
     signingConfigs {

--- a/qaul_ui/android/app/src/main/kotlin/net/qaul/qaul_app/MainActivity.kt
+++ b/qaul_ui/android/app/src/main/kotlin/net/qaul/qaul_app/MainActivity.kt
@@ -1,28 +1,17 @@
-// Copyright (c) 2021 Open Community Project Association https://ocpa.ch
-// This software is published under the AGPLv3 license.
-
-/// Main entry point of the qaul android app
-///
-/// It starts and configures the flutter GUI,
-/// set's up the communication channels,
-/// and starts libqaul via the android libqaul AAR.
-/// Everything in this function is running in the main thread.
-
 package net.qaul.qaul_app
 
+// import the libqaul AAR android library
+
+import android.content.Intent
+import android.content.pm.PackageManager
 import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
-
-// import the libqaul AAR android library
-import net.qaul.libqaul.*
-import net.qaul.ble.core.BleWrapperClass
 import net.qaul.ble.AppLog
-import net.qaul.ble.RemoteLog
+import net.qaul.ble.core.BleWrapperClass
+import net.qaul.libqaul.*
 
-import android.content.pm.PackageManager
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 
@@ -60,8 +49,9 @@ class MainActivity : FlutterActivity() {
         bleWrapperClass = BleWrapperClass(context = this)
 
         // setup message channel between flutter and android
-        MethodChannel(FlutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
-            call, result ->
+        MethodChannel(
+            FlutterEngine.dartExecutor.binaryMessenger, CHANNEL
+        ).setMethodCallHandler { call, result ->
             when {
                 // utility methods
                 call.method == "isBackgroundExecutionEnabled" -> {
@@ -204,8 +194,7 @@ class MainActivity : FlutterActivity() {
 
         if (requestCode == LOCATION_PERMISSION_REQ_CODE) {
             AppLog.e(
-                "MainActivity",
-                "REQ CODED -  " + requestCode + "  Size  " + grantResults.size
+                "MainActivity", "REQ CODED -  " + requestCode + "  Size  " + grantResults.size
             )
             if (grantResults.isNotEmpty()) {
                 for (grantResult in grantResults) {
@@ -219,8 +208,7 @@ class MainActivity : FlutterActivity() {
             }
         } else if (requestCode == BLE_PERMISSION_REQ_CODE_12) {
             AppLog.e(
-                "MainActivity",
-                "REQ CODED -  " + requestCode + "  Size  " + grantResults.size
+                "MainActivity", "REQ CODED -  " + requestCode + "  Size  " + grantResults.size
             )
             if (grantResults.isNotEmpty()) {
                 for (grantResult in grantResults) {
@@ -243,8 +231,7 @@ class MainActivity : FlutterActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         AppLog.e(
-            "MainActivity",
-            "onActivityResult requestCode=$requestCode | resultCode=$resultCode"
+            "MainActivity", "onActivityResult requestCode=$requestCode | resultCode=$resultCode"
         )
         if (requestCode == LOCATION_ENABLE_REQ_CODE) {
             if (resultCode == RESULT_OK) {

--- a/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/core/BleActor.kt
+++ b/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/core/BleActor.kt
@@ -61,9 +61,13 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
 //        if (mBluetoothGatt != null && !isFromMessage) {
         bleDevice = device
         bluetoothDevice = device!!.bluetoothDevice
+
+
+
         Handler(Looper.getMainLooper()).postDelayed({
             connectDevice()
         }, 500)
+
 //        } else {
 //            Handler(Looper.getMainLooper()).postDelayed({
 //                send(BLEUtils.byteToHex(tempData))
@@ -144,13 +148,10 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
             gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int
         ) {
             super.onCharacteristicRead(gatt, characteristic, status)
-            AppLog.d(
-                TAG,
-                "onCharacteristicRead : " + characteristic.uuid.toString() + " , data : " + BLEUtils.byteToHex(
-                    characteristic.value
-                )
+            AppLog.e(
+                "zzz",
+                "onCharacteristicRead : " + characteristic.uuid.toString() + " , isFromMessage->  $isFromMessage"
             )
-
 
 
             if (isFromMessage) {
@@ -171,16 +172,17 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
             }
         }
 
+
         override fun onCharacteristicWrite(
             gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int
         ) {
             super.onCharacteristicWrite(gatt, characteristic, status)
-            AppLog.e(
-                "zzz ",
-                "onCharacteristicWrite --------------> : " + " , data : " + BLEUtils.byteToHex(
-                    characteristic.value
-                )
-            )
+//            AppLog.e(
+//                "zzz ",
+//                "onCharacteristicWrite --------------> $listener  $messageId $ :  , data : " + BLEUtils.byteToHex(
+//                    characteristic.value
+//                )
+//            )
             if (listener != null) {
                 if (messageId.isEmpty() || messageId.isBlank()) {
                     listener!!.onCharacteristicWrite(gatt = gatt, characteristic = characteristic)
@@ -255,7 +257,7 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
     }
 
     fun send(data: String): Int {
-        AppLog.e("zzz", "send data")
+//        AppLog.e("zzz", "send data----------------->   isWriting $isWriting  data $data")
         var data = data
         while (data.length > 40) {
             sendQueue.add(data.substring(0, 40))
@@ -423,9 +425,9 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
     ): Boolean {
         if (attempt < 3) {
             if (data != null) {
-                AppLog.d(
+                AppLog.e(
                     TAG,
-                    "writeServiceData : serUUID : $serUUID, charUUID:$charUUID, data :" + BLEUtils.byteToHex(
+                    "writeServiceData -----------> : serUUID : $serUUID, charUUID:$charUUID, data :" + BLEUtils.byteToHex(
                         data
                     )
                 )
@@ -452,8 +454,8 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
                             )
                         } else {
                             bluetoothDevice!!.connectGatt(mContext, false, mGattCallback)
-
                         }
+
                         this.attempt = attempt + 1
                         tempData = data
                         isReconnect = true
@@ -502,6 +504,6 @@ class BleActor(private val mContext: Context, var listener: BleConnectionListene
     }
 
     companion object {
-        private val TAG: String = "zzz qaul-blemodule BleActor"
+        private val TAG: String = "qaul-blemodule BleActor"
     }
 }

--- a/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/core/BleWrapperClass.kt
+++ b/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/core/BleWrapperClass.kt
@@ -124,7 +124,6 @@ open class BleWrapperClass(context: Activity) {
                     stopService()
                 }
 
-
                 BleOuterClass.Ble.MessageCase.DIRECT_SEND -> {
                     AppLog.e("zzz", " DIRECT_SEND ")
 
@@ -349,12 +348,13 @@ open class BleWrapperClass(context: Activity) {
             }
 
             override fun restartService() {
-//                BleService.bleService?.stop()
-//                Handler(Looper.getMainLooper()).postDelayed({ startService(context) }, 500)
+                BleService.bleService?.stop()
+                Handler(Looper.getMainLooper()).postDelayed({ startService(context) }, 500)
             }
 
         })
     }
+
 
     /**
      * This Method Return Device Information Regarding BLE Functionality & Permissions

--- a/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/core/BleWrapperClass.kt
+++ b/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/core/BleWrapperClass.kt
@@ -43,8 +43,6 @@ open class BleWrapperClass(context: Activity) {
     private var bleCallback: BleRequestCallback? = null
     private var qaulId: ByteArray? = null
     private var advertMode = "low_latency"
-    private var lastMillieTime: Long = 0
-    private var isFromMessage = false
 
     public var mHandler: Handler? = null
 
@@ -128,16 +126,7 @@ open class BleWrapperClass(context: Activity) {
 
 
                 BleOuterClass.Ble.MessageCase.DIRECT_SEND -> {
-//                    if (isSend) {
-//                        isSend = false
-
                     AppLog.e("zzz", " DIRECT_SEND ")
-//                    if (System.currentTimeMillis() - 7000 < lastMillieTime) {
-//                        return
-//                    }
-
-
-                    lastMillieTime = System.currentTimeMillis()
 
                     val bleDirectSend = bleReq.directSend
                     if (BleService().isRunning()) {
@@ -148,7 +137,6 @@ open class BleWrapperClass(context: Activity) {
                             from = bleDirectSend.senderId.toByteArray()
                         )
                     }
-//                    }
                 }
                 else -> {}
             }
@@ -159,12 +147,12 @@ open class BleWrapperClass(context: Activity) {
      * This Method Will send response message to App & libqaul library
      */
     private fun sendResponse(bleRes: BleOuterClass.Ble.Builder) {
-        AppLog.e("TAG", "sendResponse()")
+//        AppLog.e("TAG", "sendResponse()-----------> ${bleRes.messageCase} $bleRes")
         mHandler?.post {
             //callback response for App
 
             bleCallback?.bleResponse(bleRes.build().toByteString())
-            AppLog.e(TAG, "sendResponse:: $bleRes")
+//            AppLog.e(TAG, "sendResponse:: $bleRes")
             //callback response for libqaul
             net.qaul.libqaul.syssend(bleRes.build().toByteArray())
         }

--- a/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/service/BleService.kt
+++ b/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/service/BleService.kt
@@ -93,7 +93,7 @@ class BleService : LifecycleService() {
      * This Method Will Set the necessary data and start the advertisement
      */
     fun startAdvertise(
-        qaul_id: ByteArray, mode: String, bleCallback: BleAdvertiseCallback
+        qaul_id: ByteArray, mode: String, bleCallback: BleAdvertiseCallback,
     ) {
         val name = getRandomString(5)
         bleService?.qaulId = qaul_id
@@ -150,12 +150,15 @@ class BleService : LifecycleService() {
                     "low_power" -> {
                         settingsBuilder.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_POWER)
                     }
+
                     "balanced" -> {
                         settingsBuilder.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
                     }
+
                     "low_latency" -> {
                         settingsBuilder.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
                     }
+
                     "UNRECOGNIZED" -> {
                         settingsBuilder.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
                     }
@@ -180,7 +183,7 @@ class BleService : LifecycleService() {
      * This Method Will Start the Service
      */
     fun start(
-        context: Context
+        context: Context,
     ) {
         if (bleService == null) {
             val intent = Intent(context, BleService::class.java)
@@ -244,12 +247,15 @@ class BleService : LifecycleService() {
             1 -> {
                 errorText = "SCAN_FAILED_ALREADY_STARTED"
             }
+
             2 -> {
                 errorText = "SCAN_FAILED_APPLICATION_REGISTRATION_FAILED"
             }
+
             3 -> {
                 errorText = "SCAN_FAILED_INTERNAL_ERROR"
             }
+
             4 -> {
                 errorText = "SCAN_FAILED_FEATURE_UNSUPPORTED"
             }
@@ -365,7 +371,7 @@ class BleService : LifecycleService() {
     private var gattServerCallback: BluetoothGattServerCallback =
         object : BluetoothGattServerCallback() {
             override fun onConnectionStateChange(
-                device: BluetoothDevice, status: Int, newState: Int
+                device: BluetoothDevice, status: Int, newState: Int,
             ) {
                 super.onConnectionStateChange(device, status, newState)
             }
@@ -378,7 +384,7 @@ class BleService : LifecycleService() {
                 device: BluetoothDevice,
                 requestId: Int,
                 offset: Int,
-                characteristic: BluetoothGattCharacteristic
+                characteristic: BluetoothGattCharacteristic,
             ) {
                 super.onCharacteristicReadRequest(
                     device, requestId, offset, characteristic
@@ -405,7 +411,7 @@ class BleService : LifecycleService() {
                 preparedWrite: Boolean,
                 responseNeeded: Boolean,
                 offset: Int,
-                value: ByteArray
+                value: ByteArray,
             ) {
                 super.onCharacteristicWriteRequest(
                     device, requestId, characteristic, preparedWrite, responseNeeded, offset, value
@@ -477,7 +483,7 @@ class BleService : LifecycleService() {
                 device: BluetoothDevice,
                 requestId: Int,
                 offset: Int,
-                descriptor: BluetoothGattDescriptor
+                descriptor: BluetoothGattDescriptor,
             ) {
                 super.onDescriptorReadRequest(device, requestId, offset, descriptor)
                 AppLog.e(TAG, "onDescriptorReadRequest()")
@@ -490,7 +496,7 @@ class BleService : LifecycleService() {
                 preparedWrite: Boolean,
                 responseNeeded: Boolean,
                 offset: Int,
-                value: ByteArray
+                value: ByteArray,
             ) {
                 super.onDescriptorWriteRequest(
                     device, requestId, descriptor, preparedWrite, responseNeeded, offset, value
@@ -534,15 +540,19 @@ class BleService : LifecycleService() {
                 1 -> {
                     errorText = "ADVERTISE_FAILED_DATA_TOO_LARGE"
                 }
+
                 2 -> {
                     errorText = "ADVERTISE_FAILED_TOO_MANY_ADVERTISERS"
                 }
+
                 3 -> {
                     errorText = "ADVERTISE_FAILED_ALREADY_STARTED"
                 }
+
                 4 -> {
                     errorText = "ADVERTISE_FAILED_INTERNAL_ERROR"
                 }
+
                 5 -> {
                     errorText = "ADVERTISE_FAILED_FEATURE_UNSUPPORTED"
                 }
@@ -643,7 +653,7 @@ class BleService : LifecycleService() {
      * This Method Will Start Handler for Checking Device Out Of Range
      */
     private fun startOutRangeChecker() {
-        outOfRangeChecker.postDelayed(outRangeRunnable, 2000)
+        //outOfRangeChecker.postDelayed(outRangeRunnable, 2000)
     }
 
     /**
@@ -689,7 +699,7 @@ class BleService : LifecycleService() {
                 }
                 if (System.currentTimeMillis() - 60000 > lastWriteTime) {
 //                    bleCallback?.restartService()
-                    removeGatt()
+                    //removeGatt()
                 }
             }
 
@@ -735,7 +745,7 @@ class BleService : LifecycleService() {
             override fun onCharacteristicRead(
                 bleScanDevice: BLEScanDevice,
                 gatt: BluetoothGatt?,
-                characteristic: BluetoothGattCharacteristic?
+                characteristic: BluetoothGattCharacteristic?,
             ) {
                 if (characteristic!!.uuid.toString().lowercase() == READ_CHAR.lowercase()) {
                     val existingDevice =
@@ -749,14 +759,14 @@ class BleService : LifecycleService() {
             }
 
             override fun onCharacteristicWrite(
-                gatt: BluetoothGatt?, characteristic: BluetoothGattCharacteristic?
+                gatt: BluetoothGatt?, characteristic: BluetoothGattCharacteristic?,
             ) {
                 lastWriteTime = System.currentTimeMillis()
                 AppLog.e("zzz lastWriteTime", "$lastWriteTime")
             }
 
             override fun onMessageSent(
-                gatt: BluetoothGatt?, value: ByteArray, id: String
+                gatt: BluetoothGatt?, value: ByteArray, id: String,
             ) {
                 val queue = hashMap[gatt?.device?.address]
                 if (queue?.isNotEmpty() == true) {
@@ -774,7 +784,7 @@ class BleService : LifecycleService() {
             override fun onCharacteristicChanged(
                 macAddress: String?,
                 gatt: BluetoothGatt?,
-                characteristic: BluetoothGattCharacteristic?
+                characteristic: BluetoothGattCharacteristic?,
             ) {
 
             }
@@ -801,6 +811,7 @@ class BleService : LifecycleService() {
                     actorMap[device.macAddress]
                 }
             }
+
             else -> {
                 BleActor(this, BleConnectionListener())
             }
@@ -825,8 +836,12 @@ class BleService : LifecycleService() {
         var mainQueue: Queue<Triple<String, ByteArray, ByteArray>>? = null
         bleDevice?.let {
             if (hashMap.containsKey(it.macAddress)) {
-                val queue = hashMap[it.macAddress!!]
-                queue?.add(Triple(id, from, message))
+                var queue = hashMap[it.macAddress!!]
+                if(queue!!.size < 2) {
+                    queue?.add(Triple(id, from, message))
+                } else{
+                    queue = LinkedList()
+                }
                 hashMap[it.macAddress!!] = queue!!
                 mainQueue = queue
             } else {
@@ -843,11 +858,15 @@ class BleService : LifecycleService() {
 
 
     private fun sendMessageFromQueu(macAddress: String, isFromSendMessage: Boolean = false) {
-        Thread.sleep(10)
+        //Thread.sleep(10)
         executor.execute {
             if (hashMap.isNotEmpty()) {
                 val queue = hashMap[macAddress]
                 if (!queue.isNullOrEmpty()) {
+                    AppLog.e(
+                        TAG,
+                        "sendMessageFromQueu ${queue.size}"
+                    )
                     if (!isFromSendMessage || queue.size == 1) {
                         var bleDevice = ignoreList.find { it.macAddress.contentEquals(macAddress) }
                         if (bleDevice == null) {
@@ -908,7 +927,7 @@ class BleService : LifecycleService() {
         }
 
         override fun onCharacteristicRead(
-            gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int
+            gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int,
         ) {
             super.onCharacteristicRead(gatt, characteristic, status)
 
@@ -916,27 +935,27 @@ class BleService : LifecycleService() {
 
 
         override fun onCharacteristicWrite(
-            gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int
+            gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int,
         ) {
             super.onCharacteristicWrite(gatt, characteristic, status)
 
         }
 
         override fun onCharacteristicChanged(
-            gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic
+            gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic,
         ) {
             super.onCharacteristicChanged(gatt, characteristic)
 
         }
 
         override fun onDescriptorRead(
-            gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int
+            gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int,
         ) {
             super.onDescriptorRead(gatt, descriptor, status)
         }
 
         override fun onDescriptorWrite(
-            gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int
+            gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int,
         ) {
             super.onDescriptorWrite(gatt, descriptor, status)
 

--- a/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/service/BleService.kt
+++ b/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/service/BleService.kt
@@ -297,10 +297,10 @@ class BleService : LifecycleService() {
                 bleDevice.deviceRSSI = rssi
                 bleDevice.macAddress = device.address
                 bleDevice.isConnectable = result.isConnectable
-                bleDevice.lastFoundTime = System.currentTimeMillis()
+                //bleDevice.lastFoundTime = System.currentTimeMillis()
                 devicesList.add(bleDevice)
 
-                AppLog.e(TAG, "-------------------> HERE FOR CONNECTION   parseBLEFrame ")
+
 //                Handler(Looper.getMainLooper()).postDelayed({
                 if (result.isConnectable) {
                     connectDevice(bleDevice, isFromMessage = false)
@@ -308,21 +308,23 @@ class BleService : LifecycleService() {
 //                }, 1200)
 
             } else {
-                val selectItemIgnore = ignoreList.find { it.macAddress == device.address }
-                if (selectItemIgnore != null) {
-                    selectItemIgnore.deviceRSSI = rssi
-                    selectItemIgnore.scanResult = result
-                    selectItemIgnore.name = device.name
-                    selectItemIgnore.isConnectable = result.isConnectable
-                    selectItemIgnore.lastFoundTime = System.currentTimeMillis()
-//                    if (!selectItemIgnore.isConnected) {
-//                        connectDevice(selectItemIgnore, isFromMessage = false)
-//                    }
-                } else {
-//                    selectItem.isConnected = false
-//                    devicesList.remove(selectItem)
-                    AppLog.e(TAG, "zzz device ignored: " + device.address)
-                }
+//                val selectItemIgnore = ignoreList.find { it.macAddress == device.address }
+//                if (selectItemIgnore != null) {
+//                    selectItemIgnore.deviceRSSI = rssi
+//                    selectItemIgnore.scanResult = result
+//                    selectItemIgnore.name = device.name
+//                    selectItemIgnore.isConnectable = result.isConnectable
+//                    selectItemIgnore.lastFoundTime = System.currentTimeMillis()
+////                    if (!selectItemIgnore.isConnected) {
+////                        connectDevice(selectItemIgnore, isFromMessage = false)
+////                    }
+//                } else {
+////                    selectItem.isConnected = false
+////                    devicesList.remove(selectItem)
+//                    AppLog.e(TAG, "zzz device ignored: " + device.address)
+//                }
+                //AppLog.e(TAG, "-------------------> HERE FOR CONNECTION   parseBLEFrame ")
+                ignoreList.find { it.macAddress == device.address }?.lastFoundTime = System.currentTimeMillis()
             }
 //            }, 5000)
         } else {
@@ -653,7 +655,7 @@ class BleService : LifecycleService() {
      * This Method Will Start Handler for Checking Device Out Of Range
      */
     private fun startOutRangeChecker() {
-        //outOfRangeChecker.postDelayed(outRangeRunnable, 2000)
+        outOfRangeChecker.postDelayed(outRangeRunnable, 2000)
     }
 
     /**


### PR DESCRIPTION
This PR fixes most known Android BLE connection problems.

- fixed a fatal App error on Android 12
- fixed a connection loss after 10 minutes error between Android 11 & Android 12 devices
- fixed a problem where a device was not available after restart
- fixed a messaging problem between libqaul and the BLE module, where the BLE module did not send a `device became unavailable` message when a device got disconnected.
- fixed a problem where Android 11 devices mess up the Android BLE stack on app shutdown.