### PR TITLE
[#600] include arm64 linux binaries on releases

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -457,7 +457,7 @@ jobs:
                     mkdir cli-binaries
                     mv qauld qaul-cli cli-binaries
                     cd cli-binaries
-                    zip arm-linux-cli-binaries *
+                    zip linux-cli-binaries-arm64 *
                 name: zip command-line binaries
             - persist_to_workspace:
                 paths:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -186,6 +186,14 @@ executors:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         shell: /bin/bash --login -o pipefail
         working_directory: ~/qaul-libp2p
+    rust-linux-arm:
+        docker:
+            - image: cimg/rust:1.72.0
+        environment:
+            CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        resource_class: arm.medium
+        shell: /bin/bash --login -o pipefail
+        working_directory: ~/qaul-libp2p
     rust-macos:
         environment:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
@@ -427,6 +435,34 @@ jobs:
                 paths:
                     - qaul_ui/android/libqaul/src/main/jniLibs/jniLibs.zip
                 root: ~/qaul-libp2p
+    build-libqaul-arm-linux:
+        executor: rust-linux-arm
+        steps:
+            - checkout-project
+            - run:
+                command: |
+                    sudo apt update
+                    sudo apt install -y protobuf-compiler libdbus-1-dev pkg-config
+                    protoc --version
+                name: Install protoc
+            - setup-sccache
+            - restore-sccache-cache
+            - run:
+                command: cd rust && cargo build --release
+                name: Build Libqaul for Linux on arm
+            - save-sccache-cache
+            - run:
+                command: |
+                    cd rust/target/release
+                    mkdir cli-binaries
+                    mv qauld qaul-cli cli-binaries
+                    cd cli-binaries
+                    zip arm-linux-cli-binaries *
+                name: zip command-line binaries
+            - persist_to_workspace:
+                paths:
+                    - rust/target/release/cli-binaries/arm-linux-cli-binaries.zip
+                root: ~/qaul-libp2p
     build-libqaul-ios:
         executor: rust-macos
         steps:
@@ -578,6 +614,29 @@ jobs:
                     - rust/target/release/cli-binaries/windows-cli-binaries.zip
                 root: ~/qaul-libp2p
         working_directory: ~/qaul-libp2p
+    build-qauld-arm-linux:
+        executor: rust-linux-arm
+        steps:
+            - checkout-project
+            - run:
+                command: |
+                    sudo apt update
+                    sudo apt install -y protobuf-compiler
+                    protoc --version
+                name: Install protoc
+            - setup-sccache
+            - restore-sccache-cache
+            - run:
+                command: cd rust && cargo install cargo-deb
+                name: Install cargo-deb package
+            - run:
+                command: cd rust/clients/qauld && cargo deb
+                name: Build qauld for Linux on arm
+            - save-sccache-cache
+            - persist_to_workspace:
+                paths:
+                    - rust/target/arm/debian/*.deb
+                root: ~/qaul-libp2p
     build-qauld-linux:
         executor: rust-linux
         steps:
@@ -871,9 +930,11 @@ jobs:
                     # Linux - libqaul
                     cp rust/target/release/liblibqaul.so ./artifacts/
                     cp rust/target/release/cli-binaries/linux-cli-binaries.zip ./artifacts/
+                    cp rust/target/release/cli-binaries/arm-linux-cli-binaries.zip ./artifacts/
 
                     # Linux - qauld debian installers
                     cp rust/target/debian/*.deb ./artifacts/
+                    cp rust/target/arm/debian/*.deb ./artifacts/
                     cp rust/target/armv7-unknown-linux-gnueabihf/debian/*.deb ./artifacts/
 
                     # MacOS
@@ -1231,7 +1292,19 @@ workflows:
                         only: /.*/
                 requires:
                     - verify-version-rust
+            - build-libqaul-arm-linux:
+                filters:
+                    tags:
+                        only: /.*/
+                requires:
+                    - verify-version-rust
             - build-qauld-linux:
+                filters:
+                    tags:
+                        only: /.*/
+                requires:
+                    - verify-version-rust
+            - build-qauld-arm-linux:
                 filters:
                     tags:
                         only: /.*/
@@ -1243,7 +1316,9 @@ workflows:
                         only: /.*/
                 requires:
                     - build-libqaul-linux
+                    - build-libqaul-arm-linux
                     - build-qauld-linux
+                    - build-qauld-arm-linux
         when:
             or:
                 - << pipeline.parameters.run-rust-tagged-workflow >>

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -635,7 +635,7 @@ jobs:
             - save-sccache-cache
             - persist_to_workspace:
                 paths:
-                    - rust/target/arm/debian/*.deb
+                    - rust/target/debian/*.deb
                 root: ~/qaul-libp2p
     build-qauld-linux:
         executor: rust-linux
@@ -979,6 +979,7 @@ jobs:
                     WINDOWS_FILE="qaul_installer_$FLUTTER_VERSION"
 
                     AMD64_FILE="qauld_amd64.deb"
+                    ARM64_FILE="qauld_arm64.deb"
                     ARMHF_FILE="qauld_armhf.deb"
 
                     cd artifacts
@@ -991,12 +992,14 @@ jobs:
                     mv "$ORIGINAL_ARMHF_FILE.deb" "$ARMHF_FILE"
 
                     echo "Using debian amd artifact name: $AMD64_FILE"
-                    echo "Using debian arm artifact name: $ARMHF_FILE"
+                    echo "Using debian arm artifact name: $ARM64_FILE"
+                    echo "Using debian armhf artifact name: $ARMHF_FILE"
 
                     DESCRIPTION=$(cat ../utilities/release-templates/release-template.md \
                       | sed "s/TAGNAME/${TAG}/g" \
                       | sed "s/DEB_AMD/${AMD64_FILE}/g" \
-                      | sed "s/DEB_ARM/${ARMHF_FILE}/g" \
+                      | sed "s/DEB_ARM/${ARM64_FILE}/g" \
+                      | sed "s/DEB_ARMHF/${ARMHF_FILE}/g" \
                       | sed "s/APKVERSION/${APK_FILE}/g" \
                       | sed "s/SNAPVERSION/${LINUX_FILE}/g" \
                       | sed "s/ARMSNAPVERSION/${LINUX_ARM_FILE}/g" \

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -461,7 +461,7 @@ jobs:
                 name: zip command-line binaries
             - persist_to_workspace:
                 paths:
-                    - rust/target/release/cli-binaries/arm-linux-cli-binaries.zip
+                    - rust/target/release/cli-binaries/linux-cli-binaries-arm64.zip
                 root: ~/qaul-libp2p
     build-libqaul-ios:
         executor: rust-macos
@@ -930,11 +930,10 @@ jobs:
                     # Linux - libqaul
                     cp rust/target/release/liblibqaul.so ./artifacts/
                     cp rust/target/release/cli-binaries/linux-cli-binaries.zip ./artifacts/
-                    cp rust/target/release/cli-binaries/arm-linux-cli-binaries.zip ./artifacts/
+                    cp rust/target/release/cli-binaries/linux-cli-binaries-arm64.zip ./artifacts/
 
                     # Linux - qauld debian installers
                     cp rust/target/debian/*.deb ./artifacts/
-                    cp rust/target/arm/debian/*.deb ./artifacts/
                     cp rust/target/armv7-unknown-linux-gnueabihf/debian/*.deb ./artifacts/
 
                     # MacOS
@@ -986,9 +985,11 @@ jobs:
 
                     # Get debian file names
                     ORIGINAL_AMD64_FILE=$(filename deb | grep "amd64" | cut -f1)
+                    ORIGINAL_ARM64_FILE=$(filename deb | grep "arm64" | cut -f1)
                     ORIGINAL_ARMHF_FILE=$(filename deb | grep "armhf" | cut -f1)
                     # Rename original debian file names
                     mv "$ORIGINAL_AMD64_FILE.deb" "$AMD64_FILE"
+                    mv "$ORIGINAL_ARM64_FILE.deb" "$ARM64_FILE"
                     mv "$ORIGINAL_ARMHF_FILE.deb" "$ARMHF_FILE"
 
                     echo "Using debian amd artifact name: $AMD64_FILE"

--- a/circleci_config/config-continuation/executors/@executors.yml
+++ b/circleci_config/config-continuation/executors/@executors.yml
@@ -17,6 +17,14 @@ rust-linux:
   shell: /bin/bash --login -o pipefail
   environment:
     CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+rust-linux-arm:
+  docker:
+    - image: cimg/rust:1.72.0
+  resource_class: arm.medium
+  working_directory: ~/qaul-libp2p
+  shell: /bin/bash --login -o pipefail
+  environment:
+    CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 rust-macos:
   macos:
     xcode: 13.0.0

--- a/circleci_config/config-continuation/jobs/build-libqaul-arm-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-libqaul-arm-linux.yml
@@ -24,4 +24,4 @@ steps:
   - persist_to_workspace:
       root: ~/qaul-libp2p
       paths:
-        - rust/target/release/cli-binaries/arm-linux-cli-binaries.zip
+        - rust/target/release/cli-binaries/linux-cli-binaries-arm64.zip

--- a/circleci_config/config-continuation/jobs/build-libqaul-arm-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-libqaul-arm-linux.yml
@@ -20,7 +20,7 @@ steps:
         mkdir cli-binaries
         mv qauld qaul-cli cli-binaries
         cd cli-binaries
-        zip arm-linux-cli-binaries *
+        zip linux-cli-binaries-arm64 *
   - persist_to_workspace:
       root: ~/qaul-libp2p
       paths:

--- a/circleci_config/config-continuation/jobs/build-libqaul-arm-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-libqaul-arm-linux.yml
@@ -1,0 +1,27 @@
+executor: rust-linux-arm
+steps:
+  - checkout-project
+  - run:
+      name: Install protoc
+      command: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler libdbus-1-dev pkg-config
+        protoc --version
+  - setup-sccache
+  - restore-sccache-cache
+  - run:
+      name: Build Libqaul for Linux on arm
+      command: cd rust && cargo build --release
+  - save-sccache-cache
+  - run:
+      name: zip command-line binaries
+      command: |
+        cd rust/target/release
+        mkdir cli-binaries
+        mv qauld qaul-cli cli-binaries
+        cd cli-binaries
+        zip arm-linux-cli-binaries *
+  - persist_to_workspace:
+      root: ~/qaul-libp2p
+      paths:
+        - rust/target/release/cli-binaries/arm-linux-cli-binaries.zip

--- a/circleci_config/config-continuation/jobs/build-qauld-arm-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-qauld-arm-linux.yml
@@ -1,0 +1,22 @@
+executor: rust-linux-arm
+steps:
+  - checkout-project
+  - run:
+      name: Install protoc
+      command: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler
+        protoc --version
+  - setup-sccache
+  - restore-sccache-cache
+  - run:
+      name: Install cargo-deb package
+      command: cd rust && cargo install cargo-deb
+  - run:
+      name: Build qauld for Linux on arm
+      command: cd rust/clients/qauld && cargo deb
+  - save-sccache-cache
+  - persist_to_workspace:
+      root: ~/qaul-libp2p
+      paths:
+        - rust/target/arm/debian/*.deb

--- a/circleci_config/config-continuation/jobs/build-qauld-arm-linux.yml
+++ b/circleci_config/config-continuation/jobs/build-qauld-arm-linux.yml
@@ -19,4 +19,4 @@ steps:
   - persist_to_workspace:
       root: ~/qaul-libp2p
       paths:
-        - rust/target/arm/debian/*.deb
+        - rust/target/debian/*.deb

--- a/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
+++ b/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
@@ -66,6 +66,7 @@ steps:
         WINDOWS_FILE="qaul_installer_$FLUTTER_VERSION"
 
         AMD64_FILE="qauld_amd64.deb"
+        ARM64_FILE="qauld_arm64.deb"
         ARMHF_FILE="qauld_armhf.deb"
 
         cd artifacts
@@ -78,12 +79,14 @@ steps:
         mv "$ORIGINAL_ARMHF_FILE.deb" "$ARMHF_FILE"
 
         echo "Using debian amd artifact name: $AMD64_FILE"
-        echo "Using debian arm artifact name: $ARMHF_FILE"
+        echo "Using debian arm artifact name: $ARM64_FILE"
+        echo "Using debian armhf artifact name: $ARMHF_FILE"
 
         DESCRIPTION=$(cat ../utilities/release-templates/release-template.md \
           | sed "s/TAGNAME/${TAG}/g" \
           | sed "s/DEB_AMD/${AMD64_FILE}/g" \
-          | sed "s/DEB_ARM/${ARMHF_FILE}/g" \
+          | sed "s/DEB_ARM/${ARM64_FILE}/g" \
+          | sed "s/DEB_ARMHF/${ARMHF_FILE}/g" \
           | sed "s/APKVERSION/${APK_FILE}/g" \
           | sed "s/SNAPVERSION/${LINUX_FILE}/g" \
           | sed "s/ARMSNAPVERSION/${LINUX_ARM_FILE}/g" \

--- a/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
+++ b/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
@@ -18,11 +18,10 @@ steps:
         # Linux - libqaul
         cp rust/target/release/liblibqaul.so ./artifacts/
         cp rust/target/release/cli-binaries/linux-cli-binaries.zip ./artifacts/
-        cp rust/target/release/cli-binaries/arm-linux-cli-binaries.zip ./artifacts/
+        cp rust/target/release/cli-binaries/linux-cli-binaries-arm64.zip ./artifacts/
 
         # Linux - qauld debian installers
         cp rust/target/debian/*.deb ./artifacts/
-        cp rust/target/arm/debian/*.deb ./artifacts/
         cp rust/target/armv7-unknown-linux-gnueabihf/debian/*.deb ./artifacts/
 
         # MacOS
@@ -73,9 +72,11 @@ steps:
 
         # Get debian file names
         ORIGINAL_AMD64_FILE=$(filename deb | grep "amd64" | cut -f1)
+        ORIGINAL_ARM64_FILE=$(filename deb | grep "arm64" | cut -f1)
         ORIGINAL_ARMHF_FILE=$(filename deb | grep "armhf" | cut -f1)
         # Rename original debian file names
         mv "$ORIGINAL_AMD64_FILE.deb" "$AMD64_FILE"
+        mv "$ORIGINAL_ARM64_FILE.deb" "$ARM64_FILE"
         mv "$ORIGINAL_ARMHF_FILE.deb" "$ARMHF_FILE"
 
         echo "Using debian amd artifact name: $AMD64_FILE"

--- a/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
+++ b/circleci_config/config-continuation/jobs/publish-rust-github-release.yml
@@ -18,9 +18,11 @@ steps:
         # Linux - libqaul
         cp rust/target/release/liblibqaul.so ./artifacts/
         cp rust/target/release/cli-binaries/linux-cli-binaries.zip ./artifacts/
+        cp rust/target/release/cli-binaries/arm-linux-cli-binaries.zip ./artifacts/
 
         # Linux - qauld debian installers
         cp rust/target/debian/*.deb ./artifacts/
+        cp rust/target/arm/debian/*.deb ./artifacts/
         cp rust/target/armv7-unknown-linux-gnueabihf/debian/*.deb ./artifacts/
 
         # MacOS
@@ -62,7 +64,7 @@ steps:
         LINUX_ARM_FILE="qaul-arm64-$FLUTTER_VERSION"
         MACOS_FILE="qaul-$FLUTTER_VERSION"
         WINDOWS_FILE="qaul_installer_$FLUTTER_VERSION"
-        
+
         AMD64_FILE="qauld_amd64.deb"
         ARMHF_FILE="qauld_armhf.deb"
 
@@ -74,10 +76,10 @@ steps:
         # Rename original debian file names
         mv "$ORIGINAL_AMD64_FILE.deb" "$AMD64_FILE"
         mv "$ORIGINAL_ARMHF_FILE.deb" "$ARMHF_FILE"
-        
+
         echo "Using debian amd artifact name: $AMD64_FILE"
         echo "Using debian arm artifact name: $ARMHF_FILE"
-        
+
         DESCRIPTION=$(cat ../utilities/release-templates/release-template.md \
           | sed "s/TAGNAME/${TAG}/g" \
           | sed "s/DEB_AMD/${AMD64_FILE}/g" \

--- a/circleci_config/config-continuation/workflows/build-and-deploy-rust-linux.yml
+++ b/circleci_config/config-continuation/workflows/build-and-deploy-rust-linux.yml
@@ -3,7 +3,35 @@ when:
     - << pipeline.parameters.run-rust-tagged-workflow >>
     - << pipeline.parameters.run-rust-linux-tagged-workflow >>
 jobs:
-  - verify-version-rust: { 'filters': { 'tags': { 'only': '/.*/' } } }
-  - build-libqaul-linux: { 'requires': [ 'verify-version-rust' ], 'filters': { 'tags': { 'only': '/.*/' } } }
-  - build-qauld-linux: { 'requires': [ 'verify-version-rust' ], 'filters': { 'tags': { 'only': '/.*/' } } }
-  - publish-rust-github-release: { 'requires': [ 'build-libqaul-linux', 'build-qauld-linux' ], 'filters': { 'tags': { 'only': '/.*/' } } }
+  - verify-version-rust: { "filters": { "tags": { "only": "/.*/" } } }
+  - build-libqaul-linux:
+      {
+        "requires": ["verify-version-rust"],
+        "filters": { "tags": { "only": "/.*/" } },
+      }
+  - build-libqaul-arm-linux:
+      {
+        "requires": ["verify-version-rust"],
+        "filters": { "tags": { "only": "/.*/" } },
+      }
+  - build-qauld-linux:
+      {
+        "requires": ["verify-version-rust"],
+        "filters": { "tags": { "only": "/.*/" } },
+      }
+  - build-qauld-arm-linux:
+      {
+        "requires": ["verify-version-rust"],
+        "filters": { "tags": { "only": "/.*/" } },
+      }
+  - publish-rust-github-release:
+      {
+        "requires":
+          [
+            "build-libqaul-linux",
+            "build-libqaul-arm-linux",
+            "build-qauld-linux",
+            "build-qauld-arm-linux",
+          ],
+        "filters": { "tags": { "only": "/.*/" } },
+      }

--- a/utilities/release-templates/release-template.md
+++ b/utilities/release-templates/release-template.md
@@ -2,11 +2,11 @@
 
 Download and install qaul on your device and share the app with others.
 
-* [Windows Installer](https://github.com/qaul/qaul.net/releases/download/TAGNAME/WINDOWSVERSION.exe)
-* [MacOS Installer](https://github.com/qaul/qaul.net/releases/download/TAGNAME/MACOSVERSION.dmg)
-* [Linux Snap Package - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/SNAPVERSION.snap)
-* [Linux Snap Package - arm64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/ARMSNAPVERSION.snap)
-* [Android Universal APK](https://github.com/qaul/qaul.net/releases/download/TAGNAME/APKVERSION.apk)
+- [Windows Installer](https://github.com/qaul/qaul.net/releases/download/TAGNAME/WINDOWSVERSION.exe)
+- [MacOS Installer](https://github.com/qaul/qaul.net/releases/download/TAGNAME/MACOSVERSION.dmg)
+- [Linux Snap Package - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/SNAPVERSION.snap)
+- [Linux Snap Package - armhf](https://github.com/qaul/qaul.net/releases/download/TAGNAME/ARMSNAPVERSION.snap)
+- [Android Universal APK](https://github.com/qaul/qaul.net/releases/download/TAGNAME/APKVERSION.apk)
 
 ## Command-line tools (qaul-cli & qauld)
 
@@ -16,9 +16,11 @@ The Command-line tools can be used to run qaul from the terminal. For example on
 
 **qauld** is the qaul daemon to be run in the background and work as a _Community Node_ in the network.
 
-* [Windows Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/windows-cli-binaries.zip)
-* [MacOS Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/macos-cli-binaries.zip)
-* Linux
-    * [Linux Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/linux-cli-binaries.zip)
-    * [qauld Debian Installer - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_AMD)
-    * [qauld Debian Installer - armhf (for Raspberry Pi)](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_ARM)
+- [Windows Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/windows-cli-binaries.zip)
+- [MacOS Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/macos-cli-binaries.zip)
+- Linux
+  - [Linux Command-line tools - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/linux-cli-binaries.zip)
+  - [Linux Command-line tools - arm64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/arm-linux-cli-binaries.zip)
+  - [qauld Debian Installer - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_AMD)
+  - [qauld Debian Installer - arm64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_ARM)
+  - [qauld Debian Installer - armhf (for Raspberry Pi)](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_ARMHF)

--- a/utilities/release-templates/release-template.md
+++ b/utilities/release-templates/release-template.md
@@ -20,7 +20,7 @@ The Command-line tools can be used to run qaul from the terminal. For example on
 - [MacOS Command-line tools](https://github.com/qaul/qaul.net/releases/download/TAGNAME/macos-cli-binaries.zip)
 - Linux
   - [Linux Command-line tools - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/linux-cli-binaries.zip)
-  - [Linux Command-line tools - arm64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/arm-linux-cli-binaries.zip)
+  - [Linux Command-line tools - arm64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/linux-cli-binaries-arm64.zip)
   - [qauld Debian Installer - amd64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_AMD)
   - [qauld Debian Installer - arm64](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_ARM)
   - [qauld Debian Installer - armhf (for Raspberry Pi)](https://github.com/qaul/qaul.net/releases/download/TAGNAME/DEB_ARMHF)


### PR DESCRIPTION
## Description
Closes #600.
This PR adds a new job that builds the `*.deb` image and CLI binaries for the arm64 arch.
The pipeline has been tested, as I ran a platform-specific test, and the assets are available in the [latest release](https://github.com/qaul/qaul.net/releases/tag/v2.0.0-beta.16).
Assets have been tested on a rpi 4 running Ubuntu.