### PR TITLE
Upgraded libp2p to new version: 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0 Release Candidate 3] Unreleased
+
+Changed
+
+- Upgraded libp2p to current version 0.55.0
+- Upgraded all rust libraries to newest version
+
 ## [2.0.0 Release Candidate 2] 2024-11-28
 
 Added

--- a/rust/libp2p_modules/qaul_info/Cargo.toml
+++ b/rust/libp2p_modules/qaul_info/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["qaul community <contact@qaul.net>"]
 license = "AGPL"
 
 [dependencies]
-libp2p = { version = "0.54.1", features = ["async-std", "macros", "floodsub", "identify", "mdns", "noise", "ping", "tcp", "yamux", "quic", "websocket", "dns", "macros"] }
+libp2p = { version = "0.55", features = ["async-std", "macros", "floodsub", "identify", "mdns", "noise", "ping", "tcp", "yamux", "quic", "websocket", "dns", "macros"] }
 cuckoofilter = "0.5"
 fnv = "1.0"
 futures = "0.3"
@@ -15,7 +15,7 @@ log = "0.4"
 rand = "0.8"
 smallvec = "1.13"
 asynchronous-codec = "0.7"
-bytes = "1.6"
+bytes = "1.9"
 unsigned-varint = "0.8"
 
 # internal references

--- a/rust/libp2p_modules/qaul_messaging/Cargo.toml
+++ b/rust/libp2p_modules/qaul_messaging/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["qaul community <contact@qaul.net>"]
 license = "AGPL"
 
 [dependencies]
-libp2p = { version = "0.54.1", features = ["async-std", "macros", "floodsub", "identify", "mdns", "noise", "ping", "tcp", "yamux", "quic", "websocket", "dns", "macros"] }
+libp2p = { version = "0.55", features = ["async-std", "macros", "floodsub", "identify", "mdns", "noise", "ping", "tcp", "yamux", "quic", "websocket", "dns", "macros"] }
 cuckoofilter = "0.5"
 fnv = "1.0"
 futures = "0.3"
@@ -15,7 +15,7 @@ log = "0.4"
 rand = "0.8"
 smallvec = "1.13"
 asynchronous-codec = "0.7"
-bytes = "1.6"
+bytes = "1.9"
 unsigned-varint = "0.8"
 
 # internal references

--- a/rust/libqaul/Cargo.toml
+++ b/rust/libqaul/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 default = []
 
 [dependencies]
-libp2p = { version = "0.54.1", features = ["async-std", "macros", "floodsub", "identify", "mdns", "noise", "ping", "tcp", "yamux", "quic", "dns", "macros"] }
+libp2p = { version = "0.55", features = ["async-std", "macros", "floodsub", "identify", "mdns", "noise", "ping", "tcp", "yamux", "quic", "dns", "macros"] }
 async-std = { version = "1.13", features = ["attributes"] }
 futures = "0.3"
 serde = {version = "1.0", features = ["derive"] }
@@ -25,7 +25,7 @@ simplelog = "0.12"
 multi_log = "0.1"
 filetime = "0.2"
 bincode = "1.3"
-config = "0.14"
+config = "0.15"
 lazy_static = "1.5"
 toml = "0.8"
 base64 ="0.22"
@@ -43,7 +43,7 @@ futures-ticker = "0.0.3"
 jni = "0.21"
 serde_yaml = "0.9"
 sled = "0.34.7"
-uuid = { version = "1.11", features = ["v4"] }
+uuid = { version = "1.12", features = ["v4"] }
 ed25519-dalek = "2.1.1"
 x25519-dalek = "2.0.1"
 curve25519-dalek = "4.1.3"
@@ -55,7 +55,7 @@ fs_extra = "1.3"
 semver = "1.0"
 
 # only for desktop platforms: Linux, Mac, Windows
-directories = "5.0"
+directories = "6.0"
 
 # internal references
 qaul_info = { path = "../libp2p_modules/qaul_info" }


### PR DESCRIPTION
All rust libraries have been updated to their new current versions.