### PR TITLE
Fix chat UI not updating when opening conversation (Riverpod 3)

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/group_settings.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/group_settings.dart
@@ -10,7 +10,7 @@ class _GroupSettingsPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final defaultUser = ref.watch(defaultUserProvider)!;
-    final group = ref.watch(chatRoomsProvider).firstWhere((r) => r == room);
+    final group = ref.watch(chatRoomsProvider).firstWhere((r) => r.idBase58 == room.idBase58);
 
     final nameCtrl = useTextEditingController(text: room.name);
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -113,7 +113,7 @@ class ChatRoom with EquatableMixin implements Comparable {
   }
 
   @override
-  List<Object?> get props => [idBase58];
+  List<Object?> get props => [idBase58, lastMessageIndex];
 
   @override
   String toString() {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
@@ -8,9 +8,10 @@ class ChatRoomListNotifier extends Notifier<List<ChatRoom>> {
 
   void update(ChatRoom room) {
     assert(contains(room), 'State does not contain room $room');
-    final filtered = state.where((r) => r != room);
+    final filtered = state.where((r) => r.idBase58 != room.idBase58);
     state = [room, ...filtered];
   }
 
-  bool contains(ChatRoom room) => state.contains(room);
+  bool contains(ChatRoom room) =>
+      state.any((r) => r.idBase58 == room.idBase58);
 }

--- a/qaul_ui/test/chat_room_equality_and_notifier_test.dart
+++ b/qaul_ui/test/chat_room_equality_and_notifier_test.dart
@@ -1,0 +1,97 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+
+void main() {
+  final conversationId = Uint8List.fromList('room1'.codeUnits);
+
+  Message message(int index) => Message(
+        senderId: Uint8List.fromList('sender'.codeUnits),
+        messageId: Uint8List.fromList('msg$index'.codeUnits),
+        content: const TextMessageContent('text'),
+        index: index,
+        sentAt: DateTime(2020, 1, 1),
+        receivedAt: DateTime(2020, 1, 1),
+      );
+
+  ChatRoom room({
+    List<Message>? messages,
+    int? lastMessageIndex,
+  }) =>
+      ChatRoom(
+        conversationId: conversationId,
+        name: 'Room',
+        messages: messages,
+        lastMessageIndex: lastMessageIndex,
+      );
+
+  group('ChatRoom Equatable props (idBase58, lastMessageIndex)', () {
+    test('rooms with same idBase58 and same lastMessageIndex are equal', () {
+      final a = room(messages: [message(1)], lastMessageIndex: 1);
+      final b = room(messages: [message(1)], lastMessageIndex: 1);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('rooms with same idBase58 but different lastMessageIndex are not equal', () {
+      final a = room(messages: [message(1)], lastMessageIndex: 1);
+      final b = room(messages: [message(1), message(2)], lastMessageIndex: 2);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('room with lastMessageIndex null vs set triggers inequality so UI can rebuild', () {
+      final withoutMessages = room(messages: null, lastMessageIndex: null);
+      final withMessages = room(messages: [message(0)], lastMessageIndex: 0);
+      expect(withoutMessages, isNot(equals(withMessages)));
+    });
+  });
+
+  group('ChatRoomListNotifier identify by idBase58', () {
+    test('contains returns true when list has room with same idBase58', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(chatRoomsProvider.notifier);
+
+      final roomA = room(messages: [message(1)], lastMessageIndex: 1);
+      notifier.add(roomA);
+
+      final roomB = room(messages: [message(1), message(2)], lastMessageIndex: 2);
+      expect(notifier.contains(roomB), isTrue);
+    });
+
+    test('update replaces room with same idBase58', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(chatRoomsProvider.notifier);
+
+      final roomA = room(messages: [message(1)], lastMessageIndex: 1);
+      notifier.add(roomA);
+      expect(container.read(chatRoomsProvider).single.messages!.length, 1);
+
+      final roomB = room(messages: [message(1), message(2)], lastMessageIndex: 2);
+      notifier.update(roomB);
+
+      final list = container.read(chatRoomsProvider);
+      expect(list.length, 1);
+      expect(list.single.idBase58, roomA.idBase58);
+      expect(list.single.messages!.length, 2);
+      expect(list.single.lastMessageIndex, 2);
+    });
+
+    test('contains returns false when no room has that idBase58', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(chatRoomsProvider.notifier);
+
+      notifier.add(room(messages: [message(1)], lastMessageIndex: 1));
+
+      final otherRoom = ChatRoom(
+        conversationId: Uint8List.fromList('other'.codeUnits),
+        name: 'Other',
+      );
+      expect(notifier.contains(otherRoom), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description
This PR fixes the chat not showing messages when opening a conversation after the Riverpod 3 migration.

In Riverpod 3, all providers use `==` to decide whether to notify listeners. With `ChatRoom` using only `idBase58` in its Equatable `props`, an updated room (with new messages) was considered equal to the previous one, so the provider did not notify and the chat UI did not rebuild. This change aligns `ChatRoom` equality and room lookup with that behaviour, and fixes the comparison and update logic in the chat translator so the open room receives and displays messages correctly.

## Changes

### ChatRoom equality (Riverpod 3 compatibility)
- In `chat_room.dart`, extended `props` to `[idBase58, lastMessageIndex]` so state changes when new messages arrive and the provider notifies and the UI rebuilds
- Kept only `lastMessageIndex` (not the full `messages` list) in `props` to avoid heavy comparisons in long chats

### Chat translator
- In `chat_translator.dart`, compare `conversationId` and `groupId` with `ListEquality<int>().equals()` instead of `.equals()` so the same conversation is recognised and the correct room is updated
- When the open room is not yet in `chatRoomsProvider` but the response matches `currentOpenChatRoom`, merge the response, add the room to the list, and set `currentOpenChatRoom` so the open chat shows messages

### Room identification by `idBase58`
- In `chat_room_list_notifier.dart`, `contains` and `update` now identify rooms by `idBase58` so the right room is found and replaced even when the room instance changes
- In `group_settings.dart`, room lookup uses `firstWhere((r) => r.idBase58 == room.idBase58)` so the correct room is used from the list


## Evidence
https://github.com/user-attachments/assets/e039fbc1-6402-466b-be5a-033f245e3107

https://github.com/user-attachments/assets/ff16ffa2-401c-44fc-99c1-c54fc233f3ae