### PR TITLE
[Filesize] Remove unsupported project dependencies and recreate them internally

### DIFF
--- a/qaul_ui/lib/coordinators/email_logging_coordinator/email_logging_coordinator.dart
+++ b/qaul_ui/lib/coordinators/email_logging_coordinator/email_logging_coordinator.dart
@@ -6,7 +6,6 @@ import 'dart:isolate';
 
 import 'package:archive/archive.dart';
 import 'package:device_info_plus/device_info_plus.dart';
-import 'package:filesize/filesize.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_email_sender/flutter_email_sender.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -143,7 +142,7 @@ class EmailLoggingCoordinator {
 
   Future<String> get logStorageSize async {
     final size = await _storageManager.logFolderSize;
-    return filesize(size);
+    return fileSize(size);
   }
 
   Future<void> _logError(Object e, {StackTrace? stack, String? message}) async {

--- a/qaul_ui/lib/screens/file_history_screen.dart
+++ b/qaul_ui/lib/screens/file_history_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -9,6 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:utils/utils.dart';
 
 import '../l10n/app_localizations.dart';
 import '../widgets/widgets.dart';
@@ -158,7 +158,7 @@ class _FileHistoryTile extends ConsumerWidget {
         Text(file.description),
         const SizedBox(height: 8),
         Text(
-          '${DateFormat('EEEE, MMMM d yyyy, h:mm a').format(file.time)} · Size: ${filesize(file.size)}',
+          '${DateFormat('EEEE, MMMM d yyyy, h:mm a').format(file.time)} · Size: ${fileSize(file.size)}',
           style: const TextStyle(fontStyle: FontStyle.italic),
         ),
       ],

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -236,7 +236,7 @@ class _ChatState extends _BaseTabState<_Chat> {
       return _contentFromGroupEvent(message, theme, users: users, l10n: l10n);
     } else if (message is FileShareContent) {
       return Text(
-        '${message.fileName} · ${filesize(message.size)}',
+        '${message.fileName} · ${fileSize(message.size)}',
         maxLines: 2,
         style: theme.bodyLarge!.copyWith(fontStyle: FontStyle.italic),
         overflow: TextOverflow.ellipsis,

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/audio_recording.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/audio_recording.dart
@@ -136,7 +136,7 @@ class _RecordAudioDialogState extends ConsumerState<_RecordAudioDialog> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(filesize(file!.lengthSync())),
+                      Text(fileSize(file!.lengthSync())),
                       Text(
                         _messageDuration,
                         maxLines: 2,

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -5,7 +5,6 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:bubble/bubble.dart';
 import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/file_message_widget.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/file_message_widget.dart
@@ -62,7 +62,7 @@ class FileMessageWidget extends StatelessWidget {
                   children: [
                     Text(message.name, style: style),
                     const SizedBox(height: 4),
-                    Text(filesize(message.size), style: style),
+                    Text(fileSize(message.size), style: style),
                   ],
                 ),
               ),

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/file_sharing.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/file_sharing.dart
@@ -27,7 +27,7 @@ class _SendFileDialog extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(filesize(file.lengthSync())),
+                  Text(fileSize(file.lengthSync())),
                   Text(
                     basename(file.path),
                     maxLines: 2,

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/image_message_widget.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/image_message_widget.dart
@@ -141,7 +141,7 @@ class _ImageMessageWidgetState extends State<ImageMessageWidget> {
                         top: 4,
                       ),
                       child: Text(
-                        filesize(widget.message.size.truncate()),
+                        fileSize(widget.message.size.truncate()),
                         style: style,
                       ),
                     ),

--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -2,7 +2,6 @@
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
-import 'package:filesize/filesize.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -12,7 +11,6 @@ import 'package:intl/locale.dart';
 import 'package:logging/logging.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:utils/utils.dart';
-
 
 import '../../../decorators/cron_task_decorator.dart';
 import '../../../decorators/disabled_state_decorator.dart';

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
@@ -264,7 +264,8 @@ class LibqaulWorker {
     required String description,
   }) async {
     var file = File(pathName);
-    if (isImage(file.path) && file.statSync().size >= 150.kb) {
+    final maxUncompressedSizeKB = 150 * 1000;
+    if (isImage(file.path) && file.statSync().size >= maxUncompressedSizeKB) {
       final compressed = await processImage(file);
       if (compressed != null) file = compressed;
     }

--- a/qaul_ui/packages/utils/lib/src/file_size.dart
+++ b/qaul_ui/packages/utils/lib/src/file_size.dart
@@ -1,64 +1,18 @@
-/// A method returns a human readable string representing a file _size
-String fileSize(dynamic size, [int round = 2]) {
-  /** 
-   * [size] can be passed as number or as string
-   *
-   * the optional parameter [round] specifies the number 
-   * of digits after comma/point (default is 2)
-   */
-  var divider = 1024;
-  int parsedSize;
-  try {
-    parsedSize = int.parse(size.toString());
-  } catch (e) {
-    throw ArgumentError('Can not parse the size parameter: $e');
-  }
+String fileSize(dynamic size) {
+  const divider = 1024;
+  final parsedSize = int.parse(size.toString());
 
   if (parsedSize < divider) {
     return '$parsedSize B';
   }
 
-  if (parsedSize < divider * divider && parsedSize % divider == 0) {
-    return '${(parsedSize / divider).toStringAsFixed(0)} KB';
-  }
-
   if (parsedSize < divider * divider) {
-    return '${(parsedSize / divider).toStringAsFixed(round)} KB';
-  }
-
-  if (parsedSize < divider * divider * divider && parsedSize % divider == 0) {
-    return '${(parsedSize / (divider * divider)).toStringAsFixed(0)} MB';
+    return '${(parsedSize / divider).toStringAsFixed(2)} KB';
   }
 
   if (parsedSize < divider * divider * divider) {
-    return '${(parsedSize / divider / divider).toStringAsFixed(round)} MB';
+    return '${(parsedSize / (divider * divider)).toStringAsFixed(2)} MB';
   }
 
-  if (parsedSize < divider * divider * divider * divider && parsedSize % divider == 0) {
-    return '${(parsedSize / (divider * divider * divider)).toStringAsFixed(0)} GB';
-  }
-
-  if (parsedSize < divider * divider * divider * divider) {
-    return '${(parsedSize / divider / divider / divider).toStringAsFixed(round)} GB';
-  }
-
-  if (parsedSize < divider * divider * divider * divider * divider &&
-      parsedSize % divider == 0) {
-    num r = parsedSize / divider / divider / divider / divider;
-    return '${r.toStringAsFixed(0)} TB';
-  }
-
-  if (parsedSize < divider * divider * divider * divider * divider) {
-    num r = parsedSize / divider / divider / divider / divider;
-    return '${r.toStringAsFixed(round)} TB';
-  }
-
-  if (parsedSize < divider * divider * divider * divider * divider * divider &&
-      parsedSize % divider == 0) {
-    num r = parsedSize / divider / divider / divider / divider / divider;
-    return '${r.toStringAsFixed(0)} PB';
-  } else {
-    num r = parsedSize / divider / divider / divider / divider / divider;
-    return '${r.toStringAsFixed(round)} PB';
-  }
+  return '${(parsedSize / (divider * divider * divider)).toStringAsFixed(2)} GB';
 }

--- a/qaul_ui/packages/utils/lib/src/file_size.dart
+++ b/qaul_ui/packages/utils/lib/src/file_size.dart
@@ -1,0 +1,64 @@
+/// A method returns a human readable string representing a file _size
+String fileSize(dynamic size, [int round = 2]) {
+  /** 
+   * [size] can be passed as number or as string
+   *
+   * the optional parameter [round] specifies the number 
+   * of digits after comma/point (default is 2)
+   */
+  var divider = 1024;
+  int parsedSize;
+  try {
+    parsedSize = int.parse(size.toString());
+  } catch (e) {
+    throw ArgumentError('Can not parse the size parameter: $e');
+  }
+
+  if (parsedSize < divider) {
+    return '$parsedSize B';
+  }
+
+  if (parsedSize < divider * divider && parsedSize % divider == 0) {
+    return '${(parsedSize / divider).toStringAsFixed(0)} KB';
+  }
+
+  if (parsedSize < divider * divider) {
+    return '${(parsedSize / divider).toStringAsFixed(round)} KB';
+  }
+
+  if (parsedSize < divider * divider * divider && parsedSize % divider == 0) {
+    return '${(parsedSize / (divider * divider)).toStringAsFixed(0)} MB';
+  }
+
+  if (parsedSize < divider * divider * divider) {
+    return '${(parsedSize / divider / divider).toStringAsFixed(round)} MB';
+  }
+
+  if (parsedSize < divider * divider * divider * divider && parsedSize % divider == 0) {
+    return '${(parsedSize / (divider * divider * divider)).toStringAsFixed(0)} GB';
+  }
+
+  if (parsedSize < divider * divider * divider * divider) {
+    return '${(parsedSize / divider / divider / divider).toStringAsFixed(round)} GB';
+  }
+
+  if (parsedSize < divider * divider * divider * divider * divider &&
+      parsedSize % divider == 0) {
+    num r = parsedSize / divider / divider / divider / divider;
+    return '${r.toStringAsFixed(0)} TB';
+  }
+
+  if (parsedSize < divider * divider * divider * divider * divider) {
+    num r = parsedSize / divider / divider / divider / divider;
+    return '${r.toStringAsFixed(round)} TB';
+  }
+
+  if (parsedSize < divider * divider * divider * divider * divider * divider &&
+      parsedSize % divider == 0) {
+    num r = parsedSize / divider / divider / divider / divider / divider;
+    return '${r.toStringAsFixed(0)} PB';
+  } else {
+    num r = parsedSize / divider / divider / divider / divider / divider;
+    return '${r.toStringAsFixed(round)} PB';
+  }
+}

--- a/qaul_ui/packages/utils/lib/src/file_size.dart
+++ b/qaul_ui/packages/utils/lib/src/file_size.dart
@@ -1,18 +1,17 @@
-String fileSize(dynamic size) {
+String fileSize(num size) {
   const divider = 1024;
-  final parsedSize = int.parse(size.toString());
 
-  if (parsedSize < divider) {
-    return '$parsedSize B';
+  if (size < divider) {
+    return '$size B';
   }
 
-  if (parsedSize < divider * divider) {
-    return '${(parsedSize / divider).toStringAsFixed(2)} KB';
+  if (size < divider * divider) {
+    return '${(size / divider).toStringAsFixed(2)} KB';
   }
 
-  if (parsedSize < divider * divider * divider) {
-    return '${(parsedSize / (divider * divider)).toStringAsFixed(2)} MB';
+  if (size < divider * divider * divider) {
+    return '${(size / (divider * divider)).toStringAsFixed(2)} MB';
   }
 
-  return '${(parsedSize / (divider * divider * divider)).toStringAsFixed(2)} GB';
+  return '${(size / (divider * divider * divider)).toStringAsFixed(2)} GB';
 }

--- a/qaul_ui/packages/utils/lib/src/file_size_descriptor.dart
+++ b/qaul_ui/packages/utils/lib/src/file_size_descriptor.dart
@@ -1,7 +1,3 @@
 extension FileSizeDescriptor on int {
   int get kb => this * 1000;
-
-  int get mb => kb * 1000;
-
-  int get gb => mb * 1000;
 }

--- a/qaul_ui/packages/utils/lib/src/file_size_descriptor.dart
+++ b/qaul_ui/packages/utils/lib/src/file_size_descriptor.dart
@@ -1,3 +1,0 @@
-extension FileSizeDescriptor on int {
-  int get kb => this * 1000;
-}

--- a/qaul_ui/packages/utils/lib/utils.dart
+++ b/qaul_ui/packages/utils/lib/utils.dart
@@ -11,6 +11,7 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import 'src/emoji_string_manipulator.dart';
 
+export 'src/file_size.dart';
 export 'src/file_size_descriptor.dart';
 export 'src/image_manipulation.dart';
 export 'src/intersperse.dart';

--- a/qaul_ui/packages/utils/lib/utils.dart
+++ b/qaul_ui/packages/utils/lib/utils.dart
@@ -12,7 +12,6 @@ import 'package:timeago/timeago.dart' as timeago;
 import 'src/emoji_string_manipulator.dart';
 
 export 'src/file_size.dart';
-export 'src/file_size_descriptor.dart';
 export 'src/image_manipulation.dart';
 export 'src/intersperse.dart';
 export 'src/ip_utils.dart';

--- a/qaul_ui/packages/utils/test/file_size_test.dart
+++ b/qaul_ui/packages/utils/test/file_size_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:utils/utils.dart';
+
+void main() {
+  group('fileSize', () {
+    final testcases = <MapEntry<dynamic, String>>[
+      MapEntry(0, '0 B'),
+      MapEntry(1, '1 B'),
+      MapEntry(512, '512 B'),
+      MapEntry(1023, '1023 B'),
+      MapEntry(1024, '1.00 KB'),
+      MapEntry(1536, '1.50 KB'),
+      MapEntry(2048, '2.00 KB'),
+      MapEntry(10240, '10.00 KB'),
+      MapEntry(1048575, '1024.00 KB'),
+      MapEntry(1048576, '1.00 MB'),
+      MapEntry(1572864, '1.50 MB'),
+      MapEntry(10485760, '10.00 MB'),
+      MapEntry(1073741823, '1024.00 MB'),
+      MapEntry(1073741824, '1.00 GB'),
+      MapEntry(1610612736, '1.50 GB'),
+      MapEntry(10737418240, '10.00 GB'),
+      MapEntry('0', '0 B'),
+      MapEntry('1024', '1.00 KB'),
+      MapEntry('1048576', '1.00 MB'),
+      MapEntry('1073741824', '1.00 GB'),
+    ];
+
+    for (final tc in testcases) {
+      test('${tc.key} becomes ${tc.value}', () {
+        expect(fileSize(tc.key), tc.value);
+      });
+    }
+  });
+}

--- a/qaul_ui/packages/utils/test/file_size_test.dart
+++ b/qaul_ui/packages/utils/test/file_size_test.dart
@@ -3,7 +3,7 @@ import 'package:utils/utils.dart';
 
 void main() {
   group('fileSize', () {
-    final testcases = <MapEntry<dynamic, String>>[
+    final testcases = <MapEntry<num, String>>[
       MapEntry(0, '0 B'),
       MapEntry(1, '1 B'),
       MapEntry(512, '512 B'),
@@ -20,10 +20,6 @@ void main() {
       MapEntry(1073741824, '1.00 GB'),
       MapEntry(1610612736, '1.50 GB'),
       MapEntry(10737418240, '10.00 GB'),
-      MapEntry('0', '0 B'),
-      MapEntry('1024', '1.00 KB'),
-      MapEntry('1048576', '1.00 MB'),
-      MapEntry('1073741824', '1.00 GB'),
     ];
 
     for (final tc in testcases) {

--- a/qaul_ui/pubspec.lock
+++ b/qaul_ui/pubspec.lock
@@ -441,14 +441,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+5"
-  filesize:
-    dependency: "direct main"
-    description:
-      name: filesize
-      sha256: f53df1f27ff60e466eefcd9df239e02d4722d5e2debee92a87dfd99ac66de2af
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   fixnum:
     dependency: "direct main"
     description:

--- a/qaul_ui/pubspec.yaml
+++ b/qaul_ui/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   equatable: ^2.0.7
   ffi: ^2.1.5
   file_picker: ^10.3.8
-  filesize: ^2.0.1
   fixnum: ^1.1.0
   flame: ^1.34.0
   flame_forge2d: ^0.19.2+2


### PR DESCRIPTION
## Description
This PR removes the external `filesize` package dependency and internalizes its implementation directly into the repository.

The `filesize` package code was fully replicated into the codebase, preserving its original behavior. This allows us to eliminate the external dependency while maintaining full compatibility with existing usage.

This change avoids reliance on an unmaintained package, and simplifies dependency management.

## Changes

### Dependency Removal: `filesize`
- Removed `filesize` from `pubspec.yaml`
- Eliminated all references to the external package

### Internalization of `filesize` Package
- Replicated the full source code of the original `filesize` package into the repository
- Preserved original logic and structure
- Updated imports to reference the internal implementation
