### PR TITLE
[#645] Change libqaul's start method on Desktop Platforms

### DIFF
--- a/qaul_ui/lib/force_update.dart
+++ b/qaul_ui/lib/force_update.dart
@@ -56,20 +56,7 @@ class ForceUpdateSystem {
     // On iOS, it's easiePr to use `getApplicationDocumentsDirectory`; however, the path returned would be:
     // /var/mobile/Containers/Data/Application/THE-DEVICE-ID/Library/Application Support
     final appDocumentDir = await getApplicationSupportDirectory();
-
-    if (Platform.isMacOS) {
-      var dir = Directory("${appDocumentDir.parent.path}/net.qaul.qaul");
-      assert(dir.existsSync());
-      return dir;
-    }
-    if (Platform.isWindows) {
-      var dir =
-          Directory("${appDocumentDir.parent.parent.path}\\qaul\\qaul\\config");
-      assert(dir.existsSync());
-      return dir;
-    }
-
-    // if Platform.isAndroid
+    // if Platform.isMacOS || Platform.isWindows || Platform.isAndroid
     return appDocumentDir;
   }
 

--- a/qaul_ui/macos/Podfile.lock
+++ b/qaul_ui/macos/Podfile.lock
@@ -52,14 +52,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
-  file_selector_macos: 468fb6b81fac7c0e88d71317f3eec34c3b008ff9
+  file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
   flutter_app_badger: 55a64b179f8438e89d574320c77b306e327a1730
   flutter_local_notifications: 3805ca215b2fb7f397d78b66db91f6a747af52e4
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
-  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul/libqaul.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul/libqaul.dart
@@ -24,6 +24,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
+import 'package:path_provider/path_provider.dart';
 
 import 'libqaul_interface.dart';
 

--- a/qaul_ui/packages/qaul_rpc/pubspec.lock
+++ b/qaul_ui/packages/qaul_rpc/pubspec.lock
@@ -252,13 +252,13 @@ packages:
     source: hosted
     version: "1.9.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
-      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:

--- a/qaul_ui/packages/qaul_rpc/pubspec.yaml
+++ b/qaul_ui/packages/qaul_rpc/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   fast_base58: ^0.2.1
   hooks_riverpod: ^1.0.4
   utils: { "path": "../utils" }
+  path_provider: ^2.1.4
 
 dev_dependencies:
   flutter_test:

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -975,10 +975,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
Instead of using the deprecated `start_desktop`, use `start` for all FFI-based Platforms (desktop), with config path parameter.

This affects the `force_update` method, as it needs to search for the `version` file that libqaul creates.
