### PR TITLE
Re-enable BLE filter on network tab for linux

### DIFF
--- a/qaul_ui/lib/screens/home/dynamic_network/widgets/network_type_filter.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/widgets/network_type_filter.dart
@@ -40,7 +40,7 @@ class _NetworkTypeFilterToolbar extends HookConsumerWidget {
   const _NetworkTypeFilterToolbar({Key? key}) : super(key: key);
 
   static final List<NetworkTypeFilter> availableFilters = [
-    if (Platform.isAndroid) NetworkTypeFilter.bluetooth,
+    if (Platform.isAndroid || Platform.isLinux) NetworkTypeFilter.bluetooth,
     NetworkTypeFilter.lan,
     NetworkTypeFilter.internet,
     NetworkTypeFilter.all,


### PR DESCRIPTION
## Description
Re-enable BLE filter on network tab for Linux, so it can be used with the new feature implementation.