### PR TITLE
Hide bluetooth filter on network tab if not on android

### DIFF
--- a/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async' as async;
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:equatable/equatable.dart';

--- a/qaul_ui/lib/screens/home/dynamic_network/widgets/network_type_filter.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/widgets/network_type_filter.dart
@@ -39,6 +39,13 @@ final _filteredNodes = Provider<NetworkNode>((ref) {
 class _NetworkTypeFilterToolbar extends HookConsumerWidget {
   const _NetworkTypeFilterToolbar({Key? key}) : super(key: key);
 
+  static final List<NetworkTypeFilter> availableFilters = [
+    if (Platform.isAndroid) NetworkTypeFilter.bluetooth,
+    NetworkTypeFilter.lan,
+    NetworkTypeFilter.internet,
+    NetworkTypeFilter.all,
+  ];
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final filter = ref.watch(_networkTypeFilter);
@@ -47,8 +54,8 @@ class _NetworkTypeFilterToolbar extends HookConsumerWidget {
       return filter == t ? Colors.lightBlue : Colors.blueGrey.shade200;
     }
 
-    final buttons = List.generate(NetworkTypeFilter.values.length, (i) {
-      final filter = NetworkTypeFilter.values[i];
+    final buttons = List.generate(availableFilters.length, (i) {
+      final filter = availableFilters[i];
       return filterButton(
         context,
         filter: filter,


### PR DESCRIPTION
## Description
Simple UX improvement, since bluetooth is not supported on other platforms yet. Removing the filter from the Network tab if the device is not android.