### PR TITLE
Do not crash if bluetoothLeAdvertiser.startAdvertising fails

### DIFF
--- a/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/service/BleService.kt
+++ b/qaul_ui/android/blemodule/src/main/java/net/qaul/ble/service/BleService.kt
@@ -166,9 +166,13 @@ class BleService : LifecycleService() {
                 settingsBuilder.setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
                 settingsBuilder.setConnectable(true)
 
-                bluetoothLeAdvertiser!!.startAdvertising(
-                    settingsBuilder.build(), dataBuilder.build(), advertiseCallback
-                )
+                try {
+                    bluetoothLeAdvertiser!!.startAdvertising(
+                        settingsBuilder.build(), dataBuilder.build(), advertiseCallback
+                    )
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
             } else {
                 AppLog.e(
                     TAG, "Peripheral not supported"


### PR DESCRIPTION
On my phone it throws NullPointerException.
This workaround prevents crash on my phone
when bluetooth is enabled.
This will not fix bluetooth support,
but at least the app is usable over Wi-Fi.

Related issue describing the crash
with stacktraces: <https://github.com/qaul/qaul.net/issues/589>
