### PR TITLE
[ci/cd] Include qaul-matrix-bridge in Linux build pipeline

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -478,7 +478,7 @@ jobs:
                 command: |
                     cd rust/target/release
                     mkdir cli-binaries
-                    mv qauld qaul-cli cli-binaries qaul-matrix-bridge
+                    mv qauld qaul-cli  qaul-matrix-bridge cli-binaries
                     cd cli-binaries
                     zip linux-cli-binaries *
                 name: zip command-line binaries

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -465,20 +465,20 @@ jobs:
             - run:
                 command: |
                     sudo apt update
-                    sudo apt install -y protobuf-compiler libdbus-1-dev pkg-config
+                    sudo apt install -y protobuf-compiler libdbus-1-dev pkg-config cmake libssl-dev build-essential
                     protoc --version
                 name: Install protoc
             - setup-sccache
             - restore-sccache-cache
             - run:
-                command: cd rust && cargo build --release
+                command: cd rust && cargo build --release --all
                 name: Build Libqaul for Linux
             - save-sccache-cache
             - run:
                 command: |
                     cd rust/target/release
                     mkdir cli-binaries
-                    mv qauld qaul-cli cli-binaries
+                    mv qauld qaul-cli cli-binaries qaul-matrix-bridge
                     cd cli-binaries
                     zip linux-cli-binaries *
                 name: zip command-line binaries

--- a/circleci_config/config-continuation/jobs/build-libqaul-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-libqaul-linux.yml
@@ -18,7 +18,7 @@ steps:
       command: |
         cd rust/target/release
         mkdir cli-binaries
-        mv qauld qaul-cli cli-binaries qaul-matrix-bridge
+        mv qauld qaul-cli  qaul-matrix-bridge cli-binaries
         cd cli-binaries
         zip linux-cli-binaries *
   - persist_to_workspace:

--- a/circleci_config/config-continuation/jobs/build-libqaul-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-libqaul-linux.yml
@@ -5,20 +5,20 @@ steps:
       name: Install protoc
       command: |
         sudo apt update
-        sudo apt install -y protobuf-compiler libdbus-1-dev pkg-config
+        sudo apt install -y protobuf-compiler libdbus-1-dev pkg-config cmake libssl-dev build-essential
         protoc --version
   - setup-sccache
   - restore-sccache-cache
   - run:
       name: Build Libqaul for Linux
-      command: cd rust && cargo build --release
+      command: cd rust && cargo build --release --all
   - save-sccache-cache
   - run:
       name: zip command-line binaries
       command: |
         cd rust/target/release
         mkdir cli-binaries
-        mv qauld qaul-cli cli-binaries
+        mv qauld qaul-cli cli-binaries qaul-matrix-bridge
         cd cli-binaries
         zip linux-cli-binaries *
   - persist_to_workspace:


### PR DESCRIPTION
## Description
Updating the Linux CI Pipeline to accommodate including the `qaul-matrix-bridge` into the `linux-cli-binaries.zip`.

The pipeline works, as verified by the latest update to [Release v2.0.0-beta.16](https://github.com/qaul/qaul.net/releases/tag/v2.0.0-beta.16), which now includes the aforementioned binary in the [linux-cli-binaries.zip](https://github.com/qaul/qaul.net/releases/download/v2.0.0-beta.16/linux-cli-binaries.zip).