### PR TITLE
Migrate riverpod remaining legacy state providers

### DIFF
--- a/qaul_ui/lib/decorators/search_user_decorator.dart
+++ b/qaul_ui/lib/decorators/search_user_decorator.dart
@@ -14,6 +14,8 @@ typedef SearchUserResultBuilder = Widget Function(
 class _SearchKeyNotifier extends Notifier<String> {
   @override
   String build() => '';
+
+  void setKey(String value) => state = value;
 }
 
 final _searchKeyProvider =
@@ -45,8 +47,6 @@ class SearchUserDecorator extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final controller = useTextEditingController();
-    final searchKeyNotifier = _searchKeyProvider.notifier;
-
     final l10n = AppLocalizations.of(context)!;
     final searchBar = PreferredSize(
       preferredSize: const Size(double.maxFinite, 40),
@@ -64,13 +64,13 @@ class SearchUserDecorator extends HookConsumerWidget {
             suffixIcon: IconButton(
               onPressed: () {
                 controller.clear();
-                ref.read(searchKeyNotifier).state = '';
+                ref.read(_searchKeyProvider.notifier).setKey('');
               },
               splashRadius: 16,
               icon: const Icon(Icons.clear_rounded),
             ),
           ),
-          onChanged: (val) => ref.read(searchKeyNotifier).state = val,
+          onChanged: (val) => ref.read(_searchKeyProvider.notifier).setKey(val),
         ),
       ),
     );
@@ -85,7 +85,7 @@ class SearchUserDecorator extends HookConsumerWidget {
             ),
       body: Consumer(
         builder: (context, ref, _) {
-          final users = ref.watch(_userSearchProvider.notifier).state;
+          final users = ref.watch(_userSearchProvider);
           return builder(context, users);
         },
       ),

--- a/qaul_ui/lib/screens/create_account_screen.dart
+++ b/qaul_ui/lib/screens/create_account_screen.dart
@@ -11,6 +11,8 @@ import '../widgets/widgets.dart';
 class _UsernameNotifier extends Notifier<String?> {
   @override
   String? build() => null;
+
+  void setUsername(String? value) => state = value;
 }
 
 class CreateAccountScreen extends HookConsumerWidget {
@@ -161,6 +163,6 @@ class CreateAccountScreen extends HookConsumerWidget {
     if (!valid) return;
 
     loading.value = true;
-    ref.read(_usernameProvider.notifier).state = nameCtrl.text;
+    ref.read(_usernameProvider.notifier).setUsername(nameCtrl.text);
   }
 }

--- a/qaul_ui/lib/screens/create_account_screen.dart
+++ b/qaul_ui/lib/screens/create_account_screen.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 import 'package:logging/logging.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 
 import '../helpers/navigation_helper.dart';
 import '../l10n/app_localizations.dart';
 import '../widgets/widgets.dart';
+
+class _UsernameNotifier extends Notifier<String?> {
+  @override
+  String? build() => null;
+}
 
 class CreateAccountScreen extends HookConsumerWidget {
   CreateAccountScreen() : super(key: widgetKey);
@@ -20,7 +24,8 @@ class CreateAccountScreen extends HookConsumerWidget {
 
   static final _log = Logger('CreateAccountScreen');
 
-  static final _usernameProvider = StateProvider<String?>((ref) => null);
+  static final _usernameProvider =
+      NotifierProvider<_UsernameNotifier, String?>(_UsernameNotifier.new);
 
   final _sendRequestProvider = FutureProvider<bool?>((ref) async {
     final name = ref.watch(_usernameProvider);

--- a/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/dynamic_network_screen.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:equatable/equatable.dart';
-import 'package:flame/components.dart';
+import 'package:flame/components.dart' hide Notifier;
 import 'package:flame/events.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
@@ -13,7 +13,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Draggable;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:utils/utils.dart';
 

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -50,7 +50,7 @@ class _ChatState extends _BaseTabState<_Chat> {
             user: defaultUser,
             otherUser: otherUser);
       } else {
-        ref.read(currentOpenChatRoom.notifier).state = room;
+        ref.read(currentOpenChatRoom.notifier).setRoom(room);
       }
     }, [mobile]);
 

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -61,7 +61,7 @@ Future<void> openChat(
   required User user,
   User? otherUser,
 }) async {
-  ref.read(currentOpenChatRoom.notifier).state = room;
+  ref.read(currentOpenChatRoom.notifier).setRoom(room);
 
   bool isMobile =
       MediaQuery.of(context).size.width < Responsiveness.kTabletBreakpoint;
@@ -192,7 +192,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   void _scheduleUpdateCurrentOpenChat() =>
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        ref.read(currentOpenChatRoom.notifier).state = room;
+        ref.read(currentOpenChatRoom.notifier).setRoom(room);
         ref.read(qaulWorkerProvider).getChatRoomMessages(room.conversationId);
       });
 
@@ -237,7 +237,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     final closeChat = useCallback(() {
       if (!mounted) return;
-      ref.read(currentOpenChatRoom.notifier).state = null;
+      ref.read(currentOpenChatRoom.notifier).setRoom(null);
       if (_kChatRouteName == ModalRoute.of(context)?.settings.name) {
         Navigator.pop(context);
       }

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 
 import 'package:fixnum/fixnum.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 import 'package:logging/logging.dart';
 import 'package:protobuf/protobuf.dart' as pb;
 import 'package:utils/utils.dart';
@@ -31,7 +30,14 @@ import 'utils.dart';
 
 final qaulWorkerProvider = Provider<LibqaulWorker>((ref) => LibqaulWorker(ref));
 
-final libqaulLogsStoragePath = StateProvider<String?>((ref) => null);
+final libqaulLogsStoragePath =
+    NotifierProvider<LibqaulLogsStoragePathNotifier, String?>(
+        LibqaulLogsStoragePathNotifier.new);
+
+class LibqaulLogsStoragePathNotifier extends Notifier<String?> {
+  @override
+  String? build() => null;
+}
 
 class LibqaulWorker {
   LibqaulWorker(Ref ref) : _ref = ref {

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
@@ -37,6 +37,8 @@ final libqaulLogsStoragePath =
 class LibqaulLogsStoragePathNotifier extends Notifier<String?> {
   @override
   String? build() => null;
+
+  void setPath(String? value) => state = value;
 }
 
 class LibqaulWorker {
@@ -406,7 +408,7 @@ class LibqaulWorker {
       final path =
           await findFolderWithFilesOfExtension(Directory(res.data), '.log');
       _log.info('libqaul log storage path: $path');
-      _ref.read(libqaulLogsStoragePath.notifier).state = path;
+      _ref.read(libqaulLogsStoragePath.notifier).setPath(path);
     }
   }
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/ble_connection_status.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/ble_connection_status.dart
@@ -2,9 +2,16 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:fast_base58/fast_base58.dart';
-import 'package:hooks_riverpod/legacy.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final bleStatusProvider = StateProvider<BleConnectionStatus?>((_) => null);
+final bleStatusProvider =
+    NotifierProvider<BleStatusNotifier, BleConnectionStatus?>(
+        BleStatusNotifier.new);
+
+class BleStatusNotifier extends Notifier<BleConnectionStatus?> {
+  @override
+  BleConnectionStatus? build() => null;
+}
 
 class BleConnectionStatus {
   final Uint8List bleId;

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/ble_connection_status.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/ble_connection_status.dart
@@ -11,6 +11,8 @@ final bleStatusProvider =
 class BleStatusNotifier extends Notifier<BleConnectionStatus?> {
   @override
   BleConnectionStatus? build() => null;
+
+  void setStatus(BleConnectionStatus? value) => state = value;
 }
 
 class BleConnectionStatus {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -7,7 +7,6 @@ import 'package:equatable/equatable.dart';
 import 'package:fast_base58/fast_base58.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 
 import '../../../qaul_rpc.dart';
 import '../../generated/services/chat/chat.pb.dart';

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/providers.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/providers.dart
@@ -4,4 +4,11 @@ final chatRoomsProvider =
     NotifierProvider<ChatRoomListNotifier, List<ChatRoom>>(
         ChatRoomListNotifier.new);
 
-final currentOpenChatRoom = StateProvider<ChatRoom?>((ref) => null);
+final currentOpenChatRoom =
+    NotifierProvider<CurrentOpenChatRoomNotifier, ChatRoom?>(
+        CurrentOpenChatRoomNotifier.new);
+
+class CurrentOpenChatRoomNotifier extends Notifier<ChatRoom?> {
+  @override
+  ChatRoom? build() => null;
+}

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/providers.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/providers.dart
@@ -11,4 +11,6 @@ final currentOpenChatRoom =
 class CurrentOpenChatRoomNotifier extends Notifier<ChatRoom?> {
   @override
   ChatRoom? build() => null;
+
+  void setRoom(ChatRoom? room) => state = room;
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/dtn_configuration.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/dtn_configuration.dart
@@ -1,10 +1,17 @@
 import 'package:collection/collection.dart';
-import 'package:hooks_riverpod/legacy.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../generated/services/dtn/dtn_rpc.pb.dart';
 import 'models.dart';
 
-final dtnConfigurationProvider = StateProvider<DTNConfiguration?>((_) => null);
+final dtnConfigurationProvider =
+    NotifierProvider<DtnConfigurationNotifier, DTNConfiguration?>(
+        DtnConfigurationNotifier.new);
+
+class DtnConfigurationNotifier extends Notifier<DTNConfiguration?> {
+  @override
+  DTNConfiguration? build() => null;
+}
 
 class DTNConfiguration {
   DTNConfiguration._(this.totalSize, this.users);

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/dtn_configuration.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/dtn_configuration.dart
@@ -11,6 +11,8 @@ final dtnConfigurationProvider =
 class DtnConfigurationNotifier extends Notifier<DTNConfiguration?> {
   @override
   DTNConfiguration? build() => null;
+
+  void setConfiguration(DTNConfiguration? value) => state = value;
 }
 
 class DTNConfiguration {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/internet_node.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/internet_node.dart
@@ -1,9 +1,16 @@
 import 'package:equatable/equatable.dart';
-import 'package:hooks_riverpod/legacy.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../generated/connections/connections.pb.dart';
 
-final connectedNodesProvider = StateProvider<List<InternetNode>>((ref) => []);
+final connectedNodesProvider =
+    NotifierProvider<ConnectedNodesNotifier, List<InternetNode>>(
+        ConnectedNodesNotifier.new);
+
+class ConnectedNodesNotifier extends Notifier<List<InternetNode>> {
+  @override
+  List<InternetNode> build() => [];
+}
 
 class InternetNode extends Equatable {
   InternetNode(

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/internet_node.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/internet_node.dart
@@ -10,6 +10,8 @@ final connectedNodesProvider =
 class ConnectedNodesNotifier extends Notifier<List<InternetNode>> {
   @override
   List<InternetNode> build() => [];
+
+  void setNodes(List<InternetNode> value) => state = value;
 }
 
 class InternetNode extends Equatable {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/node_info.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/node_info.dart
@@ -1,6 +1,12 @@
-import 'package:hooks_riverpod/legacy.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final nodeInfoProvider = StateProvider<NodeInfo?>((_) => null);
+final nodeInfoProvider =
+    NotifierProvider<NodeInfoNotifier, NodeInfo?>(NodeInfoNotifier.new);
+
+class NodeInfoNotifier extends Notifier<NodeInfo?> {
+  @override
+  NodeInfo? build() => null;
+}
 
 class NodeInfo {
   const NodeInfo(this.idBase58, this.knownAddresses);

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/node_info.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/node_info.dart
@@ -6,6 +6,8 @@ final nodeInfoProvider =
 class NodeInfoNotifier extends Notifier<NodeInfo?> {
   @override
   NodeInfo? build() => null;
+
+  void setNodeInfo(NodeInfo? value) => state = value;
 }
 
 class NodeInfo {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/security_number.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/security_number.dart
@@ -8,6 +8,8 @@ final currentSecurityNoProvider =
 class CurrentSecurityNoNotifier extends Notifier<SecurityNumber?> {
   @override
   SecurityNumber? build() => null;
+
+  void setSecurityNumber(SecurityNumber? value) => state = value;
 }
 
 class SecurityNumber {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/security_number.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/security_number.dart
@@ -1,7 +1,14 @@
 import 'package:flutter/foundation.dart';
-import 'package:hooks_riverpod/legacy.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final currentSecurityNoProvider = StateProvider<SecurityNumber?>((_) => null);
+final currentSecurityNoProvider =
+    NotifierProvider<CurrentSecurityNoNotifier, SecurityNumber?>(
+        CurrentSecurityNoNotifier.new);
+
+class CurrentSecurityNoNotifier extends Notifier<SecurityNumber?> {
+  @override
+  SecurityNumber? build() => null;
+}
 
 class SecurityNumber {
   SecurityNumber({

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -4,9 +4,9 @@ import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:fast_base58/fast_base58.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 
-final defaultUserProvider = StateProvider<User?>((ref) => null);
+final defaultUserProvider =
+    NotifierProvider<DefaultUserNotifier, User?>(DefaultUserNotifier.new);
 
 final usersProvider = NotifierProvider<UserListNotifier, List<User>>(
   UserListNotifier.new,
@@ -85,6 +85,11 @@ class ConnectionInfo extends Equatable {
 
   @override
   List<Object?> get props => [ping, hopCount, nodeID, nodeIDBase58];
+}
+
+class DefaultUserNotifier extends Notifier<User?> {
+  @override
+  User? build() => null;
 }
 
 class UserListNotifier extends Notifier<List<User>> {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -90,6 +90,8 @@ class ConnectionInfo extends Equatable {
 class DefaultUserNotifier extends Notifier<User?> {
   @override
   User? build() => null;
+
+  void setUser(User? value) => state = value;
 }
 
 class UserListNotifier extends Notifier<List<User>> {

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/abstract_rpc_module_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/abstract_rpc_module_translator.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:fast_base58/fast_base58.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/ble_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/ble_translator.dart
@@ -48,6 +48,6 @@ class BleTranslator extends RpcModuleTranslator {
       );
       _log.finest('BLE Module: Merged with previous status: $newStatus');
     }
-    ref.read(bleStatusProvider.notifier).state = newStatus;
+    ref.read(bleStatusProvider.notifier).setStatus(newStatus);
   }
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
@@ -39,7 +39,7 @@ class ChatTranslator extends RpcModuleTranslator {
   }
 
   bool _currentOpenRoomEqualsChatConversationList(
-    StateController<ChatRoom?> currentOpenRoomNotifier,
+    Notifier<ChatRoom?> currentOpenRoomNotifier,
     RpcTranslatorResponse res,
   ) =>
       currentOpenRoomNotifier.state != null &&

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/connection_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/connection_translator.dart
@@ -26,6 +26,6 @@ class ConnectionTranslator extends RpcModuleTranslator {
   @override
   Future<void> processResponse(RpcTranslatorResponse res, Ref ref) async {
     if (res.module != type || res.data is! List<InternetNode>) return;
-    ref.read(connectedNodesProvider.notifier).state = res.data;
+    ref.read(connectedNodesProvider.notifier).setNodes(res.data);
   }
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/dtn_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/dtn_translator.dart
@@ -45,7 +45,7 @@ class DTNTranslator extends RpcModuleTranslator {
     // Means _receiveResultResponse yielded a success message.
     if (res.data is bool && res.data == true) return;
     if (res.data is DTNConfiguration) {
-      ref.read(dtnConfigurationProvider.notifier).state = res.data;
+      ref.read(dtnConfigurationProvider.notifier).setConfiguration(res.data);
       return;
     }
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/node_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/node_translator.dart
@@ -20,6 +20,6 @@ class NodeTranslator extends RpcModuleTranslator {
   @override
   Future<void> processResponse(RpcTranslatorResponse res, Ref ref) async {
     if (res.module != type || res.data is! NodeInfo) return;
-    ref.read(nodeInfoProvider.notifier).state = res.data;
+    ref.read(nodeInfoProvider.notifier).setNodeInfo(res.data);
   }
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/user_accounts_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/user_accounts_translator.dart
@@ -35,6 +35,6 @@ class UserAccountsTranslator extends RpcModuleTranslator {
   @override
   Future<void> processResponse(RpcTranslatorResponse res, Ref ref) async {
     if (res.module != type || res.data is! User) return;
-    ref.read(defaultUserProvider.notifier).state = res.data;
+    ref.read(defaultUserProvider.notifier).setUser(res.data);
   }
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -85,7 +85,7 @@ class UsersTranslator extends RpcModuleTranslator {
       }
     }
     if (res.data is SecurityNumber) {
-      ref.read(currentSecurityNoProvider.notifier).state = res.data;
+      ref.read(currentSecurityNoProvider.notifier).setSecurityNumber(res.data);
     }
   }
 }

--- a/qaul_ui/test/chat_tab/chat_tab_test.dart
+++ b/qaul_ui/test/chat_tab/chat_tab_test.dart
@@ -19,6 +19,13 @@ part 'fixtures.dart';
 
 part 'stubs.dart';
 
+class _OverrideDefaultUserNotifier extends DefaultUserNotifier {
+  _OverrideDefaultUserNotifier(this._value);
+  final User? _value;
+  @override
+  User? build() => _value;
+}
+
 class TestChatRoomListNotifier extends ChatRoomListNotifier {
   @override
   List<ChatRoom> build() => [buildGroupChat()];
@@ -45,7 +52,7 @@ void main() {
     final wut = ProviderScope(
       overrides: [
         defaultUserProvider.overrideWith(
-          (_) => defaultUser,
+          () => _OverrideDefaultUserNotifier(defaultUser),
         ),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
@@ -68,7 +75,7 @@ void main() {
     final wut = ProviderScope(
       overrides: [
         defaultUserProvider.overrideWith(
-          (_) => defaultUser,
+          () => _OverrideDefaultUserNotifier(defaultUser),
         ),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
@@ -103,7 +110,7 @@ void main() {
     final wut = ProviderScope(
       overrides: [
         defaultUserProvider.overrideWith(
-          (_) => defaultUser,
+          () => _OverrideDefaultUserNotifier(defaultUser),
         ),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
@@ -144,7 +151,7 @@ void main() {
     final wut = ProviderScope(
       overrides: [
         defaultUserProvider.overrideWith(
-          (_) => defaultUser,
+          () => _OverrideDefaultUserNotifier(defaultUser),
         ),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
@@ -194,7 +201,7 @@ void main() {
     final wut = ProviderScope(
       overrides: [
         defaultUserProvider.overrideWith(
-          (_) => defaultUser,
+          () => _OverrideDefaultUserNotifier(defaultUser),
         ),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
@@ -245,7 +252,7 @@ void main() {
       final wut = ProviderScope(
         overrides: [
           defaultUserProvider.overrideWith(
-            (_) => defaultUser,
+            () => _OverrideDefaultUserNotifier(defaultUser),
           ),
           chatNotificationControllerProvider.overrideWithValue(
             NullChatNotificationController(),

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -25,8 +25,8 @@ class StubLibqaulWorker implements LibqaulWorker {
       room == null || room.messages == null ? [] : room.messages!,
     );
     msgs.add(message);
-    ref.read(currentOpenChatRoom.notifier).state =
-        buildGroupChat(messages: msgs);
+    ref.read(currentOpenChatRoom.notifier).setRoom(
+        buildGroupChat(messages: msgs));
   }
 
   @override

--- a/qaul_ui/test/providers/state_providers_migration_test.dart
+++ b/qaul_ui/test/providers/state_providers_migration_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:qaul_rpc/src/generated/services/dtn/dtn_rpc.pb.dart';
-import 'package:qaul_rpc/src/models/user.dart';
 
 class _OverrideDefaultUserNotifier extends DefaultUserNotifier {
   _OverrideDefaultUserNotifier(this._value);
@@ -32,7 +31,7 @@ void main() {
         name: 'test',
         id: Uint8List.fromList([1, 2, 3]),
       );
-      container.read(defaultUserProvider.notifier).state = user;
+      container.read(defaultUserProvider.notifier).setUser(user);
       expect(container.read(defaultUserProvider), user);
     });
 
@@ -44,7 +43,7 @@ void main() {
         fireImmediately: false,
       );
       final user = User(name: 'a', id: Uint8List.fromList([1]));
-      container.read(defaultUserProvider.notifier).state = user;
+      container.read(defaultUserProvider.notifier).setUser(user);
       expect(stateChanges, [user]);
     });
 
@@ -75,7 +74,7 @@ void main() {
         securityHash: Uint8List.fromList([2]),
         securityNumberBlocks: [11111, 22222],
       );
-      container.read(currentSecurityNoProvider.notifier).state = sn;
+      container.read(currentSecurityNoProvider.notifier).setSecurityNumber(sn);
       expect(container.read(currentSecurityNoProvider), sn);
     });
   });
@@ -87,7 +86,7 @@ void main() {
 
     test('notifier.state can be set and read', () {
       final info = NodeInfo('id', ['addr1']);
-      container.read(nodeInfoProvider.notifier).state = info;
+      container.read(nodeInfoProvider.notifier).setNodeInfo(info);
       expect(container.read(nodeInfoProvider), info);
     });
   });
@@ -102,7 +101,7 @@ void main() {
         InternetNode('/ip4/1.2.3.4/udp/1234/quic-v1',
             isActive: true, name: 'n1'),
       ];
-      container.read(connectedNodesProvider.notifier).state = nodes;
+      container.read(connectedNodesProvider.notifier).setNodes(nodes);
       expect(container.read(connectedNodesProvider), nodes);
     });
   });
@@ -115,7 +114,7 @@ void main() {
     test('notifier.state can be set and read', () {
       final res = DtnConfigResponse()..totalSize = 100;
       final config = DTNConfiguration.fromRpcConfigResponse(res, []);
-      container.read(dtnConfigurationProvider.notifier).state = config;
+      container.read(dtnConfigurationProvider.notifier).setConfiguration(config);
       expect(container.read(dtnConfigurationProvider), config);
     });
   });
@@ -129,7 +128,7 @@ void main() {
       final room = ChatRoom(
         conversationId: Uint8List.fromList([1, 2, 3]),
       );
-      container.read(currentOpenChatRoom.notifier).state = room;
+      container.read(currentOpenChatRoom.notifier).setRoom(room);
       expect(container.read(currentOpenChatRoom), room);
     });
   });
@@ -141,7 +140,7 @@ void main() {
 
     test('notifier.state can be set and read', () {
       final status = BleConnectionStatus(bleId: Uint8List.fromList([1]));
-      container.read(bleStatusProvider.notifier).state = status;
+      container.read(bleStatusProvider.notifier).setStatus(status);
       expect(container.read(bleStatusProvider), status);
     });
   });
@@ -152,7 +151,7 @@ void main() {
     });
 
     test('notifier.state can be set and read', () {
-      container.read(libqaulLogsStoragePath.notifier).state = '/tmp/logs';
+      container.read(libqaulLogsStoragePath.notifier).setPath('/tmp/logs');
       expect(container.read(libqaulLogsStoragePath), '/tmp/logs');
     });
   });

--- a/qaul_ui/test/providers/state_providers_migration_test.dart
+++ b/qaul_ui/test/providers/state_providers_migration_test.dart
@@ -1,0 +1,159 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_rpc/src/generated/services/dtn/dtn_rpc.pb.dart';
+import 'package:qaul_rpc/src/models/user.dart';
+
+class _OverrideDefaultUserNotifier extends DefaultUserNotifier {
+  _OverrideDefaultUserNotifier(this._value);
+  final User? _value;
+  @override
+  User? build() => _value;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer.test();
+  });
+
+  group('defaultUserProvider', () {
+    test('initial state is null', () {
+      expect(container.read(defaultUserProvider), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      final user = User(
+        name: 'test',
+        id: Uint8List.fromList([1, 2, 3]),
+      );
+      container.read(defaultUserProvider.notifier).state = user;
+      expect(container.read(defaultUserProvider), user);
+    });
+
+    test('listeners are notified on state changes', () {
+      final stateChanges = <User?>[];
+      container.listen<User?>(
+        defaultUserProvider,
+        (previous, next) => stateChanges.add(next),
+        fireImmediately: false,
+      );
+      final user = User(name: 'a', id: Uint8List.fromList([1]));
+      container.read(defaultUserProvider.notifier).state = user;
+      expect(stateChanges, [user]);
+    });
+
+    test('overrideWith allows overriding for tests (chat_tab_test pattern)', () {
+      final overridden = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith(() =>
+              _OverrideDefaultUserNotifier(
+                  User(name: 'overridden', id: Uint8List.fromList([9, 9, 9])))),
+        ],
+      );
+      addTearDown(overridden.dispose);
+      expect(
+        overridden.read(defaultUserProvider)?.name,
+        'overridden',
+      );
+    });
+  });
+
+  group('currentSecurityNoProvider', () {
+    test('initial state is null', () {
+      expect(container.read(currentSecurityNoProvider), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      final sn = SecurityNumber(
+        userId: Uint8List.fromList([1]),
+        securityHash: Uint8List.fromList([2]),
+        securityNumberBlocks: [11111, 22222],
+      );
+      container.read(currentSecurityNoProvider.notifier).state = sn;
+      expect(container.read(currentSecurityNoProvider), sn);
+    });
+  });
+
+  group('nodeInfoProvider', () {
+    test('initial state is null', () {
+      expect(container.read(nodeInfoProvider), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      final info = NodeInfo('id', ['addr1']);
+      container.read(nodeInfoProvider.notifier).state = info;
+      expect(container.read(nodeInfoProvider), info);
+    });
+  });
+
+  group('connectedNodesProvider', () {
+    test('initial state is empty list', () {
+      expect(container.read(connectedNodesProvider), isEmpty);
+    });
+
+    test('notifier.state can be set and read', () {
+      final nodes = [
+        InternetNode('/ip4/1.2.3.4/udp/1234/quic-v1',
+            isActive: true, name: 'n1'),
+      ];
+      container.read(connectedNodesProvider.notifier).state = nodes;
+      expect(container.read(connectedNodesProvider), nodes);
+    });
+  });
+
+  group('dtnConfigurationProvider', () {
+    test('initial state is null', () {
+      expect(container.read(dtnConfigurationProvider), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      final res = DtnConfigResponse()..totalSize = 100;
+      final config = DTNConfiguration.fromRpcConfigResponse(res, []);
+      container.read(dtnConfigurationProvider.notifier).state = config;
+      expect(container.read(dtnConfigurationProvider), config);
+    });
+  });
+
+  group('currentOpenChatRoom', () {
+    test('initial state is null', () {
+      expect(container.read(currentOpenChatRoom), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      final room = ChatRoom(
+        conversationId: Uint8List.fromList([1, 2, 3]),
+      );
+      container.read(currentOpenChatRoom.notifier).state = room;
+      expect(container.read(currentOpenChatRoom), room);
+    });
+  });
+
+  group('bleStatusProvider', () {
+    test('initial state is null', () {
+      expect(container.read(bleStatusProvider), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      final status = BleConnectionStatus(bleId: Uint8List.fromList([1]));
+      container.read(bleStatusProvider.notifier).state = status;
+      expect(container.read(bleStatusProvider), status);
+    });
+  });
+
+  group('libqaulLogsStoragePath', () {
+    test('initial state is null', () {
+      expect(container.read(libqaulLogsStoragePath), isNull);
+    });
+
+    test('notifier.state can be set and read', () {
+      container.read(libqaulLogsStoragePath.notifier).state = '/tmp/logs';
+      expect(container.read(libqaulLogsStoragePath), '/tmp/logs');
+    });
+  });
+}


### PR DESCRIPTION

## Description
This PR migrates the Riverpod usage from `StateProvider` (and `legacy.dart`) to `NotifierProvider` + `Notifier`, and fixes `invalid_use_of_protected_member` / `invalid_use_of_visible_for_testing_member` by keeping `state` inside Notifiers and exposing setter methods for external updates. Used as reference: [PR #712 (HomeScreenTabController)](https://github.com/qaul/qaul.net/pull/712).

## Changes

- Addedd tests to ensure compatibility after migration.
- Replace `StateProvider` with `NotifierProvider` in `qaul_rpc` and drop `legacy.dart`.
- Migrate `StateProvider` in `qaul_ui/lib` to `NotifierProvider` and remove `legacy.dart`.

## Evidence

<img width="612" height="440" alt="Screenshot 2026-01-28 at 12 45 59" src="https://github.com/user-attachments/assets/159e886f-70c6-434a-91d2-fec514ceef2a" />



