### PR TITLE
[#576] Fix block user dialog flow

### DIFF
--- a/qaul_ui/lib/screens/home/user_details_screen.dart
+++ b/qaul_ui/lib/screens/home/user_details_screen.dart
@@ -158,11 +158,9 @@ class UserDetailsScreen extends HookConsumerWidget {
     BuildContext context, {
     required String description,
   }) async {
-    void pop({bool res = false}) => Navigator.pop(context, res);
-
     return await showDialog(
       context: context,
-      builder: (c) {
+      builder: (context) {
         final l10n = AppLocalizations.of(context)!;
 
         return QaulDialog(
@@ -177,9 +175,9 @@ class UserDetailsScreen extends HookConsumerWidget {
             ],
           ),
           button1Label: l10n.okDialogButton,
-          onButton1Pressed: () => pop(res: true),
+          onButton1Pressed: () => Navigator.pop(context, true),
           button2Label: l10n.cancelDialogButton,
-          onButton2Pressed: pop,
+          onButton2Pressed: () => Navigator.pop(context),
         );
       },
     );


### PR DESCRIPTION
## Description
The bug here was quite simple: the `pop` callback was being invoked with the parent's `context`.

Flutter uses the _navigation stack_ to know what to `pop`. Whenever we invoke it via `Navigator.pop(context)`, it uses the `context` to derive where _in the stack_ the method is being invoked and act accordingly.

By using the wrong `context`, the dialog was not being disposed of, and neither was it returning the value of the confirmation, effectively meaning the user wasn't being blocked.

With the changes done here, the feature is back to a working state: user is blocked, their messages being filtered out.

However, as described in #576, I do think that it would be useful to have more control over blocked user management:
- [ ] a place to see users previously blocked (giving the user the option to unblock)
- [ ] option to show/hide chats from blocked users
- [ ] option to show/hide public posts from blocked users

What do you think, @MathJud ?

In any case, it's not a blocker to land this fix!


#### Before

https://github.com/qaul/qaul.net/assets/54450520/ea0105f7-de77-4af4-be64-1eb68d2280ad

#### After

https://github.com/qaul/qaul.net/assets/54450520/4a1cc463-c8e4-41f1-9262-5931f1195647

