### PR TITLE
Fixed better_open_file plugin

### DIFF
--- a/qaul_ui/lib/screens/file_history_screen.dart
+++ b/qaul_ui/lib/screens/file_history_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:better_open_file/better_open_file.dart';
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -8,6 +7,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:intl/intl.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -124,7 +124,7 @@ class _FileHistoryTile extends ConsumerWidget {
 
   void _openFile(FileHistoryEntity file, WidgetRef ref) async {
     if (Platform.isIOS || Platform.isAndroid) {
-      OpenFile.open(file.filePath(ref));
+      OpenFilex.open(file.filePath(ref));
       return;
     }
 

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:audioplayers/audioplayers.dart';
-import 'package:better_open_file/better_open_file.dart';
 import 'package:bubble/bubble.dart';
 import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
@@ -24,6 +23,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' hide context, Context;
 import 'package:path_provider/path_provider.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
@@ -384,7 +384,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 return;
               }
               if (Platform.isIOS || Platform.isAndroid) {
-                OpenFile.open(message.uri);
+                OpenFilex.open(message.uri);
                 return;
               }
 

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   adaptive_theme: ^3.4.1
   archive: ^4.0.2
   badges: ^3.1.2
-  better_open_file: ^3.6.4
   bubble: ^1.2.1
   collection: ^1.17.1
   cupertino_icons: ^1.0.6
@@ -64,6 +63,7 @@ dependencies:
   record: ^5.0.4
   audioplayers: ^6.1.1
   app_links: ^6.3.3
+  open_filex: ^4.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
🔀 Fix better_open_file Build Issue by Migrating to open_filex

📌 Summary
This PR replaces better_open_file with open_filex to fix build failures when running flutter run. The issue occurred due to the removal of PluginRegistry.Registrar in Flutter’s new Android embedding, causing compilation errors.

🛠 Changes Made
✅ Removed better_open_file dependency
✅ Added open_filex as a replacement
✅ Updated all references from OpenFile.open() to OpenFilex.open()
✅ Cleaned and rebuilt the project to ensure compatibility

🚀 How to Test
Run flutter pub get
Execute flutter run
Verify that files open successfully using open_filex

✅ Final Notes
This PR ensures long-term compatibility with Flutter's latest Android embedding. Let me know if any further modifications are needed! 🚀

#667 

