### PR TITLE
[#000] Migrate from Hive to SharedPreferences

### DIFF
--- a/qaul_ui/ios/Podfile.lock
+++ b/qaul_ui/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
+  - app_badge_plus (1.1.6):
+    - Flutter
   - app_links (0.0.2):
     - Flutter
   - audioplayers_darwin (0.0.1):
-    - Flutter
-  - better_open_file (0.0.1):
     - Flutter
   - device_info_plus (0.0.1):
     - Flutter
@@ -42,8 +42,6 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
-  - flutter_app_badger (1.3.0):
-    - Flutter
   - flutter_email_sender (0.0.1):
     - Flutter
   - flutter_local_notifications (0.0.1):
@@ -51,6 +49,8 @@ PODS:
   - image_picker_ios (0.0.1):
     - Flutter
   - integration_test (0.0.1):
+    - Flutter
+  - open_filex (0.0.2):
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
@@ -70,17 +70,17 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - app_badge_plus (from `.symlinks/plugins/app_badge_plus/ios`)
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/ios`)
-  - better_open_file (from `.symlinks/plugins/better_open_file/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
-  - flutter_app_badger (from `.symlinks/plugins/flutter_app_badger/ios`)
   - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
+  - open_filex (from `.symlinks/plugins/open_filex/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - record_darwin (from `.symlinks/plugins/record_darwin/ios`)
@@ -95,20 +95,18 @@ SPEC REPOS:
     - SwiftyGif
 
 EXTERNAL SOURCES:
+  app_badge_plus:
+    :path: ".symlinks/plugins/app_badge_plus/ios"
   app_links:
     :path: ".symlinks/plugins/app_links/ios"
   audioplayers_darwin:
     :path: ".symlinks/plugins/audioplayers_darwin/ios"
-  better_open_file:
-    :path: ".symlinks/plugins/better_open_file/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
-  flutter_app_badger:
-    :path: ".symlinks/plugins/flutter_app_badger/ios"
   flutter_email_sender:
     :path: ".symlinks/plugins/flutter_email_sender/ios"
   flutter_local_notifications:
@@ -117,6 +115,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
+  open_filex:
+    :path: ".symlinks/plugins/open_filex/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
@@ -129,27 +129,27 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  app_links: 3da4c36b46cac3bf24eb897f1a6ce80bda109874
-  audioplayers_darwin: ccf9c770ee768abb07e26d90af093f7bab1c12ab
-  better_open_file: 1b4512d5c323999178c1cfe6427352cd582f351b
-  device_info_plus: 335f3ce08d2e174b9fdc3db3db0f4e3b1f66bd89
+  app_badge_plus: 060babf17a97011f0093739f0aa8bc65b2479233
+  app_links: e7a6750a915a9e161c58d91bc610e8cd1d4d0ad0
+  audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_app_badger: 16b371e989d04cd265df85be2c3851b49cb68d18
-  flutter_email_sender: 2397f5e84aaacfb61af569637a963e7c687858d8
-  flutter_local_notifications: ad39620c743ea4c15127860f4b5641649a988100
-  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  package_info_plus: 566e1b7a2f3900e4b0020914ad3fc051dcc95596
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  record_darwin: fb1f375f1d9603714f55b8708a903bbb91ffdb0a
+  flutter_email_sender: 10a22605f92809a11ef52b2f412db806c6082d40
+  flutter_local_notifications: df98d66e515e1ca797af436137b4459b160ad8c9
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  open_filex: 6e26e659846ec990262224a12ef1c528bb4edbe4
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  record_darwin: 3b1a8e7d5c0cbf45ad6165b4d83a6ca643d929c3
   SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.16.1

--- a/qaul_ui/lib/helpers/user_prefs_helper.dart
+++ b/qaul_ui/lib/helpers/user_prefs_helper.dart
@@ -6,11 +6,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class UserPrefsHelper {
   UserPrefsHelper._internal();
-  
+
   static UserPrefsHelper? _instance;
 
+  static UserPrefsHelper get instance {
+    assert(_instance != null, 'Call UserPrefsHelper.initialize() first');
+    return _instance!;
+  }
+
   final _prefs = SharedPreferencesAsync();
-  
+
   final _localeNotifier = ValueNotifier<Locale?>(null);
   final _themeModeNotifier = ValueNotifier<ThemeMode>(ThemeMode.system);
   final _publicTabNotificationsNotifier = ValueNotifier<bool>(true);
@@ -19,32 +24,34 @@ class UserPrefsHelper {
 
   static Future<void> initialize() async {
     if (_instance != null) return;
-    
+
     _instance = UserPrefsHelper._internal();
     await _instance!._loadInitialValues();
   }
-  
+
   Future<void> _loadInitialValues() async {
     _localeNotifier.value = await _loadLocaleFromPrefs();
     _themeModeNotifier.value = await _loadThemeModeFromPrefs();
-    
-    _publicTabNotificationsNotifier.value = await _prefs.getBool(_publicNTFYKey) ?? true;
-    _chatNotificationsNotifier.value = await _prefs.getBool(_chatNTFYKey) ?? true;
-    _verifiedUsersOnlyNotifier.value = await _prefs.getBool(_verifyNTFKey) ?? false;
-    
+
+    _publicTabNotificationsNotifier.value =
+        await _prefs.getBool(_publicNTFYKey) ?? true;
+    _chatNotificationsNotifier.value =
+        await _prefs.getBool(_chatNTFYKey) ?? true;
+    _verifiedUsersOnlyNotifier.value =
+        await _prefs.getBool(_verifyNTFKey) ?? false;
+
     await _cleanLegacyAdaptiveThemeKey();
   }
-  
+
   Future<void> _cleanLegacyAdaptiveThemeKey() async {
     try {
       final legacyPrefs = await SharedPreferences.getInstance();
       if (legacyPrefs.containsKey('adaptive_theme_preferences')) {
         await legacyPrefs.remove('adaptive_theme_preferences');
       }
-    } catch (e) {
-    }
+    } catch (e) {}
   }
-  
+
   @visibleForTesting
   static Future<void> resetForTesting() async {
     if (_instance != null) {
@@ -52,23 +59,24 @@ class UserPrefsHelper {
     }
     _instance = null;
   }
-  
-  factory UserPrefsHelper() {
-    assert(_instance != null, 'Call UserPrefsHelper.initialize() first!');
-    return _instance!;
-  }
-  
+
   ValueListenable<Locale?> get localeNotifier => _localeNotifier;
+
   ValueListenable<ThemeMode> get themeModeNotifier => _themeModeNotifier;
-  ValueListenable<bool> get publicTabNotificationsNotifier => 
+
+  ValueListenable<bool> get publicTabNotificationsNotifier =>
       _publicTabNotificationsNotifier;
-  ValueListenable<bool> get chatNotificationsNotifier => 
+
+  ValueListenable<bool> get chatNotificationsNotifier =>
       _chatNotificationsNotifier;
-  ValueListenable<bool> get verifiedUsersOnlyNotifier => 
+
+  ValueListenable<bool> get verifiedUsersOnlyNotifier =>
       _verifiedUsersOnlyNotifier;
 
   String get _defaultLocaleKey => 'cached_default_locale';
+
   String get _themeModeKey => 'cached_theme_mode';
+
   String get _publicNTFYKey => 'cached_public_notification_enabled';
 
   String get _chatNTFYKey => 'cached_chat_notification_enabled';
@@ -86,11 +94,11 @@ class UserPrefsHelper {
 
   Future<ThemeMode> _loadThemeModeFromPrefs() async {
     final String? modeString = await _prefs.getString(_themeModeKey);
-    
+
     if (modeString == null) {
       return ThemeMode.system;
     }
-    
+
     switch (modeString.toLowerCase()) {
       case 'light':
         return ThemeMode.light;
@@ -106,12 +114,12 @@ class UserPrefsHelper {
 
   Future<void> setDefaultLocale(Locale? l) async {
     _localeNotifier.value = l;
-    
+
     if (l == null) {
       await _prefs.remove(_defaultLocaleKey);
       return;
     }
-    
+
     String code = '${l.languageCode}_${l.countryCode}';
     await _prefs.setString(_defaultLocaleKey, code);
   }
@@ -119,12 +127,16 @@ class UserPrefsHelper {
   ThemeMode get themeMode => _themeModeNotifier.value;
 
   Future<void> setThemeMode(ThemeMode mode) async {
-    final modeString = mode == ThemeMode.light ? 'light' : mode == ThemeMode.dark ? 'dark' : 'system';
+    final modeString = mode == ThemeMode.light
+        ? 'light'
+        : mode == ThemeMode.dark
+            ? 'dark'
+            : 'system';
     await _prefs.setString(_themeModeKey, modeString);
     _themeModeNotifier.value = mode;
   }
 
-  bool get publicTabNotificationsEnabled => 
+  bool get publicTabNotificationsEnabled =>
       _publicTabNotificationsNotifier.value;
 
   Future<void> setPublicTabNotificationsEnabled(bool val) async {

--- a/qaul_ui/lib/helpers/user_prefs_helper.dart
+++ b/qaul_ui/lib/helpers/user_prefs_helper.dart
@@ -14,11 +14,18 @@ class UserPrefsHelper {
 
   final SharedPreferencesAsync _prefs;
 
+  static const _defaultLocaleKey = 'cached_default_locale';
+  static const _themeModeKey = 'cached_theme_mode';
+  static const _publicNTFYKey = 'cached_public_notification_enabled';
+  static const _chatNTFYKey = 'cached_chat_notification_enabled';
+  static const _verifyNTFKey = 'cached_verified_users_only';
+
   final _localeNotifier = ValueNotifier<Locale?>(null);
   final _themeModeNotifier = ValueNotifier<ThemeMode>(ThemeMode.system);
-  final _publicTabNotificationsNotifier = ValueNotifier<bool>(true);
-  final _chatNotificationsNotifier = ValueNotifier<bool>(true);
-  final _verifiedUsersOnlyNotifier = ValueNotifier<bool>(false);
+
+  bool _publicTabNotificationsEnabled = true;
+  bool _chatNotificationsEnabled = true;
+  bool _notifyOnlyForVerifiedUsers = false;
 
   /// Initializes the singleton.
   ///
@@ -38,12 +45,10 @@ class UserPrefsHelper {
     _localeNotifier.value = await _loadLocaleFromPrefs();
     _themeModeNotifier.value = await _loadThemeModeFromPrefs();
 
-    _publicTabNotificationsNotifier.value =
+    _publicTabNotificationsEnabled =
         await _prefs.getBool(_publicNTFYKey) ?? true;
-    _chatNotificationsNotifier.value =
-        await _prefs.getBool(_chatNTFYKey) ?? true;
-    _verifiedUsersOnlyNotifier.value =
-        await _prefs.getBool(_verifyNTFKey) ?? false;
+    _chatNotificationsEnabled = await _prefs.getBool(_chatNTFYKey) ?? true;
+    _notifyOnlyForVerifiedUsers = await _prefs.getBool(_verifyNTFKey) ?? false;
 
     await _cleanLegacyAdaptiveThemeKey();
   }
@@ -60,25 +65,6 @@ class UserPrefsHelper {
   ValueListenable<Locale?> get localeNotifier => _localeNotifier;
 
   ValueListenable<ThemeMode> get themeModeNotifier => _themeModeNotifier;
-
-  ValueListenable<bool> get publicTabNotificationsNotifier =>
-      _publicTabNotificationsNotifier;
-
-  ValueListenable<bool> get chatNotificationsNotifier =>
-      _chatNotificationsNotifier;
-
-  ValueListenable<bool> get verifiedUsersOnlyNotifier =>
-      _verifiedUsersOnlyNotifier;
-
-  String get _defaultLocaleKey => 'cached_default_locale';
-
-  String get _themeModeKey => 'cached_theme_mode';
-
-  String get _publicNTFYKey => 'cached_public_notification_enabled';
-
-  String get _chatNTFYKey => 'cached_chat_notification_enabled';
-
-  String get _verifyNTFKey => 'cached_verified_users_only';
 
   Future<Locale?> _loadLocaleFromPrefs() async {
     String? completeCode = await _prefs.getString(_defaultLocaleKey);
@@ -133,25 +119,24 @@ class UserPrefsHelper {
     _themeModeNotifier.value = mode;
   }
 
-  bool get publicTabNotificationsEnabled =>
-      _publicTabNotificationsNotifier.value;
+  bool get publicTabNotificationsEnabled => _publicTabNotificationsEnabled;
 
   Future<void> setPublicTabNotificationsEnabled(bool val) async {
     await _prefs.setBool(_publicNTFYKey, val);
-    _publicTabNotificationsNotifier.value = val;
+    _publicTabNotificationsEnabled = val;
   }
 
-  bool get chatNotificationsEnabled => _chatNotificationsNotifier.value;
+  bool get chatNotificationsEnabled => _chatNotificationsEnabled;
 
   Future<void> setChatNotificationsEnabled(bool val) async {
     await _prefs.setBool(_chatNTFYKey, val);
-    _chatNotificationsNotifier.value = val;
+    _chatNotificationsEnabled = val;
   }
 
-  bool get notifyOnlyForVerifiedUsers => _verifiedUsersOnlyNotifier.value;
+  bool get notifyOnlyForVerifiedUsers => _notifyOnlyForVerifiedUsers;
 
-  Future<void> setNotifyOnlyForVerifiedUsers(bool v) async {
-    await _prefs.setBool(_verifyNTFKey, v);
-    _verifiedUsersOnlyNotifier.value = v;
+  Future<void> setNotifyOnlyForVerifiedUsers(bool val) async {
+    await _prefs.setBool(_verifyNTFKey, val);
+    _notifyOnlyForVerifiedUsers = val;
   }
 }

--- a/qaul_ui/lib/helpers/user_prefs_helper.dart
+++ b/qaul_ui/lib/helpers/user_prefs_helper.dart
@@ -8,8 +8,7 @@ class UserPrefsHelper {
   UserPrefsHelper._internal();
   
   static UserPrefsHelper? _instance;
-  static final Completer<void> _readyCompleter = Completer();
-  
+
   final _prefs = SharedPreferencesAsync();
   
   final _localeNotifier = ValueNotifier<Locale?>(null);
@@ -17,18 +16,12 @@ class UserPrefsHelper {
   final _publicTabNotificationsNotifier = ValueNotifier<bool>(true);
   final _chatNotificationsNotifier = ValueNotifier<bool>(true);
   final _verifiedUsersOnlyNotifier = ValueNotifier<bool>(false);
-  
-  static Future<void> get ready => _readyCompleter.future;
-  
+
   static Future<void> initialize() async {
     if (_instance != null) return;
     
     _instance = UserPrefsHelper._internal();
     await _instance!._loadInitialValues();
-    
-    if (!_readyCompleter.isCompleted) {
-      _readyCompleter.complete();
-    }
   }
   
   Future<void> _loadInitialValues() async {

--- a/qaul_ui/lib/helpers/user_prefs_helper.dart
+++ b/qaul_ui/lib/helpers/user_prefs_helper.dart
@@ -79,13 +79,15 @@ class UserPrefsHelper {
   Locale? get defaultLocale => _localeNotifier.value;
 
   set defaultLocale(Locale? l) {
+    _localeNotifier.value = l;
+    
     if (l == null) {
       _prefs.remove(_defaultLocaleKey);
-    } else {
-      String code = '${l.languageCode}_${l.countryCode}';
-      _prefs.setString(_defaultLocaleKey, code);
+      return;
     }
-    _localeNotifier.value = l;
+    
+    String code = '${l.languageCode}_${l.countryCode}';
+    _prefs.setString(_defaultLocaleKey, code);
   }
 
   bool get publicTabNotificationsEnabled => 

--- a/qaul_ui/lib/helpers/user_prefs_helper.dart
+++ b/qaul_ui/lib/helpers/user_prefs_helper.dart
@@ -1,11 +1,9 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class UserPrefsHelper {
-  UserPrefsHelper._internal();
+  UserPrefsHelper._internal(this._prefs);
 
   static UserPrefsHelper? _instance;
 
@@ -14,7 +12,7 @@ class UserPrefsHelper {
     return _instance!;
   }
 
-  final _prefs = SharedPreferencesAsync();
+  final SharedPreferencesAsync _prefs;
 
   final _localeNotifier = ValueNotifier<Locale?>(null);
   final _themeModeNotifier = ValueNotifier<ThemeMode>(ThemeMode.system);
@@ -22,12 +20,19 @@ class UserPrefsHelper {
   final _chatNotificationsNotifier = ValueNotifier<bool>(true);
   final _verifiedUsersOnlyNotifier = ValueNotifier<bool>(false);
 
-  static Future<void> initialize() async {
+  /// Initializes the singleton.
+  ///
+  /// If [prefs] is not provided, a default [SharedPreferencesAsync] is used.
+  /// Returns immediately if already initialized.
+  static Future<void> initialize({SharedPreferencesAsync? prefs}) async {
     if (_instance != null) return;
 
-    _instance = UserPrefsHelper._internal();
+    _instance = UserPrefsHelper._internal(prefs ?? SharedPreferencesAsync());
     await _instance!._loadInitialValues();
   }
+
+  /// Reload all internal state values from preferences.
+  Future<void> refresh() => _loadInitialValues();
 
   Future<void> _loadInitialValues() async {
     _localeNotifier.value = await _loadLocaleFromPrefs();
@@ -50,14 +55,6 @@ class UserPrefsHelper {
         await legacyPrefs.remove('adaptive_theme_preferences');
       }
     } catch (e) {}
-  }
-
-  @visibleForTesting
-  static Future<void> resetForTesting() async {
-    if (_instance != null) {
-      await _instance!._prefs.clear();
-    }
-    _instance = null;
   }
 
   ValueListenable<Locale?> get localeNotifier => _localeNotifier;

--- a/qaul_ui/lib/main.dart
+++ b/qaul_ui/lib/main.dart
@@ -55,7 +55,7 @@ void main() async {
 Future<void> _defaultAppEntrypoint() async {
   await Initializer.initialize(_container);
 
-  final savedThemeMode = UserPrefsHelper().themeMode;
+  final savedThemeMode = UserPrefsHelper.instance.themeMode;
   runApp(_CustomProviderScope(QaulApp(themeMode: savedThemeMode)));
 }
 

--- a/qaul_ui/lib/main.dart
+++ b/qaul_ui/lib/main.dart
@@ -4,7 +4,6 @@ import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:local_notifications/local_notifications.dart';
 import 'package:logging/logging.dart';
@@ -94,8 +93,7 @@ class Initializer {
     await _container.read(qaulWorkerProvider).initialized;
     await EmailLoggingCoordinator.instance.initialize(container: container);
 
-    await Hive.initFlutter();
-    await Hive.openBox(UserPrefsHelper.hiveBoxName);
+    await UserPrefsHelper.initialize();
 
     await LocalNotifications.instance.initialize();
   }

--- a/qaul_ui/lib/main.dart
+++ b/qaul_ui/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -29,27 +28,22 @@ void main() async {
       PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
       runApp(
-        AdaptiveTheme(
-            light: QaulApp.lightTheme,
-            dark: QaulApp.darkTheme,
-            initial: AdaptiveThemeMode.system,
-            builder: (theme, darkTheme) {
-              return MaterialApp(
-                theme: theme,
-                darkTheme: darkTheme,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: ForceUpdateDialog(
-                  current: packageInfo.version,
-                  previous: previousVersion?.toString() ?? '',
-                  onLinkPressed: ForceUpdateSystem.openQaulRepo,
-                  onDeleteAccountPressed: () async {
-                    await ForceUpdateSystem.deleteAccount();
-                    await _defaultAppEntrypoint();
-                  },
-                ),
-              );
-            }),
+        MaterialApp(
+          theme: QaulApp.lightTheme,
+          darkTheme: QaulApp.darkTheme,
+          themeMode: ThemeMode.system,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ForceUpdateDialog(
+            current: packageInfo.version,
+            previous: previousVersion?.toString() ?? '',
+            onLinkPressed: ForceUpdateSystem.openQaulRepo,
+            onDeleteAccountPressed: () async {
+              await ForceUpdateSystem.deleteAccount();
+              await _defaultAppEntrypoint();
+            },
+          ),
+        ),
       );
       return;
     }
@@ -61,7 +55,7 @@ void main() async {
 Future<void> _defaultAppEntrypoint() async {
   await Initializer.initialize(_container);
 
-  final savedThemeMode = await AdaptiveTheme.getThemeMode();
+  final savedThemeMode = UserPrefsHelper().themeMode;
   runApp(_CustomProviderScope(QaulApp(themeMode: savedThemeMode)));
 }
 

--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -45,7 +45,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
     var newMessages =
         List<ChatRoom>.from(values.where((room) => !_localCacheContains(room)))
           ..addAll(values.where(_localCacheContains).where(_hasNewMessage));
-    if (UserPrefsHelper().notifyOnlyForVerifiedUsers) {
+    if (UserPrefsHelper.instance.notifyOnlyForVerifiedUsers) {
       final verifiedIds = ref
           .read(usersProvider)
           .where((u) => u.isVerified ?? false)
@@ -73,7 +73,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
   LocalNotification? process(ChatRoom value) {
     _updateLocalCachedChatWith(value);
     if (currentVisibleHomeTab == TabType.chat) return null;
-    if (!UserPrefsHelper().chatNotificationsEnabled ||
+    if (!UserPrefsHelper.instance.chatNotificationsEnabled ||
         _lastMessageIsFromLocalUser(value)) {
       return null;
     }

--- a/qaul_ui/lib/providers/notification_controller/public_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/public_notification_controller_provider.dart
@@ -40,7 +40,7 @@ class PublicNotificationController
   @override
   Iterable<PublicPost> entriesToBeProcessed(List<PublicPost> values) {
     var newPosts = values.where((f) => (f.index ?? 1) > _lastIndex).toList();
-    if (UserPrefsHelper().notifyOnlyForVerifiedUsers) {
+    if (UserPrefsHelper.instance.notifyOnlyForVerifiedUsers) {
       final verifiedIds = ref
           .read(usersProvider)
           .where((u) => u.isVerified ?? false)
@@ -72,7 +72,7 @@ class PublicNotificationController
       _log.finer('currently in Public tab, filtering notifications');
       return null;
     }
-    if (!UserPrefsHelper().publicTabNotificationsEnabled) {
+    if (!UserPrefsHelper.instance.publicTabNotificationsEnabled) {
       _log.finer('public notifications disabled, filtering notifications');
       return null;
     }

--- a/qaul_ui/lib/qaul_app.dart
+++ b/qaul_ui/lib/qaul_app.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:responsive_framework/responsive_framework.dart';
@@ -125,8 +124,8 @@ class QaulApp extends PlatformAwareBuilder {
       initial: themeMode ?? AdaptiveThemeMode.system,
       builder: (theme, darkTheme) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(UserPrefsHelper.hiveBoxName).listenable(),
-          builder: (context, box, _) {
+          valueListenable: UserPrefsHelper().listenable,
+          builder: (context, _, __) {
             return MaterialApp(
               theme: theme,
               darkTheme: darkTheme,

--- a/qaul_ui/lib/qaul_app.dart
+++ b/qaul_ui/lib/qaul_app.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -13,7 +12,7 @@ import 'widgets/widgets.dart';
 
 class QaulApp extends PlatformAwareBuilder {
   const QaulApp({super.key, this.themeMode});
-  final AdaptiveThemeMode? themeMode;
+  final ThemeMode? themeMode;
 
   static final lightTheme = ThemeData(
     useMaterial3: true,
@@ -118,66 +117,65 @@ class QaulApp extends PlatformAwareBuilder {
 
   @override
   Widget defaultBuilder(BuildContext context, WidgetRef ref) {
-    return AdaptiveTheme(
-      dark: darkTheme,
-      light: lightTheme,
-      initial: themeMode ?? AdaptiveThemeMode.system,
-      builder: (theme, darkTheme) {
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: UserPrefsHelper().themeModeNotifier,
+      builder: (context, currentThemeMode, _) {
         return ValueListenableBuilder<Locale?>(
           valueListenable: UserPrefsHelper().localeNotifier,
           builder: (context, currentLocale, _) {
             return MaterialApp(
-              theme: theme,
+              theme: lightTheme,
               darkTheme: darkTheme,
-              debugShowCheckedModeBanner: false,
-              initialRoute: NavigationHelper.initial,
-              onGenerateRoute: NavigationHelper.onGenerateRoute,
-              locale: currentLocale,
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              localeResolutionCallback: (locale, supportedLocales) {
-                if (currentLocale != null) {
-                  Intl.defaultLocale = currentLocale.toLanguageTag();
-                  return currentLocale;
-                }
-                if (locale != null && supportedLocales.contains(locale)) {
-                  Intl.defaultLocale = locale.toLanguageTag();
-                  return locale;
-                }
+              themeMode: currentThemeMode,
+                  debugShowCheckedModeBanner: false,
+                  initialRoute: NavigationHelper.initial,
+                  onGenerateRoute: NavigationHelper.onGenerateRoute,
+                  locale: currentLocale,
+                  localizationsDelegates: AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  localeResolutionCallback: (locale, supportedLocales) {
+                    if (currentLocale != null) {
+                      Intl.defaultLocale = currentLocale.toLanguageTag();
+                      return currentLocale;
+                    }
+                    if (locale != null && supportedLocales.contains(locale)) {
+                      Intl.defaultLocale = locale.toLanguageTag();
+                      return locale;
+                    }
 
-                final List<Locale> systemLocales =
-                    View.of(context).platformDispatcher.locales;
-                for (final systemLocale in systemLocales) {
-                  final lang = Locale.fromSubtags(
-                      languageCode: systemLocale.languageCode);
-                  if (supportedLocales.contains(systemLocale)) {
-                    Intl.defaultLocale = systemLocale.toLanguageTag();
-                    return systemLocale;
-                  } else if (supportedLocales.contains(lang)) {
-                    Intl.defaultLocale = lang.toLanguageTag();
-                    return lang;
-                  }
-                }
+                    final List<Locale> systemLocales =
+                        View.of(context).platformDispatcher.locales;
+                    for (final systemLocale in systemLocales) {
+                      final lang = Locale.fromSubtags(
+                          languageCode: systemLocale.languageCode);
+                      if (supportedLocales.contains(systemLocale)) {
+                        Intl.defaultLocale = systemLocale.toLanguageTag();
+                        return systemLocale;
+                      } else if (supportedLocales.contains(lang)) {
+                        Intl.defaultLocale = lang.toLanguageTag();
+                        return lang;
+                      }
+                    }
 
-                return const Locale.fromSubtags(languageCode: 'en');
-              },
-              builder: (context, child) {
-                if (Platform.isLinux || Platform.isMacOS) {
-                  return child ?? const SizedBox();
-                }
+                    return const Locale.fromSubtags(languageCode: 'en');
+                  },
+                  builder: (context, child) {
+                    if (Platform.isLinux || Platform.isMacOS) {
+                      return child ?? const SizedBox();
+                    }
 
-                return ResponsiveBreakpoints.builder(
-                  child: child!,
-                  breakpoints: const [
-                    Breakpoint(start: 0, end: 350, name: "ANDROID"),
-                    Breakpoint(start: 351, end: 480, name: MOBILE),
-                    Breakpoint(start: 481, end: 680, name: "MOBILE_LANDSCAPE"),
-                    Breakpoint(start: 681, end: 800, name: TABLET),
-                    Breakpoint(start: 801, end: 1920, name: DESKTOP),
-                  ],
+                    return ResponsiveBreakpoints.builder(
+                      child: child!,
+                      breakpoints: const [
+                        Breakpoint(start: 0, end: 350, name: "ANDROID"),
+                        Breakpoint(start: 351, end: 480, name: MOBILE),
+                        Breakpoint(start: 481, end: 680, name: "MOBILE_LANDSCAPE"),
+                        Breakpoint(start: 681, end: 800, name: TABLET),
+                        Breakpoint(start: 801, end: 1920, name: DESKTOP),
+                      ],
+                    );
+                  },
                 );
-              },
-            );
           },
         );
       },

--- a/qaul_ui/lib/qaul_app.dart
+++ b/qaul_ui/lib/qaul_app.dart
@@ -118,10 +118,10 @@ class QaulApp extends PlatformAwareBuilder {
   @override
   Widget defaultBuilder(BuildContext context, WidgetRef ref) {
     return ValueListenableBuilder<ThemeMode>(
-      valueListenable: UserPrefsHelper().themeModeNotifier,
+      valueListenable: UserPrefsHelper.instance.themeModeNotifier,
       builder: (context, currentThemeMode, _) {
         return ValueListenableBuilder<Locale?>(
-          valueListenable: UserPrefsHelper().localeNotifier,
+          valueListenable: UserPrefsHelper.instance.localeNotifier,
           builder: (context, currentLocale, _) {
             return MaterialApp(
               theme: lightTheme,

--- a/qaul_ui/lib/qaul_app.dart
+++ b/qaul_ui/lib/qaul_app.dart
@@ -132,14 +132,13 @@ class QaulApp extends PlatformAwareBuilder {
               debugShowCheckedModeBanner: false,
               initialRoute: NavigationHelper.initial,
               onGenerateRoute: NavigationHelper.onGenerateRoute,
-              locale: UserPrefsHelper().defaultLocale,
+              locale: currentLocale,
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
               localeResolutionCallback: (locale, supportedLocales) {
-                final defaultLocale = UserPrefsHelper().defaultLocale;
-                if (defaultLocale != null) {
-                  Intl.defaultLocale = defaultLocale.toLanguageTag();
-                  return defaultLocale;
+                if (currentLocale != null) {
+                  Intl.defaultLocale = currentLocale.toLanguageTag();
+                  return currentLocale;
                 }
                 if (locale != null && supportedLocales.contains(locale)) {
                   Intl.defaultLocale = locale.toLanguageTag();

--- a/qaul_ui/lib/qaul_app.dart
+++ b/qaul_ui/lib/qaul_app.dart
@@ -123,9 +123,9 @@ class QaulApp extends PlatformAwareBuilder {
       light: lightTheme,
       initial: themeMode ?? AdaptiveThemeMode.system,
       builder: (theme, darkTheme) {
-        return ValueListenableBuilder(
-          valueListenable: UserPrefsHelper().listenable,
-          builder: (context, _, __) {
+        return ValueListenableBuilder<Locale?>(
+          valueListenable: UserPrefsHelper().localeNotifier,
+          builder: (context, currentLocale, _) {
             return MaterialApp(
               theme: theme,
               darkTheme: darkTheme,

--- a/qaul_ui/lib/screens/settings_screen.dart
+++ b/qaul_ui/lib/screens/settings_screen.dart
@@ -92,14 +92,14 @@ class _NotificationOptionsState extends State<_NotificationOptions> {
             label: l10n.publicNotificationsEnabled,
             value: UserPrefsHelper().publicTabNotificationsEnabled,
             onValueChanged: (val) =>
-                UserPrefsHelper().publicTabNotificationsEnabled = val,
+                UserPrefsHelper().setPublicTabNotificationsEnabled(val),
           ),
           const SizedBox(height: 20),
           _buildConfigurationOption(
             label: l10n.chatNotificationsEnabled,
             value: UserPrefsHelper().chatNotificationsEnabled,
             onValueChanged: (val) =>
-                UserPrefsHelper().chatNotificationsEnabled = val,
+                UserPrefsHelper().setChatNotificationsEnabled(val),
           ),
           if (_notificationsAreEnabled) ...[
             const SizedBox(height: 20),
@@ -107,7 +107,7 @@ class _NotificationOptionsState extends State<_NotificationOptions> {
               label: l10n.notifyOnlyForVerifiedUsers,
               value: UserPrefsHelper().notifyOnlyForVerifiedUsers,
               onValueChanged: (val) =>
-                  UserPrefsHelper().notifyOnlyForVerifiedUsers = val,
+                  UserPrefsHelper().setNotifyOnlyForVerifiedUsers(val),
             ),
           ],
         ],
@@ -118,7 +118,7 @@ class _NotificationOptionsState extends State<_NotificationOptions> {
   Widget _buildConfigurationOption(
       {required String label,
       required bool value,
-      required Function(bool newValue) onValueChanged}) {
+      required void Function(bool newValue) onValueChanged}) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/qaul_ui/lib/screens/settings_screen.dart
+++ b/qaul_ui/lib/screens/settings_screen.dart
@@ -73,8 +73,8 @@ class _NotificationOptions extends StatefulWidget {
 
 class _NotificationOptionsState extends State<_NotificationOptions> {
   bool get _notificationsAreEnabled =>
-      UserPrefsHelper().chatNotificationsEnabled ||
-      UserPrefsHelper().publicTabNotificationsEnabled;
+      UserPrefsHelper.instance.chatNotificationsEnabled ||
+      UserPrefsHelper.instance.publicTabNotificationsEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -90,24 +90,24 @@ class _NotificationOptionsState extends State<_NotificationOptions> {
         children: [
           _buildConfigurationOption(
             label: l10n.publicNotificationsEnabled,
-            value: UserPrefsHelper().publicTabNotificationsEnabled,
+            value: UserPrefsHelper.instance.publicTabNotificationsEnabled,
             onValueChanged: (val) =>
-                UserPrefsHelper().setPublicTabNotificationsEnabled(val),
+                UserPrefsHelper.instance.setPublicTabNotificationsEnabled(val),
           ),
           const SizedBox(height: 20),
           _buildConfigurationOption(
             label: l10n.chatNotificationsEnabled,
-            value: UserPrefsHelper().chatNotificationsEnabled,
+            value: UserPrefsHelper.instance.chatNotificationsEnabled,
             onValueChanged: (val) =>
-                UserPrefsHelper().setChatNotificationsEnabled(val),
+                UserPrefsHelper.instance.setChatNotificationsEnabled(val),
           ),
           if (_notificationsAreEnabled) ...[
             const SizedBox(height: 20),
             _buildConfigurationOption(
               label: l10n.notifyOnlyForVerifiedUsers,
-              value: UserPrefsHelper().notifyOnlyForVerifiedUsers,
+              value: UserPrefsHelper.instance.notifyOnlyForVerifiedUsers,
               onValueChanged: (val) =>
-                  UserPrefsHelper().setNotifyOnlyForVerifiedUsers(val),
+                  UserPrefsHelper.instance.setNotifyOnlyForVerifiedUsers(val),
             ),
           ],
         ],

--- a/qaul_ui/lib/widgets/language_select_dropdown.dart
+++ b/qaul_ui/lib/widgets/language_select_dropdown.dart
@@ -33,12 +33,12 @@ class _LanguageDropdown extends StatelessWidget {
     final items = <Locale?>[null, ...AppLocalizations.supportedLocales];
 
     return ValueListenableBuilder<Locale?>(
-      valueListenable: UserPrefsHelper().localeNotifier,
+      valueListenable: UserPrefsHelper.instance.localeNotifier,
       builder: (context, currentLocale, _) {
         return DropdownBuilder<Locale?>(
           value: currentLocale,
           itemsLength: items.length,
-          onChanged: (val) => UserPrefsHelper().setDefaultLocale(val),
+          onChanged: (val) => UserPrefsHelper.instance.setDefaultLocale(val),
           itemBuilder: (c, i) {
             final value = items[i];
             return DropdownMenuItem<Locale?>(

--- a/qaul_ui/lib/widgets/language_select_dropdown.dart
+++ b/qaul_ui/lib/widgets/language_select_dropdown.dart
@@ -38,7 +38,7 @@ class _LanguageDropdown extends StatelessWidget {
         return DropdownBuilder<Locale?>(
           value: currentLocale,
           itemsLength: items.length,
-          onChanged: (val) => UserPrefsHelper().defaultLocale = val,
+          onChanged: (val) => UserPrefsHelper().setDefaultLocale(val),
           itemBuilder: (c, i) {
             final value = items[i];
             return DropdownMenuItem<Locale?>(

--- a/qaul_ui/lib/widgets/language_select_dropdown.dart
+++ b/qaul_ui/lib/widgets/language_select_dropdown.dart
@@ -32,11 +32,11 @@ class _LanguageDropdown extends StatelessWidget {
   Widget build(BuildContext context) {
     final items = <Locale?>[null, ...AppLocalizations.supportedLocales];
 
-    return ValueListenableBuilder(
-      valueListenable: UserPrefsHelper().listenable,
-      builder: (context, _, __) {
+    return ValueListenableBuilder<Locale?>(
+      valueListenable: UserPrefsHelper().localeNotifier,
+      builder: (context, currentLocale, _) {
         return DropdownBuilder<Locale?>(
-          value: UserPrefsHelper().defaultLocale,
+          value: currentLocale,
           itemsLength: items.length,
           onChanged: (val) => UserPrefsHelper().defaultLocale = val,
           itemBuilder: (c, i) {

--- a/qaul_ui/lib/widgets/language_select_dropdown.dart
+++ b/qaul_ui/lib/widgets/language_select_dropdown.dart
@@ -33,8 +33,8 @@ class _LanguageDropdown extends StatelessWidget {
     final items = <Locale?>[null, ...AppLocalizations.supportedLocales];
 
     return ValueListenableBuilder(
-      valueListenable: Hive.box(UserPrefsHelper.hiveBoxName).listenable(),
-      builder: (context, box, _) {
+      valueListenable: UserPrefsHelper().listenable,
+      builder: (context, _, __) {
         return DropdownBuilder<Locale?>(
           value: UserPrefsHelper().defaultLocale,
           itemsLength: items.length,

--- a/qaul_ui/lib/widgets/theme_select_dropdown.dart
+++ b/qaul_ui/lib/widgets/theme_select_dropdown.dart
@@ -20,45 +20,35 @@ class _ThemeDropdown extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
-    return ValueListenableBuilder<AdaptiveThemeMode>(
-      valueListenable: AdaptiveTheme.of(context).modeChangeNotifier,
-      builder: (_, mode, child) {
-        return DropdownBuilder<AdaptiveThemeMode>(
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: UserPrefsHelper().themeModeNotifier,
+      builder: (context, mode, child) {
+        return DropdownBuilder<ThemeMode>(
           value: mode,
-          itemsLength: AdaptiveThemeMode.values.length,
+          itemsLength: ThemeMode.values.length,
           itemBuilder: (context, i) {
-            final val = AdaptiveThemeMode.values[i];
+            final val = ThemeMode.values[i];
             var label = '';
             switch (val) {
-              case AdaptiveThemeMode.light:
+              case ThemeMode.light:
                 label = l10n.lightTheme;
                 break;
-              case AdaptiveThemeMode.dark:
+              case ThemeMode.dark:
                 label = l10n.darkTheme;
                 break;
-              case AdaptiveThemeMode.system:
+              case ThemeMode.system:
                 label = l10n.useSystemDefaultMessage;
                 break;
             }
 
-            return DropdownMenuItem<AdaptiveThemeMode>(
+            return DropdownMenuItem<ThemeMode>(
               value: val,
               child: Text(label),
             );
           },
-          onChanged: (chosenMode) {
-            switch (chosenMode) {
-              case AdaptiveThemeMode.light:
-                AdaptiveTheme.of(context).setLight();
-                break;
-              case AdaptiveThemeMode.dark:
-                AdaptiveTheme.of(context).setDark();
-                break;
-              case AdaptiveThemeMode.system:
-              default:
-                AdaptiveTheme.of(context).setSystem();
-                break;
-            }
+          onChanged: (chosenMode) async {
+            if (chosenMode == null) return;
+            await UserPrefsHelper().setThemeMode(chosenMode);
           },
         );
       },

--- a/qaul_ui/lib/widgets/theme_select_dropdown.dart
+++ b/qaul_ui/lib/widgets/theme_select_dropdown.dart
@@ -21,7 +21,7 @@ class _ThemeDropdown extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
 
     return ValueListenableBuilder<ThemeMode>(
-      valueListenable: UserPrefsHelper().themeModeNotifier,
+      valueListenable: UserPrefsHelper.instance.themeModeNotifier,
       builder: (context, mode, child) {
         return DropdownBuilder<ThemeMode>(
           value: mode,
@@ -48,7 +48,7 @@ class _ThemeDropdown extends StatelessWidget {
           },
           onChanged: (chosenMode) async {
             if (chosenMode == null) return;
-            await UserPrefsHelper().setThemeMode(chosenMode);
+            await UserPrefsHelper.instance.setThemeMode(chosenMode);
           },
         );
       },

--- a/qaul_ui/lib/widgets/widgets.dart
+++ b/qaul_ui/lib/widgets/widgets.dart
@@ -11,7 +11,6 @@ import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:utils/utils.dart';

--- a/qaul_ui/lib/widgets/widgets.dart
+++ b/qaul_ui/lib/widgets/widgets.dart
@@ -4,7 +4,6 @@ library;
 import 'dart:io';
 import 'dart:math';
 
-import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:badges/badges.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' hide Badge;

--- a/qaul_ui/macos/Podfile.lock
+++ b/qaul_ui/macos/Podfile.lock
@@ -66,19 +66,19 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  app_links: 9028728e32c83a0831d9db8cf91c526d16cc5468
-  audioplayers_darwin: 761f2948df701d05b5db603220c384fb55720012
-  device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
-  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
-  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
-  flutter_local_notifications: 13862b132e32eb858dea558a86d45d08daeacfe7
+  app_links: 10e0a0ab602ffaf34d142cd4862f29d34b303b2a
+  audioplayers_darwin: dcad41de4fbd0099cb3749f7ab3b0cb8f70b810c
+  device_info_plus: 1b14eed9bf95428983aed283a8d51cce3d8c4215
+  file_picker: e716a70a9fe5fd9e09ebc922d7541464289443af
+  file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
+  flutter_local_notifications: 7062189aabf7f50938a7b8b6614ffa97656eb0bf
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  record_darwin: 30509266ae213af8afdb09a8ae7467cb64c1377e
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  record_darwin: a0d515a0ef78c440c123ea3ac76184c9927a94d6
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
 
 PODFILE CHECKSUM: 0d3963a09fc94f580682bd88480486da345dc3f0
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.16.1

--- a/qaul_ui/packages/qaul_rpc/pubspec.lock
+++ b/qaul_ui/packages/qaul_rpc/pubspec.lock
@@ -130,10 +130,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: d84e180f039a6b963e610d2e4435641fdfe8f12437e8770e963632e05af16d80
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -143,10 +143,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: c2264035396e5fc238e98ef053b07b9cab298450e39c6a8704634c8452c61bbe
+      sha256: "70bba33cfc5670c84b796e6929c54b8bc5be7d0fe15bb28c2560500b9ad06966"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.6.1"
   image:
     dependency: transitive
     description:
@@ -335,10 +335,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: e7f097159b9512f5953ff544164c19057f45ce28fd0cb971fc4cad1f7b28217d
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.6.1"
   rxdart:
     dependency: "direct main"
     description:

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -14,14 +14,6 @@ packages:
     description: dart
     source: sdk
     version: "0.3.3"
-  adaptive_theme:
-    dependency: "direct main"
-    description:
-      name: adaptive_theme
-      sha256: caa49b4c73b681bf12a641dff77aa1383262a00cf38b9d1a25b180e275ba5ab9
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.0"
   analyzer:
     dependency: transitive
     description:

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -158,14 +158,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  better_open_file:
-    dependency: "direct main"
-    description:
-      name: better_open_file
-      sha256: "975d700240a1529105b32fb5ff3fe127719e6d980ad8bbf07a43fdc326d71413"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.6.5"
   boolean_selector:
     dependency: transitive
     description:
@@ -708,30 +700,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  hive:
-    dependency: "direct main"
-    description:
-      name: hive
-      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.3"
-  hive_flutter:
-    dependency: "direct main"
-    description:
-      name: hive_flutter
-      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
-  hive_generator:
-    dependency: "direct dev"
-    description:
-      name: hive_generator
-      sha256: "06cb8f58ace74de61f63500564931f9505368f45f98958bd7a6c35ba24159db4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   hooks_riverpod:
     dependency: "direct main"
     description:
@@ -1024,6 +992,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  open_filex:
+    dependency: "direct main"
+    description:
+      name: open_filex
+      sha256: "9976da61b6a72302cf3b1efbce259200cd40232643a467aac7370addf94d6900"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   open_simplex_2:
     dependency: "direct main"
     description:
@@ -1420,22 +1396,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  source_gen:
-    dependency: transitive
-    description:
-      name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.0"
-  source_helper:
-    dependency: transitive
-    description:
-      name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.5"
   source_span:
     dependency: transitive
     description:

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -35,8 +35,6 @@ dependencies:
   flutter_hooks: ^0.20.5
   flutter_svg: ^2.0.9
   font_awesome_flutter: ^10.6.0
-  hive: ^2.2.3
-  hive_flutter: ^1.1.0
   hooks_riverpod: ^2.6.1
   image: ^4.1.3
   image_picker: ^1.1.2
@@ -75,7 +73,6 @@ dev_dependencies:
   fast_base58: ^0.2.1
   flutter_launcher_icons: ^0.14.3
   flutter_lints: ^5.0.0
-  hive_generator: ^2.0.1
   uuid: ^3.0.7
 
 flutter_icons:

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  adaptive_theme: ^3.4.1
   archive: ^4.0.2
   badges: ^3.1.2
   bubble: ^1.2.1

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -13,7 +13,7 @@ void main() {
     await UserPrefsHelper.initialize();
   });
 
-  group('Hive to SharedPreferences migration', () {
+  group('UserPrefsHelper', () {
     test('initializes with SharedPreferencesWithCache', () {
       expect(() => UserPrefsHelper(), returnsNormally);
     });

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_ui/helpers/user_prefs_helper.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.empty();
+    await UserPrefsHelper.initialize();
+  });
+
+  group('Hive to SharedPreferences migration', () {
+    test('initializes with SharedPreferencesWithCache', () {
+      expect(() => UserPrefsHelper(), returnsNormally);
+    });
+
+    test('returns same singleton instance', () {
+      final helper1 = UserPrefsHelper();
+      final helper2 = UserPrefsHelper();
+      expect(identical(helper1, helper2), true);
+    });
+
+    test('reads and writes preferences correctly with updates', () {
+      final helper = UserPrefsHelper();
+
+      helper.defaultTheme = ThemeMode.dark;
+      expect(helper.defaultTheme, ThemeMode.dark);
+
+      helper.defaultTheme = ThemeMode.light;
+      expect(helper.defaultTheme, ThemeMode.light);
+
+      helper.defaultLocale = const Locale('pt', 'BR');
+      expect(helper.defaultLocale, equals(const Locale('pt', 'BR')));
+
+      helper.defaultLocale = const Locale('en', 'US');
+      expect(helper.defaultLocale, equals(const Locale('en', 'US')));
+
+      helper.publicTabNotificationsEnabled = false;
+      expect(helper.publicTabNotificationsEnabled, false);
+
+      helper.publicTabNotificationsEnabled = true;
+      expect(helper.publicTabNotificationsEnabled, true);
+    });
+
+    test('notifies listeners when preferences change', () {
+      final helper = UserPrefsHelper();
+      int notificationCount = 0;
+
+      helper.listenable.addListener(() {
+        notificationCount++;
+      });
+
+      helper.defaultLocale = const Locale('en', 'US');
+      helper.defaultTheme = ThemeMode.light;
+      helper.chatNotificationsEnabled = false;
+
+      expect(notificationCount, 3);
+    });
+
+    test('uses correct default values', () {
+      final helper = UserPrefsHelper();
+
+      expect(helper.defaultLocale, isNull);
+      expect(helper.defaultTheme, ThemeMode.system);
+      expect(helper.publicTabNotificationsEnabled, true);
+      expect(helper.chatNotificationsEnabled, true);
+      expect(helper.notifyOnlyForVerifiedUsers, false);
+    });
+  });
+}

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -8,6 +8,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {
+    UserPrefsHelper.resetForTesting();
     SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.empty();
     await UserPrefsHelper.initialize();
   });
@@ -26,12 +27,6 @@ void main() {
     test('reads and writes preferences correctly with updates', () {
       final helper = UserPrefsHelper();
 
-      helper.defaultTheme = ThemeMode.dark;
-      expect(helper.defaultTheme, ThemeMode.dark);
-
-      helper.defaultTheme = ThemeMode.light;
-      expect(helper.defaultTheme, ThemeMode.light);
-
       helper.defaultLocale = const Locale('pt', 'BR');
       expect(helper.defaultLocale, equals(const Locale('pt', 'BR')));
 
@@ -47,24 +42,30 @@ void main() {
 
     test('notifies listeners when preferences change', () {
       final helper = UserPrefsHelper();
-      int notificationCount = 0;
+      int localeChanges = 0;
+      int chatNotifChanges = 0;
 
-      helper.listenable.addListener(() {
-        notificationCount++;
+      helper.localeNotifier.addListener(() {
+        localeChanges++;
+      });
+      
+      helper.chatNotificationsNotifier.addListener(() {
+        chatNotifChanges++;
       });
 
       helper.defaultLocale = const Locale('en', 'US');
-      helper.defaultTheme = ThemeMode.light;
-      helper.chatNotificationsEnabled = false;
+      expect(localeChanges, 1);
+      expect(chatNotifChanges, 0);
 
-      expect(notificationCount, 3);
+      helper.chatNotificationsEnabled = false;
+      expect(localeChanges, 1);
+      expect(chatNotifChanges, 1);
     });
 
     test('uses correct default values', () {
       final helper = UserPrefsHelper();
 
       expect(helper.defaultLocale, isNull);
-      expect(helper.defaultTheme, ThemeMode.system);
       expect(helper.publicTabNotificationsEnabled, true);
       expect(helper.chatNotificationsEnabled, true);
       expect(helper.notifyOnlyForVerifiedUsers, false);

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -52,23 +52,23 @@ void main() {
     test('notifies listeners when preferences change', () async {
       final helper = UserPrefsHelper.instance;
       int localeChanges = 0;
-      int chatNotifChanges = 0;
+      int themeChanges = 0;
 
       helper.localeNotifier.addListener(() {
         localeChanges++;
       });
-      
-      helper.chatNotificationsNotifier.addListener(() {
-        chatNotifChanges++;
+
+      helper.themeModeNotifier.addListener(() {
+        themeChanges++;
       });
 
       await helper.setDefaultLocale(const Locale('en', 'US'));
       expect(localeChanges, 1);
-      expect(chatNotifChanges, 0);
+      expect(themeChanges, 0);
 
-      await helper.setChatNotificationsEnabled(false);
+      await helper.setThemeMode(ThemeMode.dark);
       expect(localeChanges, 1);
-      expect(chatNotifChanges, 1);
+      expect(themeChanges, 1);
     });
 
     test('uses correct default values', () {

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -8,7 +8,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() async {
-    UserPrefsHelper.resetForTesting();
+    await UserPrefsHelper.resetForTesting();
     SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.empty();
     await UserPrefsHelper.initialize();
   });
@@ -24,23 +24,23 @@ void main() {
       expect(identical(helper1, helper2), true);
     });
 
-    test('reads and writes preferences correctly with updates', () {
+    test('reads and writes preferences correctly with updates', () async {
       final helper = UserPrefsHelper();
 
-      helper.defaultLocale = const Locale('pt', 'BR');
+      await helper.setDefaultLocale(const Locale('pt', 'BR'));
       expect(helper.defaultLocale, equals(const Locale('pt', 'BR')));
 
-      helper.defaultLocale = const Locale('en', 'US');
+      await helper.setDefaultLocale(const Locale('en', 'US'));
       expect(helper.defaultLocale, equals(const Locale('en', 'US')));
 
-      helper.publicTabNotificationsEnabled = false;
+      await helper.setPublicTabNotificationsEnabled(false);
       expect(helper.publicTabNotificationsEnabled, false);
 
-      helper.publicTabNotificationsEnabled = true;
+      await helper.setPublicTabNotificationsEnabled(true);
       expect(helper.publicTabNotificationsEnabled, true);
     });
 
-    test('notifies listeners when preferences change', () {
+    test('notifies listeners when preferences change', () async {
       final helper = UserPrefsHelper();
       int localeChanges = 0;
       int chatNotifChanges = 0;
@@ -53,11 +53,11 @@ void main() {
         chatNotifChanges++;
       });
 
-      helper.defaultLocale = const Locale('en', 'US');
+      await helper.setDefaultLocale(const Locale('en', 'US'));
       expect(localeChanges, 1);
       expect(chatNotifChanges, 0);
 
-      helper.chatNotificationsEnabled = false;
+      await helper.setChatNotificationsEnabled(false);
       expect(localeChanges, 1);
       expect(chatNotifChanges, 1);
     });
@@ -66,9 +66,23 @@ void main() {
       final helper = UserPrefsHelper();
 
       expect(helper.defaultLocale, isNull);
+      expect(helper.themeMode, ThemeMode.system);
       expect(helper.publicTabNotificationsEnabled, true);
       expect(helper.chatNotificationsEnabled, true);
       expect(helper.notifyOnlyForVerifiedUsers, false);
+    });
+
+    test('reads and writes theme mode correctly', () async {
+      final helper = UserPrefsHelper();
+
+      await helper.setThemeMode(ThemeMode.dark);
+      expect(helper.themeMode, equals(ThemeMode.dark));
+
+      await helper.setThemeMode(ThemeMode.light);
+      expect(helper.themeMode, equals(ThemeMode.light));
+
+      await helper.setThemeMode(ThemeMode.system);
+      expect(helper.themeMode, equals(ThemeMode.system));
     });
   });
 }

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -15,17 +15,17 @@ void main() {
 
   group('UserPrefsHelper', () {
     test('initializes with SharedPreferencesWithCache', () {
-      expect(() => UserPrefsHelper(), returnsNormally);
+      expect(() => UserPrefsHelper.instance, returnsNormally);
     });
 
     test('returns same singleton instance', () {
-      final helper1 = UserPrefsHelper();
-      final helper2 = UserPrefsHelper();
+      final helper1 = UserPrefsHelper.instance;
+      final helper2 = UserPrefsHelper.instance;
       expect(identical(helper1, helper2), true);
     });
 
     test('reads and writes preferences correctly with updates', () async {
-      final helper = UserPrefsHelper();
+      final helper = UserPrefsHelper.instance;
 
       await helper.setDefaultLocale(const Locale('pt', 'BR'));
       expect(helper.defaultLocale, equals(const Locale('pt', 'BR')));
@@ -41,7 +41,7 @@ void main() {
     });
 
     test('notifies listeners when preferences change', () async {
-      final helper = UserPrefsHelper();
+      final helper = UserPrefsHelper.instance;
       int localeChanges = 0;
       int chatNotifChanges = 0;
 
@@ -63,7 +63,7 @@ void main() {
     });
 
     test('uses correct default values', () {
-      final helper = UserPrefsHelper();
+      final helper = UserPrefsHelper.instance;
 
       expect(helper.defaultLocale, isNull);
       expect(helper.themeMode, ThemeMode.system);
@@ -73,7 +73,7 @@ void main() {
     });
 
     test('reads and writes theme mode correctly', () async {
-      final helper = UserPrefsHelper();
+      final helper = UserPrefsHelper.instance;
 
       await helper.setThemeMode(ThemeMode.dark);
       expect(helper.themeMode, equals(ThemeMode.dark));

--- a/qaul_ui/test/user_prefs_helper_test.dart
+++ b/qaul_ui/test/user_prefs_helper_test.dart
@@ -1,16 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qaul_ui/helpers/user_prefs_helper.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late SharedPreferencesAsync testPrefs;
+
+  setUpAll(() async {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    testPrefs = SharedPreferencesAsync();
+    await UserPrefsHelper.initialize(prefs: testPrefs);
+  });
+
   setUp(() async {
-    await UserPrefsHelper.resetForTesting();
-    SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.empty();
-    await UserPrefsHelper.initialize();
+    await testPrefs.clear();
+    await UserPrefsHelper.instance.refresh();
   });
 
   group('UserPrefsHelper', () {


### PR DESCRIPTION
## Description

This PR removes the unmaintained `Hive` package and migrates user preference storage to the modern `SharedPreferencesWithCache`

## Changes

- Removed packages: `hive`, `hive_flutter`, `hive_generator`
- Migrated `UserPrefsHelper` to use `SharedPreferencesWithCache` (`SharedPreferences` is also being [deprecated](https://pub.dev/packages/shared_preferences))
- All setters now trigger notifications to maintain UI reactivity
- Unit test to cover `UserPrefsHelper`

## Additional Notes
Users will lose their saved preferences related to (language, theme, notifications) on first launch after this update. 

All preferences will reset to system defaults.

Also, @brenodt let me know if there is any file that I shouldn't be including in this PR.

## Evidence

https://github.com/user-attachments/assets/85308e18-0ed8-4de4-8ec0-6f9827b5c778



