### PR TITLE
fix: improve group creation flow on mobile

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -62,6 +62,8 @@ class _ChatState extends _BaseTabState<_Chat> {
       if (newChat is User) {
         final newRoom = ChatRoom.blank(otherUser: newChat);
         setOpenChat(newRoom, newChat);
+      } else if (newChat is ChatRoom) {
+        setOpenChat(newChat);
       }
     }, [setOpenChat]);
 

--- a/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
@@ -25,12 +25,15 @@ class _CreateNewRoomDialog extends StatelessWidget {
                   ],
                 ),
                 title: Text(l10n.createNewGroup),
-                onTap: () => Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => _CreateNewGroupDialog(),
-                  ),
-                ),
+                onTap: () async {
+                  final result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => _CreateNewGroupDialog(),
+                    ),
+                  );
+                  Navigator.pop(context, result);
+                },
               );
             }
             final usr = users[i - 1];
@@ -53,21 +56,6 @@ class _CreateNewGroupDialog extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final worker = ref.read(qaulWorkerProvider);
-    final defaultUser = ref.watch(defaultUserProvider)!;
-
-    final mobile =
-        Responsiveness.isMobile(context); // MediaQuery on HookState.init throws
-    final setOpenChat = useCallback((ChatRoom room, [User? otherUser]) {
-      if (mobile) {
-        openChat(room,
-            ref: ref,
-            context: context,
-            user: defaultUser,
-            otherUser: otherUser);
-      } else {
-        ref.read(currentOpenChatRoom.notifier).state = room;
-      }
-    }, [mobile]);
 
     final loading = useState(false);
     final nameCtrl = useTextEditingController();
@@ -141,7 +129,7 @@ class _CreateNewGroupDialog extends HookConsumerWidget {
                   var chatRoom = ref
                       .read(chatRoomsProvider)
                       .firstWhereOrNull((g) => g.name == name);
-                  if (chatRoom != null) setOpenChat(chatRoom);
+
                   Navigator.pop(context, chatRoom);
                 },
               ),


### PR DESCRIPTION
## Description
Upon reviewing, I was able to reproduce the issue on Android - on Mac it wasn't reproducible, since Desktop has a different "Chat opening" logic (it's nested in the tab, rather than being a new screen).

I was able to improve the chat creation flow by changing how the navigation is being handled, and returning the newly created room from the "Create Group" dialog.

@MathJud could you please test on Android also to see if I didn't forget anything?

### Tests
#### Android 10, Moto G7 - bug fixed

https://github.com/qaul/qaul.net/assets/54450520/39221dd4-5540-42fc-a20b-c7bfbac91981

#### MacOS Ventura 13.3.1 (a) - no regression

https://github.com/qaul/qaul.net/assets/54450520/3add08fb-c36a-4c7e-85d1-6cee3a1b2fc6


