### PR TITLE
ci: bump flutter version to fix compatibility issue

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -124,7 +124,7 @@ executors:
             _JAVA_OPTIONS: -Xmx2048m
             FASTLANE_LANE: upload_beta_playstore
             FL_OUTPUT_DIR: output
-            FLUTTER_VERSION: 3.10.5
+            FLUTTER_VERSION: 3.16.0
             GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m"
             LANG: en_US.UTF-8
             LC_ALL: en_US.UTF-8
@@ -137,7 +137,7 @@ executors:
         environment:
             FASTLANE_LANE: upload_testflight
             FL_OUTPUT_DIR: output
-            FLUTTER_VERSION: 3.10.5
+            FLUTTER_VERSION: 3.16.0
             REPO_URL: https://github.com/qaul/qaul.net
         macos:
             xcode: 14.1.0
@@ -145,14 +145,14 @@ executors:
         working_directory: ~/qaul-libp2p/qaul_ui/ios
     flutter-linux:
         environment:
-            FLUTTER_VERSION: 3.10.5
+            FLUTTER_VERSION: 3.16.0
             REPO_URL: https://github.com/qaul/qaul.net
         machine:
             image: ubuntu-2004:202010-01
         working_directory: ~/qaul-libp2p/qaul_ui
     flutter-linux-arm:
         environment:
-            FLUTTER_VERSION: 3.10.5
+            FLUTTER_VERSION: 3.16.0
             REPO_URL: https://github.com/qaul/qaul.net
         machine:
             image: ubuntu-2004:202101-01
@@ -160,7 +160,7 @@ executors:
         working_directory: ~/qaul-libp2p/qaul_ui
     flutter-macos:
         environment:
-            FLUTTER_VERSION: 3.10.5
+            FLUTTER_VERSION: 3.16.0
             REPO_URL: https://github.com/qaul/qaul.net
         macos:
             xcode: 14.0.1

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -115,7 +115,7 @@ commands:
 executors:
     flutter:
         docker:
-            - image: ghcr.io/cirruslabs/flutter:3.10.5
+            - image: ghcr.io/cirruslabs/flutter:3.16.0
         working_directory: ~/qaul-libp2p/qaul_ui
     flutter-android:
         docker:
@@ -366,7 +366,7 @@ jobs:
                 root: ~/qaul-libp2p
     build-flutter-windows:
         environment:
-            FLUTTER_VERSION: 3.10.5
+            FLUTTER_VERSION: 3.16.0
             REPO_URL: https://github.com/qaul/qaul.net
         executor:
             name: win/server-2022

--- a/circleci_config/config-continuation/executors/@executors.yml
+++ b/circleci_config/config-continuation/executors/@executors.yml
@@ -37,7 +37,7 @@ rust-macos:
 # --------------------
 flutter:
   docker:
-    - image: ghcr.io/cirruslabs/flutter:3.10.5
+    - image: ghcr.io/cirruslabs/flutter:3.16.0
   working_directory: ~/qaul-libp2p/qaul_ui
 flutter-android:
   docker:

--- a/circleci_config/config-continuation/executors/@executors.yml
+++ b/circleci_config/config-continuation/executors/@executors.yml
@@ -53,7 +53,7 @@ flutter-android:
     _JAVA_OPTIONS: "-Xmx2048m"
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m"'
     SUPPLY_JSON_KEY: ~/qaul-libp2p/qaul_ui/android/fastlane/google-credentials.json
-    FLUTTER_VERSION: "3.10.5"
+    FLUTTER_VERSION: "3.16.0"
     REPO_URL: "https://github.com/qaul/qaul.net"
 flutter-ios:
   macos:
@@ -63,14 +63,14 @@ flutter-ios:
   environment:
     FL_OUTPUT_DIR: output
     FASTLANE_LANE: upload_testflight
-    FLUTTER_VERSION: "3.10.5"
+    FLUTTER_VERSION: "3.16.0"
     REPO_URL: "https://github.com/qaul/qaul.net"
 flutter-linux:
   machine:
     image: ubuntu-2004:202010-01
   working_directory: ~/qaul-libp2p/qaul_ui
   environment:
-    FLUTTER_VERSION: "3.10.5"
+    FLUTTER_VERSION: "3.16.0"
     REPO_URL: "https://github.com/qaul/qaul.net"
 flutter-linux-arm:
   machine:
@@ -78,7 +78,7 @@ flutter-linux-arm:
   resource_class: arm.medium
   working_directory: ~/qaul-libp2p/qaul_ui
   environment:
-    FLUTTER_VERSION: "3.10.5"
+    FLUTTER_VERSION: "3.16.0"
     REPO_URL: "https://github.com/qaul/qaul.net"
 flutter-macos:
   macos:
@@ -86,7 +86,7 @@ flutter-macos:
   shell: /bin/bash --login -o pipefail
   working_directory: ~/qaul-libp2p/qaul_ui
   environment:
-    FLUTTER_VERSION: "3.10.5"
+    FLUTTER_VERSION: "3.16.0"
     REPO_URL: "https://github.com/qaul/qaul.net"
 flutter-ubuntu-lean:
   working_directory: ~/qaul-libp2p/qaul_ui

--- a/circleci_config/config-continuation/jobs/build-flutter-windows.yml
+++ b/circleci_config/config-continuation/jobs/build-flutter-windows.yml
@@ -4,7 +4,7 @@ executor:
   shell: bash.exe
 working_directory: ~/qaul-libp2p/qaul_ui
 environment:
-  FLUTTER_VERSION: "3.10.5"
+  FLUTTER_VERSION: "3.16.0"
   REPO_URL: "https://github.com/qaul/qaul.net"
 steps:
   - checkout-project

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+
   adaptive_theme: 3.4.1
   archive: 3.4.9
   badges: 3.1.2


### PR DESCRIPTION
## Description
The new Flutter package versions defined in the latest update require the latest Flutter version.
This PR bumps the pipeline version of Flutter to 3.16.0 to remedy that issue.