### PR TITLE
[#642] iOS Network view with unselectable filters

### DIFF
--- a/qaul_ui/lib/decorators/qaul_nav_bar_decorator.dart
+++ b/qaul_ui/lib/decorators/qaul_nav_bar_decorator.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:badges/badges.dart';
 import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -136,7 +138,7 @@ class _QaulNavBarDecoratorState extends State<QaulNavBarDecorator> {
     return ConstrainedBox(
       constraints: BoxConstraints(maxHeight: 600 + safePadding),
       child: FractionallySizedBox(
-        heightFactor: 0.12 + safeFraction,
+        heightFactor: 0.13 + safeFraction,
         child: _barBackground(
           context,
           Padding(

--- a/qaul_ui/lib/decorators/qaul_nav_bar_decorator.dart
+++ b/qaul_ui/lib/decorators/qaul_nav_bar_decorator.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:badges/badges.dart';
 import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
@@ -46,10 +46,13 @@ class DynamicNetworkScreen extends HookConsumerWidget {
 
     return Scaffold(
       body: Stack(
-        alignment: AlignmentDirectional.topEnd,
+        alignment: AlignmentDirectional.bottomCenter,
         children: [
           InteractiveViewer(child: GameWidget(game: gameEngine)),
-          const _NetworkTypeFilterToolbar(),
+          const Padding(
+            padding: EdgeInsets.only(bottom: 16),
+            child: _NetworkTypeFilterToolbar(),
+          ),
         ],
       ),
     );

--- a/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
@@ -46,7 +46,9 @@ class DynamicNetworkScreen extends HookConsumerWidget {
 
     return Scaffold(
       body: Stack(
-        alignment: AlignmentDirectional.bottomCenter,
+        alignment: Platform.isIOS
+            ? AlignmentDirectional.bottomCenter
+            : AlignmentDirectional.topEnd,
         children: [
           InteractiveViewer(child: GameWidget(game: gameEngine)),
           const Padding(

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,3 +12,6 @@ members = [
     "libp2p_modules/qaul_info",
     "libp2p_modules/qaul_messaging"
 ]
+
+[patch.crates-io]
+libp2p = { git = "https://github.com/brenodt/rust-libp2p.git", branch = "deps/update-system-configuration" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,3 @@ members = [
     "libp2p_modules/qaul_info",
     "libp2p_modules/qaul_messaging"
 ]
-
-[patch.crates-io]
-libp2p = { git = "https://github.com/brenodt/rust-libp2p.git", branch = "deps/update-system-configuration" }


### PR DESCRIPTION
## Description
Closes #642 . A way I found to remedy the issue is to change the alignment on the `_NetworkTypeFilterToolbar`.

It seems to be related with a Flutter issue in nesting tappable components in Stacks, which can cause issues in the gesture detection.

In changing the alignment, I no longer can reproduce the issues, whilst prior to the change it was consistently reproducible.