### PR TITLE
[CI/CD] Replace deprecated MacOS executors

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -145,7 +145,7 @@ executors:
             REPO_URL: https://github.com/qaul/qaul.net
         macos:
             xcode: 15.0.0
-        resource_class: macos.x86.medium.gen2
+        resource_class: macos.m1.medium.gen1
         shell: /bin/bash --login -o pipefail
         working_directory: ~/qaul.net/qaul_ui/ios
     flutter-linux:
@@ -169,7 +169,7 @@ executors:
             REPO_URL: https://github.com/qaul/qaul.net
         macos:
             xcode: 15.0.0
-        resource_class: macos.x86.medium.gen2
+        resource_class: macos.m1.medium.gen1
         shell: /bin/bash --login -o pipefail
         working_directory: ~/qaul.net/qaul_ui
     flutter-ubuntu-lean:
@@ -206,7 +206,7 @@ executors:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         macos:
             xcode: 14.0.1
-        resource_class: macos.x86.medium.gen2
+        resource_class: macos.m1.medium.gen1
         shell: /bin/bash --login -o pipefail
         working_directory: ~/qaul.net
 jobs:

--- a/circleci_config/config-continuation/executors/@executors.yml
+++ b/circleci_config/config-continuation/executors/@executors.yml
@@ -29,7 +29,7 @@ rust-linux-arm:
 rust-macos:
   macos:
     xcode: 14.0.1
-  resource_class: macos.x86.medium.gen2
+  resource_class: macos.m1.medium.gen1
   working_directory: ~/qaul.net
   shell: /bin/bash --login -o pipefail
   environment:
@@ -60,7 +60,7 @@ flutter-android:
 flutter-ios:
   macos:
     xcode: 15.0.0
-  resource_class: macos.x86.medium.gen2
+  resource_class: macos.m1.medium.gen1
 #  TODO: resource class is deprecated but still not available on Free tier; must be changed on June.
 #  resource_class: macos.m1.medium.gen1
   shell: /bin/bash --login -o pipefail
@@ -90,7 +90,7 @@ flutter-linux-arm:
 flutter-macos:
   macos:
     xcode: 15.0.0
-  resource_class: macos.x86.medium.gen2
+  resource_class: macos.m1.medium.gen1
   shell: /bin/bash --login -o pipefail
   working_directory: ~/qaul.net/qaul_ui
   environment:


### PR DESCRIPTION
## Description
Since yesterday, June-28th, the [x86 MacOS executor is no longer available](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718#timeline-5).

As a result, we now need to use the `macos.m1.medium.gen1` variant, instead.

This PR addressed that by replacing the deprecated executor in all places it's defined.