### PR TITLE
 [Version] Remove unsupported project dependencies and recreate them internally

### DIFF
--- a/docs/licenses/THIRD_PARTY_LICENSES.md
+++ b/docs/licenses/THIRD_PARTY_LICENSES.md
@@ -30,3 +30,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## version
+
+- **Source:** https://github.com/dartninja/version
+- **Used in:** `qaul_ui/packages/utils/lib/src/version.dart`
+
+Copyright (c) 2021, Matthew Barbour.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of the <organization> nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/qaul_ui/lib/force_update.dart
+++ b/qaul_ui/lib/force_update.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:version/version.dart';
+import 'package:utils/utils.dart';
 
 import 'l10n/app_localizations.dart';
 

--- a/qaul_ui/packages/utils/lib/src/version.dart
+++ b/qaul_ui/packages/utils/lib/src/version.dart
@@ -49,7 +49,7 @@ class Version implements Comparable<Version> {
             "preRelease segments must only contain [0-9A-Za-z-]");
       }
     }
-    if (this.build.isNotEmpty && !_buildRegex.hasMatch(this.build)) {
+    if (build.isNotEmpty && !_buildRegex.hasMatch(build)) {
       throw FormatException("build must only contain [0-9A-Za-z-.]");
     }
 

--- a/qaul_ui/packages/utils/lib/src/version.dart
+++ b/qaul_ui/packages/utils/lib/src/version.dart
@@ -1,5 +1,6 @@
-// Copyright (c) 2021, Matthew Barbour. All rights reserved. Use of this source code
-// is governed by a BSD-style license that can be found in the LICENSE file.
+// From https://github.com/dartninja/version
+// Copyright (c) 2021, Matthew Barbour.
+// Licensed under BSD-3-Clause. See docs/licenses/THIRD_PARTY_LICENSES.md
 
 /// Provides immutable storage and comparison of semantic version numbers.
 class Version {

--- a/qaul_ui/packages/utils/lib/src/version.dart
+++ b/qaul_ui/packages/utils/lib/src/version.dart
@@ -1,0 +1,261 @@
+// Copyright (c) 2021, Matthew Barbour. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+/// Provides version objects to enforce conformance to the Semantic Versioning 2.0 spec. The spec can be read at http://semver.org/
+library;
+
+/// Provides immutable storage and comparison of semantic version numbers.
+class Version implements Comparable<Version> {
+  static final RegExp _versionRegex =
+      RegExp(r"^([\d.]+)(-([0-9A-Za-z\-.]+))?(\+([0-9A-Za-z\-.]+))?$");
+  static final RegExp _buildRegex = RegExp(r"^[0-9A-Za-z\-.]+$");
+  static final RegExp _preReleaseRegex = RegExp(r"^[0-9A-Za-z\-]+$");
+
+  /// The major number of the version, incremented when making breaking changes.
+  final int major;
+
+  /// The minor number of the version, incremented when adding new functionality in a backwards-compatible manner.
+  final int minor;
+
+  /// The patch number of the version, incremented when making backwards-compatible bug fixes.
+  final int patch;
+
+  /// Build information relevant to the version. Does not contribute to sorting.
+  final String build;
+
+  final List<String> _preRelease;
+
+  /// Indicates that the version is a pre-release. Returns true if preRelease has any segments, otherwise false
+  bool get isPreRelease => _preRelease.isNotEmpty;
+
+  /// Creates a new instance of [Version].
+  ///
+  /// [major], [minor], and [patch] are all required, all must be greater than 0 and not null, and at least one must be greater than 0.
+  /// [preRelease] is optional, but if specified must be a [List] of [String] and must not be null. Each element in the list represents one of the period-separated segments of the pre-release information, and may only contain [0-9A-Za-z-].
+  /// [build] is optional, but if specified must be a [String]. must contain only [0-9A-Za-z-.], and must not be null.
+  /// Throws a [FormatException] if the [String] content does not follow the character constraints defined above.
+  /// Throes an [ArgumentError] if any of the other conditions are violated.
+  Version(this.major, this.minor, this.patch,
+      {List<String> preRelease = const <String>[], this.build = ""})
+      : _preRelease = preRelease {
+    for (int i = 0; i < _preRelease.length; i++) {
+      if (_preRelease[i].toString().trim().isEmpty) {
+        throw ArgumentError("preRelease segments must not be empty");
+      }
+      // Just in case
+      _preRelease[i] = _preRelease[i].toString();
+      if (!_preReleaseRegex.hasMatch(_preRelease[i])) {
+        throw FormatException(
+            "preRelease segments must only contain [0-9A-Za-z-]");
+      }
+    }
+    if (this.build.isNotEmpty && !_buildRegex.hasMatch(this.build)) {
+      throw FormatException("build must only contain [0-9A-Za-z-.]");
+    }
+
+    if (major < 0 || minor < 0 || patch < 0) {
+      throw ArgumentError("Version numbers must be greater than 0");
+    }
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  /// Pre-release information segments.
+  List<String> get preRelease => List<String>.from(_preRelease);
+
+  /// Determines whether the left-hand [Version] represents a lower precedence than the right-hand [Version].
+  bool operator <(dynamic o) => o is Version && _compare(this, o) < 0;
+
+  /// Determines whether the left-hand [Version] represents an equal or lower precedence than the right-hand [Version].
+  bool operator <=(dynamic o) => o is Version && _compare(this, o) <= 0;
+
+  /// Determines whether the left-hand [Version] represents an equal precedence to the right-hand [Version].
+  @override
+  bool operator ==(dynamic o) => o is Version && _compare(this, o) == 0;
+
+  /// Determines whether the left-hand [Version] represents a greater precedence than the right-hand [Version].
+  bool operator >(dynamic o) => o is Version && _compare(this, o) > 0;
+
+  /// Determines whether the left-hand [Version] represents an equal or greater precedence than the right-hand [Version].
+  bool operator >=(dynamic o) => o is Version && _compare(this, o) >= 0;
+
+  @override
+  int compareTo(Version? other) {
+    if (other == null) {
+      throw ArgumentError.notNull("other");
+    }
+
+    return _compare(this, other);
+  }
+
+  /// Creates a new [Version] with the [major] version number incremented.
+  ///
+  /// Also resets the [minor] and [patch] numbers to 0, and clears the [build] and [preRelease] information.
+  Version incrementMajor() => Version(major + 1, 0, 0);
+
+  /// Creates a new [Version] with the [minor] version number incremented.
+  ///
+  /// Also resets the [patch] number to 0, and clears the [build] and [preRelease] information.
+  Version incrementMinor() => Version(major, minor + 1, 0);
+
+  /// Creates a new [Version] with the [patch] version number incremented.
+  ///
+  /// Also clears the [build] and [preRelease] information.
+  Version incrementPatch() => Version(major, minor, patch + 1);
+
+  /// Creates a new [Version] with the right-most numeric [preRelease] segment incremented.
+  /// If no numeric segment is found, one will be added with the value "1".
+  ///
+  /// If this [Version] is not a pre-release version, an Exception will be thrown.
+  Version incrementPreRelease() {
+    if (!isPreRelease) {
+      throw Exception(
+          "Cannot increment pre-release on a non-pre-release [Version]");
+    }
+    var newPreRelease = preRelease;
+
+    var found = false;
+    for (var i = newPreRelease.length - 1; i >= 0; i--) {
+      var segment = newPreRelease[i];
+      if (Version._isNumeric(segment)) {
+        var intVal = int.parse(segment);
+        intVal++;
+        newPreRelease[i] = intVal.toString();
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      newPreRelease.add("1");
+    }
+
+    return Version(major, minor, patch,
+        preRelease: newPreRelease);
+  }
+
+  /// Returns a [String] representation of the [Version].
+  ///
+  /// Uses the format "$major.$minor.$patch".
+  /// If [preRelease] has segments available they are appended as "-segmentOne.segmentTwo", with each segment separated by a period.
+  /// If [build] is specified, it is appended as "+build.info" where "build.info" is whatever value [build] is set to.
+  /// If all [preRelease] and [build] are specified, then both are appended, [preRelease] first and [build] second.
+  /// An example of such output would be "1.0.0-preRelease.segment+build.info".
+  @override
+  String toString() {
+    final StringBuffer output = StringBuffer("$major.$minor.$patch");
+    if (_preRelease.isNotEmpty) {
+      output.write("-${_preRelease.join('.')}");
+    }
+    if (build.trim().isNotEmpty) {
+      output.write("+${build.trim()}");
+    }
+    return output.toString();
+  }
+
+  /// Creates a [Version] instance from a string.
+  ///
+  /// The string must conform to the specification at http://semver.org/
+  /// Throws [FormatException] if the string is empty or does not conform to the spec.
+  static Version parse(String versionString) {
+    if (versionString.trim().isEmpty) {
+      throw FormatException("Cannot parse empty string into version");
+    }
+    if (!_versionRegex.hasMatch(versionString)) {
+      throw FormatException("Not a properly formatted version string");
+    }
+    final Match m = _versionRegex.firstMatch(versionString)!;
+    final String version = m.group(1)!;
+
+    int? major, minor, patch;
+    final List<String> parts = version.split(".");
+    major = int.parse(parts[0]);
+    if (parts.length > 1) {
+      minor = int.parse(parts[1]);
+      if (parts.length > 2) {
+        patch = int.parse(parts[2]);
+      }
+    }
+
+    final String preReleaseString = m.group(3) ?? "";
+    List<String> preReleaseList = <String>[];
+    if (preReleaseString.trim().isNotEmpty) {
+      preReleaseList = preReleaseString.split(".");
+    }
+    final String build = m.group(5) ?? "";
+
+    return Version(major, minor ?? 0, patch ?? 0,
+        build: build, preRelease: preReleaseList);
+  }
+
+  static int _compare(Version? a, Version? b) {
+    if (a == null) {
+      throw ArgumentError.notNull("a");
+    }
+
+    if (b == null) {
+      throw ArgumentError.notNull("b");
+    }
+
+    if (a.major > b.major) return 1;
+    if (a.major < b.major) return -1;
+
+    if (a.minor > b.minor) return 1;
+    if (a.minor < b.minor) return -1;
+
+    if (a.patch > b.patch) return 1;
+    if (a.patch < b.patch) return -1;
+
+    if (a.preRelease.isEmpty) {
+      if (b.preRelease.isEmpty) {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else if (b.preRelease.isEmpty) {
+      return -1;
+    } else {
+      int preReleaseMax = a.preRelease.length;
+      if (b.preRelease.length > a.preRelease.length) {
+        preReleaseMax = b.preRelease.length;
+      }
+
+      for (int i = 0; i < preReleaseMax; i++) {
+        if (b.preRelease.length <= i) {
+          return 1;
+        } else if (a.preRelease.length <= i) {
+          return -1;
+        }
+
+        if (a.preRelease[i] == b.preRelease[i]) continue;
+
+        final bool aNumeric = _isNumeric(a.preRelease[i]);
+        final bool bNumeric = _isNumeric(b.preRelease[i]);
+
+        if (aNumeric && bNumeric) {
+          final double aNumber = double.parse(a.preRelease[i]);
+          final double bNumber = double.parse(b.preRelease[i]);
+          if (aNumber > bNumber) {
+            return 1;
+          } else {
+            return -1;
+          }
+        } else if (bNumeric) {
+          return 1;
+        } else if (aNumeric) {
+          return -1;
+        } else {
+          return a.preRelease[i].compareTo(b.preRelease[i]);
+        }
+      }
+    }
+    return 0;
+  }
+
+  static bool _isNumeric(String? s) {
+    if (s == null) {
+      return false;
+    }
+    return double.tryParse(s) != null;
+  }
+}

--- a/qaul_ui/packages/utils/lib/src/version.dart
+++ b/qaul_ui/packages/utils/lib/src/version.dart
@@ -72,8 +72,10 @@ class Version implements Comparable<Version> {
 
   /// Determines whether the left-hand [Version] represents an equal precedence to the right-hand [Version].
   @override
-  bool operator ==(dynamic o) => o is Version && _compare(this, o) == 0;
-
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Version && _compare(this, other) == 0;
+  }
   /// Determines whether the left-hand [Version] represents a greater precedence than the right-hand [Version].
   bool operator >(dynamic o) => o is Version && _compare(this, o) > 0;
 

--- a/qaul_ui/packages/utils/lib/utils.dart
+++ b/qaul_ui/packages/utils/lib/utils.dart
@@ -15,6 +15,7 @@ export 'src/file_size_descriptor.dart';
 export 'src/image_manipulation.dart';
 export 'src/intersperse.dart';
 export 'src/ip_utils.dart';
+export 'src/version.dart';
 
 Color colorGenerationStrategy(String first) {
   // defined using --dart-define=testing_mode=true when running tests

--- a/qaul_ui/packages/utils/test/version_test.dart
+++ b/qaul_ui/packages/utils/test/version_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:utils/utils.dart';
+
+void main() {
+  group('Version', () {
+    group('constructor', () {
+      test('creates version with correct properties', () {
+        final version = Version(1, 2, 3);
+        expect(version.major, 1);
+        expect(version.minor, 2);
+        expect(version.patch, 3);
+        expect(version.build, '');
+      });
+
+      test('creates version with preRelease and build', () {
+        final version = Version(2, 0, 0, preRelease: ['beta'], build: '18');
+        expect(version.major, 2);
+        expect(version.minor, 0);
+        expect(version.patch, 0);
+        expect(version.build, '18');
+      });
+
+      test('validates and rejects invalid inputs', () {
+        expect(() => Version(-1, 0, 0), throwsArgumentError);
+        expect(() => Version(0, -1, 0), throwsArgumentError);
+        expect(() => Version(0, 0, -1), throwsArgumentError);
+        expect(() => Version(1, 0, 0, preRelease: ['beta.1']), throwsFormatException);
+        expect(() => Version(1, 0, 0, preRelease: ['']), throwsArgumentError);
+        expect(() => Version(1, 0, 0, build: 'build@123'), throwsFormatException);
+      });
+    });
+
+    group('toString', () {
+      test('formats basic version correctly', () {
+        expect(Version(1, 2, 3).toString(), '1.2.3');
+      });
+
+      test('formats version with preRelease and build', () {
+        final testCases = [
+          (Version(1, 0, 0, preRelease: ['beta']), '1.0.0-beta'),
+          (Version(1, 0, 0, build: '18'), '1.0.0+18'),
+          (Version(2, 0, 0, preRelease: ['beta'], build: '18'), '2.0.0-beta+18'),
+          (Version(1, 0, 0, preRelease: ['beta', '1']), '1.0.0-beta.1'),
+        ];
+
+        for (final (version, expected) in testCases) {
+          expect(version.toString(), expected);
+        }
+      });
+    });
+
+    group('parse and round-trip', () {
+      test('parses valid version strings correctly', () {
+        final testCases = [
+          ('1.2.3', Version(1, 2, 3)),
+          ('1.0.0-beta', Version(1, 0, 0, preRelease: ['beta'])),
+          ('1.0.0+18', Version(1, 0, 0, build: '18')),
+          ('2.0.0-beta+18', Version(2, 0, 0, preRelease: ['beta'], build: '18')),
+          ('1.0.0-beta.1', Version(1, 0, 0, preRelease: ['beta', '1'])),
+        ];
+
+        for (final (input, expected) in testCases) {
+          final parsed = Version.parse(input);
+          expect(parsed.major, expected.major);
+          expect(parsed.minor, expected.minor);
+          expect(parsed.patch, expected.patch);
+          expect(parsed.build, expected.build);
+        }
+      });
+
+      test('parse and toString are consistent', () {
+        final testCases = [
+          '1.2.3',
+          '1.0.0-beta',
+          '1.0.0+18',
+          '2.0.0-beta+18',
+          '1.0.0-beta.1',
+        ];
+
+        for (final input in testCases) {
+          final version = Version.parse(input);
+          expect(version.toString(), input);
+        }
+      });
+
+      test('rejects invalid version strings', () {
+        expect(() => Version.parse(''), throwsFormatException);
+        expect(() => Version.parse('   '), throwsFormatException);
+        expect(() => Version.parse('invalid'), throwsFormatException);
+        expect(() => Version.parse('not.a.version'), throwsFormatException);
+        expect(() => Version.parse('abc.def.ghi'), throwsFormatException);
+      });
+    });
+
+    group('equality', () {
+      test('equal versions are equal regardless of build', () {
+        final v1 = Version(1, 2, 3);
+        final v2 = Version(1, 2, 3);
+        final v3 = Version(1, 2, 3, build: '18');
+        final v4 = Version(1, 2, 3, build: '19');
+
+        expect(v1 == v2, true);
+        expect(v1.hashCode, v2.hashCode);
+        expect(v1 == v3, true);
+        expect(v3 == v4, true);
+      });
+
+      test('different version numbers are not equal', () {
+        final base = Version(1, 0, 0);
+        expect(base == Version(2, 0, 0), false);
+        expect(base == Version(1, 1, 0), false);
+        expect(base == Version(1, 0, 1), false);
+      });
+
+      test('preRelease affects equality', () {
+        final withPreRelease = Version(1, 0, 0, preRelease: ['beta']);
+        final withoutPreRelease = Version(1, 0, 0);
+        final samePreRelease = Version(1, 0, 0, preRelease: ['beta']);
+
+        expect(withPreRelease == withoutPreRelease, false);
+        expect(withPreRelease == samePreRelease, true);
+      });
+    });
+
+    group('force update use case', () {
+      test('compares versions correctly for force update logic', () {
+        final target = Version(2, 0, 0, preRelease: ['beta'], build: '18');
+        final currentOld = Version(2, 0, 0, preRelease: ['beta'], build: '15');
+        final currentSame = Version(2, 0, 0, preRelease: ['beta'], build: '18');
+        final currentNewer = Version(2, 0, 0, preRelease: ['beta'], build: '19');
+
+        expect(currentOld == target, true);
+        expect(int.parse(currentOld.build) < int.parse(target.build), true);
+
+        expect(currentSame == target, true);
+        expect(int.parse(currentSame.build) < int.parse(target.build), false);
+
+        expect(currentNewer == target, true);
+        expect(int.parse(currentNewer.build) < int.parse(target.build), false);
+      });
+
+      test('parses version from file format used in force update', () {
+        final versionString = '2.0.0-beta+18';
+        final version = Version.parse(versionString);
+        expect(version.toString(), versionString);
+        expect(version.major, 2);
+        expect(version.minor, 0);
+        expect(version.patch, 0);
+        expect(version.build, '18');
+      });
+    });
+  });
+}

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -1678,14 +1678,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  version:
-    dependency: "direct main"
-    description:
-      name: version
-      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
   visibility_detector:
     dependency: transitive
     description:

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -54,7 +54,6 @@ dependencies:
   shared_preferences: ^2.5.4
   url_launcher: ^6.1.14
   utils: { "path": "packages/utils" }
-  version: ^3.0.2
   flutter_markdown_plus: ^1.0.0
   record: ^6.0.0
   audioplayers: ^6.1.1

--- a/qaul_ui/test/force_update_test.dart
+++ b/qaul_ui/test/force_update_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qaul_ui/force_update.dart';
-import 'package:version/version.dart';
+import 'package:utils/utils.dart';
 
 void main() {
   test('current: 2.0.0-beta+15 ; target: 2.0.0-beta+18 ; true', () async {


### PR DESCRIPTION
## Description
This PR removes the external `version` package dependency and internalizes its implementation directly into the repository.

The `version` package code was fully replicated into the codebase, preserving its original behavior. This allows us to eliminate the external dependency while maintaining full compatibility with existing usage.

This change avoids reliance on an unmaintained package, and simplifies dependency management.

## Changes

### Dependency Removal: `version`
- Removed `version` from `pubspec.yaml`
- Eliminated all references to the external package

### Internalization of `version` Package
- Replicated the full source code of the original `version` package into the repository
- Preserved original logic and structure
- Updated imports to reference the internal implementation
