### PR TITLE
[chore] Reinstate Flutter's "deprecated member" lint warning

### DIFF
--- a/qaul_ui/analysis_options.yaml
+++ b/qaul_ui/analysis_options.yaml
@@ -14,9 +14,6 @@ analyzer:
     - "**/*generated/**"
     - "**/*.pb*.dart"
 
-  errors:
-
-    deprecated_member_use: ignore
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/qaul_ui/lib/helpers/navigation_helper.dart
+++ b/qaul_ui/lib/helpers/navigation_helper.dart
@@ -18,17 +18,24 @@ class NavigationHelper {
   static const support = '/support';
   static const fileHistory = '/fileHistory';
 
-  static Route<T> _buildRoute<T>(final RouteSettings settings, final WidgetBuilder page) =>
+  static Route<T> _buildRoute<T>(
+          final RouteSettings settings, final WidgetBuilder page) =>
       CupertinoPageRoute(builder: page, settings: settings);
 
   static Route<dynamic> onGenerateRoute(final RouteSettings s) {
     Widget routeWidget = const SizedBox.shrink();
     switch (s.name) {
       case initial:
-        routeWidget = WillPopScope(onWillPop: () async => false, child: SplashScreen());
+        routeWidget = PopScope(
+          canPop: false,
+          child: SplashScreen(),
+        );
         break;
       case createAccount:
-        routeWidget = WillPopScope(onWillPop: () async => false, child: CreateAccountScreen());
+        routeWidget = PopScope(
+          canPop: false,
+          child: CreateAccountScreen(),
+        );
         break;
       case home:
         // WillPopScope handled in build method of HomeScreen -> Custom behavior

--- a/qaul_ui/lib/screens/home/home_screen.dart
+++ b/qaul_ui/lib/screens/home/home_screen.dart
@@ -25,10 +25,9 @@ class HomeScreen extends HookConsumerWidget {
 
     final disablePageViewScroll = useState(false);
 
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      onPopInvoked: (_) async {
         if (Platform.isAndroid) gotoToPubTab();
-        return false;
       },
       child: Scaffold(
         body: QaulNavBarDecorator(

--- a/qaul_ui/lib/screens/home/tabs/network_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/network_tab.dart
@@ -125,8 +125,8 @@ class _AvailableConnectionsTable extends ConsumerWidget {
     );
   }
 
-  String _buildCapitalizedEnumName() => describeEnum(type)
-      .splitMapJoin(RegExp(r'^.{1}'), onMatch: (m) => m[0]!.toUpperCase(), onNonMatch: (n) => n);
+  String _buildCapitalizedEnumName() => type.name
+      .splitMapJoin(RegExp(r'^.'), onMatch: (m) => m[0]!.toUpperCase(), onNonMatch: (n) => n);
 
   IconData _mapIconFromType(ConnectionType type) {
     switch (type) {

--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -4,7 +4,6 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';

--- a/qaul_ui/lib/screens/support_screen.dart
+++ b/qaul_ui/lib/screens/support_screen.dart
@@ -72,7 +72,7 @@ class _SupportScreenState extends ConsumerState<SupportScreen> {
                                 child: Text(l10n.deleteLogs),
                                 onPressed: () async {
                                   await emailLogger.deleteLogs();
-                                  if (!mounted) return;
+                                  if (!context.mounted) return;
                                   Navigator.pop(context);
                                 },
                               ),
@@ -102,7 +102,7 @@ class _SupportScreenState extends ConsumerState<SupportScreen> {
                                     await emailLogger.sendLogs(
                                         reader: ref.read);
                                     await emailLogger.deleteLogs();
-                                    if (!mounted) return;
+                                    if (!context.mounted) return;
                                     Navigator.pop(context);
                                   }
                                 : null,

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -373,18 +373,18 @@ packages:
     dependency: "direct main"
     description:
       name: flame
-      sha256: "12db9de3cd31b86465b0c1ea173020fb71b15df424ca01b665fa5300b24864c8"
+      sha256: da1812e2f17a8ffd5d43ea6a83137794e7f482bcf50419bc9847b8efdb39f791
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.17.0"
   flame_forge2d:
     dependency: "direct main"
     description:
       name: flame_forge2d
-      sha256: "939f221ab7fe1819fcc0452720e2a4fa47ba1474733a1dfe1f328055cb004b1d"
+      sha256: "61c459209a19653f36ad1336fc3b22f35ea4650220ac4d2f5c815f664fabc017"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.1"
+    version: "0.15.1"
   fluent_ui:
     dependency: "direct main"
     description:
@@ -1592,4 +1592,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.19.0"

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   filesize: ^2.0.1
   fixnum: ^1.1.0
   flame: ^1.8.1
-  flame_forge2d: ^0.14.1
+  flame_forge2d: ^0.15.1
   fluent_ui: ^4.7.3
   flutter_chat_types: ^3.6.2
   flutter_chat_ui: ^1.6.10


### PR DESCRIPTION
## Description
The goal here is to revert this patch PR: https://github.com/qaul/qaul.net/pull/572

At the time it was done, the `flame_forge2d` package was not up-to-date with `flame`, which had deprecated the `camera` component.

The workaround was to disable the "deprecated member" lint warning ([link](https://dart.dev/tools/diagnostic-messages#deprecated_member_use)).

Since then, `flame_forge2d` was updated, and we now can upgrade it and safely move to the new `camera` system.

This PR reinstates the lint rule and fixes all deprecated members that have appeared in the codebase, besides refactoring the Network tab to use the new Flame/Forge2D camera logic.