### PR TITLE
[#636] Fix keyboard overlay issue on share content dialog

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -184,6 +184,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
+      resizeToAvoidBottomInset: true,
       appBar: AppBar(
         leading: IconButtonFactory(onPressed: closeChat),
         title: Row(
@@ -266,12 +267,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                       if (result != null && result.files.single.path != null) {
                         File file = File(result.files.single.path!);
 
-                        // ignore: use_build_context_synchronously
                         if (!context.mounted) return;
                         showModalBottomSheet(
                           context: context,
-                          builder: (_) {
-                            return _SendFileDialog(
+                          useSafeArea: true,
+                          isScrollControlled: true,
+                          builder: (context) {
+                            final dialog = _SendFileDialog(
                               file,
                               room: room,
                               partialMessage: text?.text,
@@ -283,6 +285,18 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                   description: description.text,
                                 );
                               },
+                            );
+                            if (!Platform.isIOS) {
+                              return dialog;
+                            }
+
+                            final bottomPadding =
+                                MediaQuery.of(context).viewInsets.bottom;
+                            return SingleChildScrollView(
+                              child: Container(
+                                padding: EdgeInsets.only(bottom: bottomPadding),
+                                child: dialog,
+                              ),
                             );
                           },
                         );
@@ -299,12 +313,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                           if (result != null) {
                             File file = File(result.path);
 
-                            // ignore: use_build_context_synchronously
                             if (!context.mounted) return;
                             showModalBottomSheet(
                               context: context,
-                              builder: (_) {
-                                return _SendFileDialog(
+                              useSafeArea: true,
+                              isScrollControlled: true,
+                              builder: (context) {
+                                final dialog = _SendFileDialog(
                                   file,
                                   room: room,
                                   partialMessage: text?.text,
@@ -316,6 +331,20 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                       description: description.text,
                                     );
                                   },
+                                );
+                                if (!Platform.isIOS) {
+                                  return dialog;
+                                }
+
+                                final bottomPadding =
+                                    MediaQuery.of(context).viewInsets.bottom;
+                                return SingleChildScrollView(
+                                  child: Container(
+                                    padding: EdgeInsets.only(
+                                      bottom: bottomPadding,
+                                    ),
+                                    child: dialog,
+                                  ),
                                 );
                               },
                             );


### PR DESCRIPTION
## Description
Fixes #636 on iOS by changing how the `showModalBottomSheet` is invoked and constructs the dialog widget.
This makes so that content expands on iOS when the keyboard is detected to be open, which in turn prevents the field from being inaccessible.

Kept the existing behavior on other platforms.