### PR TITLE
[#598] Network View not showing all connections

### DIFF
--- a/qaul_ui/lib/screens/home/dynamic_network/models/network_node.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/models/network_node.dart
@@ -22,15 +22,13 @@ class NetworkNode extends Equatable {
     var rootNode = NetworkNode(user: root, children: const {});
     if (users.isEmpty) return rootNode;
 
-    bool typeIsNotAll(NetworkTypeFilter t) => t != NetworkTypeFilter.all;
-
     final options = filter != NetworkTypeFilter.all
         ? [filter]
-        : NetworkTypeFilter.values.where(typeIsNotAll).toList();
+        : [NetworkTypeFilter.bluetooth, NetworkTypeFilter.internet, NetworkTypeFilter.lan];
 
-    if (filter == NetworkTypeFilter.all) {
-      users = _filterOutRepeatingConnections(users);
-    }
+    // if (filter == NetworkTypeFilter.all) {
+    //   users = _filterOutRepeatingConnections(users);
+    // }
 
     final unstructured = _assignParentToChildNodes(root, users, options);
     return _buildNetworkNodeListRecursively(rootNode, allNodes: unstructured);

--- a/qaul_ui/test/network_node_test.dart
+++ b/qaul_ui/test/network_node_test.dart
@@ -379,10 +379,11 @@ void main() {
     );
   });
 
-  test('Node with cyclic reference drops worst connection 2', () async {
-    var user = generateUser('a');
+  test('branch one takes the LAN Path, branch two takes the Internet Path', () async {
+    var user = generateUser('0');
 
-    var peer1 = generateUser('t v', connections: const {
+    // Branch 1
+    var peer1 = generateUser('a', connections: const {
       ConnectionType.ble: ConnectionInfo(ping: 3, hopCount: 2),
       ConnectionType.lan: ConnectionInfo(ping: 218, hopCount: 1),
       ConnectionType.internet: ConnectionInfo(ping: 115, hopCount: 2),
@@ -400,11 +401,23 @@ void main() {
       ConnectionType.ble: ConnectionInfo(ping: 44, hopCount: 3),
       ConnectionType.lan: ConnectionInfo(ping: 259, hopCount: 2),
     });
+
+    // Branch 2
+    var peer5 = generateUser('f', connections: const {
+      ConnectionType.internet: ConnectionInfo(ping: 180, hopCount: 1),
+    });
+    var peer6 = generateUser('g', connections: const {
+      ConnectionType.internet: ConnectionInfo(ping: 250, hopCount: 2),
+    });
+
     final users = [
       peer1,
       peer2,
       peer3,
       peer4,
+
+      peer5,
+      peer6,
     ];
 
     final tree = NetworkNode.fromUserData(user, users, NetworkTypeFilter.all);
@@ -425,6 +438,10 @@ void main() {
             toNetworkNode(peer4, parent: peer1, children: {
               toNetworkNode(peer3, parent: peer4),
             }),
+          }),
+
+          toNetworkNode(peer5, parent: user, children: {
+            toNetworkNode(peer6, parent: peer5),
           }),
         },
       ),

--- a/qaul_ui/test/network_node_test.dart
+++ b/qaul_ui/test/network_node_test.dart
@@ -378,4 +378,56 @@ void main() {
       ),
     );
   });
+
+  test('Node with cyclic reference drops worst connection 2', () async {
+    var user = generateUser('a');
+
+    var peer1 = generateUser('t v', connections: const {
+      ConnectionType.ble: ConnectionInfo(ping: 3, hopCount: 2),
+      ConnectionType.lan: ConnectionInfo(ping: 218, hopCount: 1),
+      ConnectionType.internet: ConnectionInfo(ping: 115, hopCount: 2),
+    });
+    var peer2 = generateUser('b', connections: const {
+      ConnectionType.ble: ConnectionInfo(ping: 0, hopCount: 1),
+      ConnectionType.lan: ConnectionInfo(ping: 19, hopCount: 1),
+      ConnectionType.internet: ConnectionInfo(ping: 50, hopCount: 1),
+    });
+    var peer3 = generateUser('c', connections: const {
+      ConnectionType.ble: ConnectionInfo(ping: 312, hopCount: 4),
+      ConnectionType.lan: ConnectionInfo(ping: 527, hopCount: 3),
+    });
+    var peer4 = generateUser('d', connections: const {
+      ConnectionType.ble: ConnectionInfo(ping: 44, hopCount: 3),
+      ConnectionType.lan: ConnectionInfo(ping: 259, hopCount: 2),
+    });
+    final users = [
+      peer1,
+      peer2,
+      peer3,
+      peer4,
+    ];
+
+    final tree = NetworkNode.fromUserData(user, users, NetworkTypeFilter.all);
+
+    expect(
+      tree,
+      NetworkNode(
+        user: user,
+        children: {
+          toNetworkNode(peer2, parent: user, children: {
+            toNetworkNode(peer1, parent: peer2, children: {
+              toNetworkNode(peer4, parent: peer1, children: {
+                toNetworkNode(peer3, parent: peer4),
+              }),
+            }),
+          }),
+          toNetworkNode(peer1, parent: user, children: {
+            toNetworkNode(peer4, parent: peer1, children: {
+              toNetworkNode(peer3, parent: peer4),
+            }),
+          }),
+        },
+      ),
+    );
+  });
 }


### PR DESCRIPTION
## Description
This PR aims to improve accuracy and readability of the network table from the `NetworkTab`.

The first step was to no longer filter out "best" connections (which were determined by the slowest ping in each node's connection table). This was an invalid strategy, as doing so didn't consider that, at times, the only path to a node is through a slower option.

The second step is to remove duplicated nodes.

I tested it by defining the stub network table:
```dart
// ------------------
// helper function
// ------------------
User generateUser(String name,
    {Map<ConnectionType, ConnectionInfo>? connections}) {
  return User(
    name: name,
    id: Uint8List.fromList(name.codeUnits),
    availableTypes: connections,
  );
}

// ------------------
// Stub network table
// ------------------
var user = generateUser('0');

// Branch 1
var peer1 = generateUser('a', connections: const {
  ConnectionType.ble: ConnectionInfo(ping: 3, hopCount: 2),
  ConnectionType.lan: ConnectionInfo(ping: 218, hopCount: 1),
  ConnectionType.internet: ConnectionInfo(ping: 115, hopCount: 2),
});
var peer2 = generateUser('b', connections: const {
  ConnectionType.ble: ConnectionInfo(ping: 0, hopCount: 1),
  ConnectionType.lan: ConnectionInfo(ping: 19, hopCount: 1),
  ConnectionType.internet: ConnectionInfo(ping: 50, hopCount: 1),
});
var peer3 = generateUser('c', connections: const {
  ConnectionType.ble: ConnectionInfo(ping: 312, hopCount: 4),
  ConnectionType.lan: ConnectionInfo(ping: 527, hopCount: 3),
});
var peer4 = generateUser('d', connections: const {
  ConnectionType.ble: ConnectionInfo(ping: 44, hopCount: 3),
  ConnectionType.lan: ConnectionInfo(ping: 259, hopCount: 2),
});

// Branch 2
var peer5 = generateUser('f', connections: const {
  ConnectionType.internet: ConnectionInfo(ping: 180, hopCount: 1),
});
var peer6 = generateUser('g', connections: const {
  ConnectionType.internet: ConnectionInfo(ping: 250, hopCount: 2),
});

final users = [
  peer1,
  peer2,
  peer3,
  peer4,
  peer5,
  peer6,
];

final tree = NetworkNode.fromUserData(user, users, ref.watch(_networkTypeFilter));
```

Upon rendering it in the FE, we see three branches in the "all connections" filter:
- One for `"A" -> (B is omitted) -> "C" -> "D"` : the LAN connections
- One for `"B"` : the BLE connections
- One for `"F" -> "G"` : the internet connections from `peer5` and `peer6`

`B` is omitted from the LAN path, because:
1. his hop count is the same for both
2. his ping in BLE is lower (0 BLE vs. 19 LAN)

To improve readability, he's omitted from the LAN path and render as a standalone node in the BLE path.

@MathJud let me know if you'd like this behavior to change.

https://github.com/qaul/qaul.net/assets/54450520/1cb0273f-2359-4418-a6a4-616b764ce1d1



