### PR TITLE
Implement the password support

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -188,14 +188,14 @@ executors:
         working_directory: ~/qaul.net
     rust-linux:
         docker:
-            - image: cimg/rust:1.87.0
+            - image: cimg/rust:1.92.0
         environment:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         shell: /bin/bash --login -o pipefail
         working_directory: ~/qaul.net
     rust-linux-arm:
         docker:
-            - image: cimg/rust:1.87.0
+            - image: cimg/rust:1.92.0
         environment:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         resource_class: arm.medium

--- a/circleci_config/config-continuation/executors/@executors.yml
+++ b/circleci_config/config-continuation/executors/@executors.yml
@@ -13,14 +13,14 @@ rust-android:
     FLUTTER_VERSION: "3.27.2"
 rust-linux:
   docker:
-    - image: cimg/rust:1.87.0
+    - image: cimg/rust:1.92.0
   working_directory: ~/qaul.net
   shell: /bin/bash --login -o pipefail
   environment:
     CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 rust-linux-arm:
   docker:
-    - image: cimg/rust:1.87.0
+    - image: cimg/rust:1.92.0
   resource_class: arm.medium
   working_directory: ~/qaul.net
   shell: /bin/bash --login -o pipefail

--- a/rust/clients/cli/src/user_accounts.rs
+++ b/rust/clients/cli/src/user_accounts.rs
@@ -81,7 +81,7 @@ impl UserAccounts {
         // create info request message
         let proto_message = proto::UserAccounts {
             message: Some(proto::user_accounts::Message::CreateUserAccount(
-                proto::CreateUserAccount { name: user_name },
+                proto::CreateUserAccount { name: user_name , password: None},
             )),
         };
 

--- a/rust/clients/qauld/src/main.rs
+++ b/rust/clients/qauld/src/main.rs
@@ -72,7 +72,7 @@ async fn main() {
         } else {
             user_name = create_default_named();
         }
-        libqaul::node::user_accounts::UserAccounts::create(user_name.clone());
+        libqaul::node::user_accounts::UserAccounts::create(user_name.clone(), None);
     }
 
     // loop

--- a/rust/libqaul/Cargo.toml
+++ b/rust/libqaul/Cargo.toml
@@ -53,7 +53,7 @@ noise-rust-crypto = { git = "https://github.com/qaul/noise-rust.git", branch = "
 crc = "3.2"
 fs_extra = "1.3"
 semver = "1.0"
-bcrypt = "0.17.0"
+argon2 = "0.5.3"
 
 # only for desktop platforms: Linux, Mac, Windows
 directories = "6.0"

--- a/rust/libqaul/Cargo.toml
+++ b/rust/libqaul/Cargo.toml
@@ -53,6 +53,7 @@ noise-rust-crypto = { git = "https://github.com/qaul/noise-rust.git", branch = "
 crc = "3.2"
 fs_extra = "1.3"
 semver = "1.0"
+bcrypt = "0.17.0"
 
 # only for desktop platforms: Linux, Mac, Windows
 directories = "6.0"

--- a/rust/libqaul/src/node/qaul.rpc.user_accounts.rs
+++ b/rust/libqaul/src/node/qaul.rpc.user_accounts.rs
@@ -32,13 +32,13 @@ pub struct CreateUserAccount {
     pub password: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// set password request for existing user
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetPasswordRequest {
     #[prost(string, optional, tag = "2")]
     pub password: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// set password response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetPasswordResponse {
     #[prost(bool, tag = "1")]
     pub success: bool,

--- a/rust/libqaul/src/node/qaul.rpc.user_accounts.rs
+++ b/rust/libqaul/src/node/qaul.rpc.user_accounts.rs
@@ -2,7 +2,7 @@
 /// user account rpc message container
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct UserAccounts {
-    #[prost(oneof = "user_accounts::Message", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "user_accounts::Message", tags = "1, 2, 3, 4, 5, 6")]
     pub message: ::core::option::Option<user_accounts::Message>,
 }
 /// Nested message and enum types in `UserAccounts`.
@@ -17,6 +17,10 @@ pub mod user_accounts {
         DefaultUserAccount(super::DefaultUserAccount),
         #[prost(message, tag = "4")]
         MyUserAccount(super::MyUserAccount),
+        #[prost(message, tag = "5")]
+        SetPasswordRequest(super::SetPasswordRequest),
+        #[prost(message, tag = "6")]
+        SetPasswordResponse(super::SetPasswordResponse),
     }
 }
 /// create a new user on this node
@@ -24,6 +28,22 @@ pub mod user_accounts {
 pub struct CreateUserAccount {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "2")]
+    pub password: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// set password request for existing user
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPasswordRequest {
+    #[prost(string, optional, tag = "2")]
+    pub password: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// set password response
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPasswordResponse {
+    #[prost(bool, tag = "1")]
+    pub success: bool,
+    #[prost(string, tag = "2")]
+    pub error_message: ::prost::alloc::string::String,
 }
 /// Session Information
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -48,4 +68,6 @@ pub struct MyUserAccount {
     pub key_type: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
     pub key_base58: ::prost::alloc::string::String,
+    #[prost(bool, tag = "7")]
+    pub has_password: bool,
 }

--- a/rust/libqaul/src/node/user_accounts.proto
+++ b/rust/libqaul/src/node/user_accounts.proto
@@ -9,12 +9,26 @@ message UserAccounts {
         CreateUserAccount create_user_account = 2;
         DefaultUserAccount default_user_account = 3;
         MyUserAccount my_user_account = 4;
+        SetPasswordRequest set_password_request = 5;
+        SetPasswordResponse set_password_response = 6;
     }
 }
 
 // create a new user on this node
 message CreateUserAccount {
     string name = 1;
+    optional string password = 2;
+}
+
+// set password request for existing user
+message SetPasswordRequest {
+    optional string password = 2;
+}
+
+// set password response
+message SetPasswordResponse {
+    bool success = 1;
+    string error_message = 2;
 }
 
 // Session Information
@@ -31,4 +45,5 @@ message MyUserAccount {
     bytes key = 4;
     string key_type = 5;
     string key_base58 = 6;
+    bool has_password = 7;
 }

--- a/rust/libqaul/src/node/user_accounts.rs
+++ b/rust/libqaul/src/node/user_accounts.rs
@@ -9,7 +9,6 @@
 //! * Public / private key
 //! * user name (optional)
 
-use std::fmt::format;
 use base64::Engine;
 use libp2p::{
     identity::{ed25519, Keypair, PublicKey},
@@ -390,6 +389,7 @@ impl UserAccounts {
                                     key: user_account.keys.public().encode_protobuf(),
                                     key_type,
                                     key_base58,
+                                    has_password: user_account.password_hash.is_some()
                                 },
                             )),
                         };

--- a/rust/libqaul/src/rpc/mod.rs
+++ b/rust/libqaul/src/rpc/mod.rs
@@ -146,7 +146,7 @@ impl Rpc {
                         // TODO: authorisation
                     }
                     Ok(Modules::Useraccounts) => {
-                        UserAccounts::rpc(message.data);
+                        UserAccounts::rpc(message.data, message.user_id);
                     }
                     Ok(Modules::Users) => {
                         Users::rpc(message.data, message.user_id);

--- a/rust/libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.user_accounts.rs
+++ b/rust/libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.user_accounts.rs
@@ -32,13 +32,13 @@ pub struct CreateUserAccount {
     pub password: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// set password request for existing user
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetPasswordRequest {
     #[prost(string, optional, tag = "2")]
     pub password: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// set password response
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetPasswordResponse {
     #[prost(bool, tag = "1")]
     pub success: bool,

--- a/rust/libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.user_accounts.rs
+++ b/rust/libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.user_accounts.rs
@@ -2,7 +2,7 @@
 /// user account rpc message container
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct UserAccounts {
-    #[prost(oneof = "user_accounts::Message", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "user_accounts::Message", tags = "1, 2, 3, 4, 5, 6")]
     pub message: ::core::option::Option<user_accounts::Message>,
 }
 /// Nested message and enum types in `UserAccounts`.
@@ -17,6 +17,10 @@ pub mod user_accounts {
         DefaultUserAccount(super::DefaultUserAccount),
         #[prost(message, tag = "4")]
         MyUserAccount(super::MyUserAccount),
+        #[prost(message, tag = "5")]
+        SetPasswordRequest(super::SetPasswordRequest),
+        #[prost(message, tag = "6")]
+        SetPasswordResponse(super::SetPasswordResponse),
     }
 }
 /// create a new user on this node
@@ -24,6 +28,22 @@ pub mod user_accounts {
 pub struct CreateUserAccount {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "2")]
+    pub password: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// set password request for existing user
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPasswordRequest {
+    #[prost(string, optional, tag = "2")]
+    pub password: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// set password response
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPasswordResponse {
+    #[prost(bool, tag = "1")]
+    pub success: bool,
+    #[prost(string, tag = "2")]
+    pub error_message: ::prost::alloc::string::String,
 }
 /// Session Information
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -48,4 +68,6 @@ pub struct MyUserAccount {
     pub key_type: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
     pub key_base58: ::prost::alloc::string::String,
+    #[prost(bool, tag = "7")]
+    pub has_password: bool,
 }

--- a/rust/libqaul/src/storage/configuration.rs
+++ b/rust/libqaul/src/storage/configuration.rs
@@ -133,6 +133,7 @@ pub struct UserAccount {
     pub name: String,
     pub id: String,
     pub keys: String,
+    pub password_hash: Option<String>,
     pub storage: StorageOptions,
 }
 
@@ -142,6 +143,7 @@ impl Default for UserAccount {
             name: String::from(""),
             id: String::from(""),
             keys: String::from(""),
+            password_hash: None,
             storage: StorageOptions::default(),
         }
     }

--- a/rust/libqaul/src/utilities/upgrade/v2_0_0_rc_1/mod.rs
+++ b/rust/libqaul/src/utilities/upgrade/v2_0_0_rc_1/mod.rs
@@ -104,6 +104,7 @@ impl VersionUpgrade {
                     name: user.name.clone(),
                     id: user.id.clone(),
                     keys: user.keys.clone(),
+                    password_hash: None,
                     storage: crate::storage::configuration::StorageOptions {
                         users: user.storage.users.clone(),
                         size_total: user.storage.size_total,


### PR DESCRIPTION
Part of https://github.com/qaul/qaul.net/issues/531

Note:
Completed the core logic of adding password support, which includes updating the protobuf definitions. Also, I've been using unwraps in some places, and would add proper error handling at the completion of this PR.
I'm using `qaul_id: PeerId` instead of QaulId, that would be updated

Update:
The commit history is now sane.
The protobuf definitions have been revised based on our IRC chat.