### PR TITLE
Fix: network view flicker

### DIFF
--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -80,9 +80,7 @@ class UsersTranslator extends RpcModuleTranslator {
     if (res.module != type) return;
     if (res.data is List<User>) {
       final provider = reader(usersProvider.notifier);
-      for (final user in res.data) {
-        provider.contains(user) ? provider.update(user) : provider.add(user);
-      }
+      provider.updateMany(res.data);
     }
     if (res.data is SecurityNumber) {
       reader(currentSecurityNoProvider.notifier).state = res.data;


### PR DESCRIPTION
## Description
The cause of this behavior resided in the `qaul_rpc` package, which exposes a `StateNotifier<List<User>>`.

On every second, we refresh the users list, so that the UI can be notified in case of new users or state changes for existing users.

This was causing the UI to re-render, since the list of users changed on every second (i.e. the object changed, not the actual list of users).

A state change notifies the UI to trigger a re-render, which is perceived as a flicker.

This is solved by not updating the notifier's state when it and the new list of users are deeply equal.