### PR TITLE
chore: upgrade CircleCI to rust 1.85.1

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -188,14 +188,14 @@ executors:
         working_directory: ~/qaul.net
     rust-linux:
         docker:
-            - image: cimg/rust:1.83.0
+            - image: cimg/rust:1.85.1
         environment:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         shell: /bin/bash --login -o pipefail
         working_directory: ~/qaul.net
     rust-linux-arm:
         docker:
-            - image: cimg/rust:1.83.0
+            - image: cimg/rust:1.85.1
         environment:
             CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         resource_class: arm.medium


### PR DESCRIPTION
Upgrade CircleCI rust  pipeline to rust 1.85.1, in order to build bcrypt
