### PR TITLE
fix: ensure proto generated files are included in the release builds …

### DIFF
--- a/qaul_ui/android/app/build.gradle
+++ b/qaul_ui/android/app/build.gradle
@@ -67,6 +67,7 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/qaul_ui/android/app/proguard-rules.pro
+++ b/qaul_ui/android/app/proguard-rules.pro
@@ -1,0 +1,24 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+# Keep all generated protobuf classes
+-keep class qaul.sys.ble.** { *; }

--- a/qaul_ui/android/app/proguard-rules.pro
+++ b/qaul_ui/android/app/proguard-rules.pro
@@ -14,11 +14,9 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
-# Keep all generated protobuf classes
+# Keep all generated protobuf classes & projects
 -keep class qaul.sys.ble.** { *; }
+-keep class net.qaul.ble.** { *; }
+-keep class net.qaul.libqaul.** { *; }


### PR DESCRIPTION
## Description
Closes #586.

The reason the BLE Module is not working on the release build is that, during the compilation process, the generated package was being tree-shaken out.
By defining a proguard rule that explicitly asks for the `qaul.sys.ble` package to be kept, the proto generated files are included in the release.

One can verify that is the case by checking the latest internal release, [nº1152](https://play.google.com/console/u/1/developers/6839717611969266534/app/4972730030643225246/tracks/4699283206265182730/releases/44/details).