### PR TITLE
Implement User Pagination

### DIFF
--- a/qaul_ui/lib/decorators/deeplink_decorator.dart
+++ b/qaul_ui/lib/decorators/deeplink_decorator.dart
@@ -85,5 +85,5 @@ class _DeepLinkWrapperState extends ConsumerState<DeepLinkWrapper> {
   ChatRoom? _roomWithId(String id) =>
       ref.read(chatRoomsProvider).firstWhereOrNull((r) => r.idBase58 == id);
 
-  User? _userWithId(String id) => ref.read(usersProvider).firstWhereOrNull((u) => u.idBase58 == id);
+  User? _userWithId(String id) => ref.read(usersProvider).data.firstWhereOrNull((u) => u.idBase58 == id);
 }

--- a/qaul_ui/lib/decorators/search_user_decorator.dart
+++ b/qaul_ui/lib/decorators/search_user_decorator.dart
@@ -20,6 +20,7 @@ final _userSearchProvider = StateProvider.autoDispose<List<User>>((ref) {
   final defaultUser = ref.watch(defaultUserProvider)!;
   final users = ref
       .watch(usersProvider)
+      .data
       .where((u) => !u.id.equals(defaultUser.id) && !(u.isBlocked ?? false))
       .toList()
     ..sort();

--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -47,6 +47,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
     if (UserPrefsHelper.instance.notifyOnlyForVerifiedUsers) {
       final verifiedIds = ref
           .read(usersProvider)
+          .data
           .where((u) => u.isVerified ?? false)
           .map((e) => e.id);
       newMessages = newMessages

--- a/qaul_ui/lib/providers/notification_controller/public_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/public_notification_controller_provider.dart
@@ -42,6 +42,7 @@ class PublicNotificationController
     if (UserPrefsHelper.instance.notifyOnlyForVerifiedUsers) {
       final verifiedIds = ref
           .read(usersProvider)
+          .data
           .where((u) => u.isVerified ?? false)
           .map((e) => e.id);
       newPosts = newPosts

--- a/qaul_ui/lib/screens/home/dynamic_network/widgets/network_type_filter.dart
+++ b/qaul_ui/lib/screens/home/dynamic_network/widgets/network_type_filter.dart
@@ -29,6 +29,7 @@ final _filteredNodes = StateProvider<NetworkNode>((ref) {
   final defaultUser = ref.watch(defaultUserProvider)!;
   final users = ref
       .watch(usersProvider)
+      .data
       .where((u) => !(u.isBlocked ?? false))
       .where((u) => u.idBase58 != defaultUser.idBase58)
       .toList();

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -22,7 +22,7 @@ class _ChatState extends _BaseTabState<_Chat> {
     super.build(context);
 
     final defaultUser = ref.watch(defaultUserProvider)!;
-    final users = ref.watch(usersProvider);
+    final users = ref.watch(usersProvider).data;
     final chatRooms = ref.watch(chatRoomsProvider);
     final groupInvites = ref.watch(groupInvitesProvider);
     final currentOpenChat = ref.watch(currentOpenChatRoom);

--- a/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
@@ -241,7 +241,7 @@ class _InviteDetailsDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final users = ref.watch(usersProvider);
+    final users = ref.watch(usersProvider).data;
 
     final replyInvite = useCallback(({required bool accepted}) {
       final worker = ref.read(qaulWorkerProvider);

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -549,7 +549,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   User _author(Message e) => e.senderId.equals(user.id)
       ? user
-      : ref.read(usersProvider).firstWhere((usr) => usr.id.equals(e.senderId));
+      : ref.read(usersProvider).data.firstWhere((usr) => usr.id.equals(e.senderId));
 
   List<types.Message>? messages(ChatRoom room,
       {required AppLocalizations l10n}) {

--- a/qaul_ui/lib/screens/home/tabs/network_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/network_tab.dart
@@ -54,6 +54,7 @@ class _AvailableConnectionsTable extends ConsumerWidget {
     final defaultUser = ref.watch(defaultUserProvider);
     final users = ref
         .watch(usersProvider)
+        .data
         .where((u) => !(u.isBlocked ?? false))
         .where((u) => u.idBase58 != (defaultUser?.idBase58 ?? ''))
         .where((u) => u.availableTypes?.keys.contains(type) ?? false)

--- a/qaul_ui/lib/screens/home/tabs/public_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/public_tab.dart
@@ -42,7 +42,7 @@ class _PublicTabView extends HookConsumerWidget {
       return () {};
     }, []);
 
-    final users = ref.watch(usersProvider);
+    final users = ref.watch(usersProvider).data;
     final messages = ref.watch(publicMessagesProvider);
 
     final blockedIds =

--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -15,6 +15,7 @@ import 'package:utils/utils.dart';
 import '../../../decorators/cron_task_decorator.dart';
 import '../../../decorators/disabled_state_decorator.dart';
 import '../../../decorators/empty_state_text_decorator.dart';
+import '../../../decorators/loading_decorator.dart';
 import '../../../decorators/search_user_decorator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../providers/providers.dart';

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -136,7 +136,6 @@ class _UsersState extends _BaseTabState<_Users> {
             }),
           ),
         ),
-      ),
     );
   }
 }

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -83,34 +83,23 @@ class _UsersState extends _BaseTabState<_Users> {
 
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
-      body: RefreshIndicator(
-        onRefresh: () async => await _refreshUsers(),
-        child: SearchUserDecorator(builder: (_, users) {
-            return EmptyStateTextDecorator(
-              l10n.emptyUsersList,
-              isEmpty: users.isEmpty,
-              child: ListView.separated(
-                controller: _scrollController,
-                physics: const AlwaysScrollableScrollPhysics(),
-                itemCount: users.length + (_hasMore.value ? 1 : 0),
-                separatorBuilder: (_, _) => const Divider(height: 12.0),
-                itemBuilder: (_, i) {
-                  if (i == users.length) {
-                    return ValueListenableBuilder<bool>(
-                      valueListenable: _isLoadingMore,
-                      builder: (context, isLoading, _) {
-                        if (isLoading) {
-                          return const Padding(
-                            padding: EdgeInsets.all(16.0),
-                            child: Center(child: LoadingIndicator()),
-                          );
-                        }
-                        return const SizedBox.shrink();
-                      },
-                    );
-                  }
-
-                  final user = users[i];
+      body: ListenableBuilder(
+        listenable: _isLoadingMore,
+        builder: (context, _) => LoadingDecorator(
+          isLoading: _isLoadingMore.value,
+          child: RefreshIndicator(
+            onRefresh: () async => await _refreshUsers(),
+            child: SearchUserDecorator(builder: (_, users) {
+              return EmptyStateTextDecorator(
+                l10n.emptyUsersList,
+                isEmpty: users.isEmpty,
+                child: ListView.separated(
+                  controller: _scrollController,
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  itemCount: users.length,
+                  separatorBuilder: (_, _) => const Divider(height: 12.0),
+                  itemBuilder: (_, i) {
+                    final user = users[i];
                   var theme = Theme.of(context).textTheme;
                   var hasConnections =
                       user.availableTypes != null && user.availableTypes!.isNotEmpty;
@@ -145,10 +134,12 @@ class _UsersState extends _BaseTabState<_Users> {
                       tapRoutesToDetailsScreen: true,
                     ),
                   );
-                },
-              ),
-            );
-        }),
+                  },
+                ),
+              );
+            }),
+          ),
+        ),
       ),
     );
   }

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -83,18 +83,9 @@ class _UsersState extends _BaseTabState<_Users> {
 
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
-      body: CronTaskDecorator(
-        schedule: const Duration(milliseconds: 1000),
-        callback: () async {
-          final currentUsersCount = ref.read(usersProvider).length;
-          if (currentUsersCount > 0) {
-            final worker = ref.read(qaulWorkerProvider);
-            await worker.getUsers(offset: 0, limit: currentUsersCount);
-          }
-        },
-        child: RefreshIndicator(
-          onRefresh: () async => await _refreshUsers(),
-          child: SearchUserDecorator(builder: (_, users) {
+      body: RefreshIndicator(
+        onRefresh: () async => await _refreshUsers(),
+        child: SearchUserDecorator(builder: (_, users) {
             return EmptyStateTextDecorator(
               l10n.emptyUsersList,
               isEmpty: users.isEmpty,
@@ -111,7 +102,7 @@ class _UsersState extends _BaseTabState<_Users> {
                         if (isLoading) {
                           return const Padding(
                             padding: EdgeInsets.all(16.0),
-                            child: Center(child: CircularProgressIndicator()),
+                            child: Center(child: LoadingIndicator()),
                           );
                         }
                         return const SizedBox.shrink();
@@ -157,8 +148,7 @@ class _UsersState extends _BaseTabState<_Users> {
                 },
               ),
             );
-          }),
-        ),
+        }),
       ),
     );
   }

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -41,7 +41,7 @@ class _UsersState extends _BaseTabState<_Users> {
   }
 
   void _updatePaginationState() {
-    final paginationState = ref.read(usersPaginationStateProvider);
+    final paginationState = ref.read(usersProvider).pagination;
     if (paginationState != null) {
       _hasMore.value = paginationState.hasMore;
       _currentOffset = paginationState.offset + paginationState.limit;
@@ -75,8 +75,8 @@ class _UsersState extends _BaseTabState<_Users> {
   Widget build(BuildContext context) {
     super.build(context);
 
-    ref.listen(usersPaginationStateProvider, (previous, next) {
-      if (next != null && !next.hasMore) {
+    ref.listen(usersProvider, (previous, next) {
+      if (next.pagination != null && !next.pagination!.hasMore) {
         _hasMore.value = false;
       }
     });

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
@@ -92,8 +92,12 @@ class LibqaulWorker {
     _sendMessage(Modules.FEED, msg);
   }
 
-  Future<void> getUsers() async =>
-      await _sendMessage(Modules.USERS, Users(userRequest: UserRequest()));
+  Future<void> getUsers({int? offset, int? limit}) async {
+    final request = UserRequest();
+    if (offset != null) request.offset = offset;
+    if (limit != null) request.limit = limit;
+    await _sendMessage(Modules.USERS, Users(userRequest: request));
+  }
 
   void getUserSecurityNumber(User u) async {
     final msg = Users(

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -12,7 +12,19 @@ final usersProvider = NotifierProvider<UserListNotifier, List<User>>(
   UserListNotifier.new,
 );
 
-final usersPaginationStateProvider = StateProvider<UsersPaginationState?>((ref) => null);
+class UsersPaginationStateNotifier extends Notifier<UsersPaginationState?> {
+  @override
+  UsersPaginationState? build() => null;
+
+  void setPagination(UsersPaginationState? value) {
+    state = value;
+  }
+}
+
+final usersPaginationStateProvider =
+    NotifierProvider<UsersPaginationStateNotifier, UsersPaginationState?>(
+  UsersPaginationStateNotifier.new,
+);
 
 enum ConnectionStatus { online, reachable, offline }
 
@@ -160,6 +172,10 @@ class UserListNotifier extends Notifier<List<User>> {
     final newUsers = users.where((u) => !existingIds.contains(u.idBase58)).toList();
     if (newUsers.isEmpty) return;
     state = [...state, ...newUsers];
+  }
+
+  void replaceAll(List<User> users) {
+    state = users;
   }
 }
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -214,13 +214,16 @@ class UserListNotifier extends PaginatedDataNotifier<User> {
 
   @override
   void update(User item) {
+    final data = <User>[];
+    for (final usr in state.data) {
+      if (usr.id != item.id && usr.idBase58 != item.idBase58) {
+        data.add(usr);
+      } else {
+        data.add(_mergeUser(usr, item));
+      }
+    }
     state = PaginatedData(
-      data: state.data.map((usr) {
-        if (usr.id != item.id && usr.idBase58 != item.idBase58) {
-          return usr;
-        }
-        return _mergeUser(usr, item);
-      }).toList(),
+      data: data,
       pagination: state.pagination,
     );
   }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/dtn_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/dtn_translator.dart
@@ -13,7 +13,7 @@ class DTNTranslator extends RpcModuleTranslator {
         // TODO
         return super.decodeMessageBytes(data, ref);
       case DTN_Message.dtnConfigResponse:
-        final users = ref.read(usersProvider);
+        final users = ref.read(usersProvider).data;
         final dtnConfiguration = DTNConfiguration.fromRpcConfigResponse(
           message.ensureDtnConfigResponse(),
           users,

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
@@ -6,7 +6,7 @@ class GroupTranslator extends RpcModuleTranslator {
 
   @override
   Future<RpcTranslatorResponse?> decodeMessageBytes(List<int> data, Ref ref) async {
-    final users = ref.read(usersProvider);
+    final users = ref.read(usersProvider).data;
     final message = Group.fromBuffer(data);
 
     switch (message.whichMessage()) {

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -94,16 +94,17 @@ class UsersTranslator extends RpcModuleTranslator {
     
     if (res.data is PaginatedUsers) {
       final paginatedUsers = res.data as PaginatedUsers;
-      final provider = ref.read(usersProvider.notifier);
+      final usersNotifier = ref.read(usersProvider.notifier);
       final isFirstPage = paginatedUsers.pagination?.offset == 0;
       if (isFirstPage) {
-        provider.state = paginatedUsers.users;
+        usersNotifier.replaceAll(paginatedUsers.users);
       }
       if (!isFirstPage) {
-        provider.appendMany(paginatedUsers.users);
+        usersNotifier.appendMany(paginatedUsers.users);
       }
-      ref.read(usersPaginationStateProvider.notifier).state =
-          paginatedUsers.pagination;
+      ref.read(usersPaginationStateProvider.notifier).setPagination(
+            paginatedUsers.pagination,
+          );
       return;
     }
     

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -25,10 +25,10 @@ class UsersTranslator extends RpcModuleTranslator {
                 ))
             .toList();
 
-        UsersPaginationState? pagination;
+        PaginationState? pagination;
         if (userList.hasPagination()) {
           final paginationMetadata = userList.pagination;
-          pagination = UsersPaginationState(
+          pagination = PaginationState(
             hasMore: paginationMetadata.hasMore,
             total: paginationMetadata.total,
             offset: paginationMetadata.offset,
@@ -97,13 +97,11 @@ class UsersTranslator extends RpcModuleTranslator {
       final usersNotifier = ref.read(usersProvider.notifier);
       final isFirstPage = paginatedUsers.pagination?.offset == 0;
       if (isFirstPage) {
-        usersNotifier.replaceAll(paginatedUsers.users);
+        usersNotifier.replaceAll(paginatedUsers.users, pagination: paginatedUsers.pagination);
       } else {
         usersNotifier.appendMany(paginatedUsers.users);
+        usersNotifier.setPagination(paginatedUsers.pagination);
       }
-      ref.read(usersPaginationStateProvider.notifier).setPagination(
-            paginatedUsers.pagination,
-          );
     } else if (res.data is SecurityNumber) {
       ref.read(currentSecurityNoProvider.notifier).state = res.data;
     }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -98,25 +98,13 @@ class UsersTranslator extends RpcModuleTranslator {
       final isFirstPage = paginatedUsers.pagination?.offset == 0;
       if (isFirstPage) {
         usersNotifier.replaceAll(paginatedUsers.users);
-      }
-      if (!isFirstPage) {
+      } else {
         usersNotifier.appendMany(paginatedUsers.users);
       }
       ref.read(usersPaginationStateProvider.notifier).setPagination(
             paginatedUsers.pagination,
           );
-      return;
-    }
-    
-    if (res.data is List<User>) {
-      final provider = ref.read(usersProvider.notifier);
-      for (final user in res.data) {
-        provider.contains(user) ? provider.update(user) : provider.add(user);
-      }
-      return;
-    }
-    
-    if (res.data is SecurityNumber) {
+    } else if (res.data is SecurityNumber) {
       ref.read(currentSecurityNoProvider.notifier).state = res.data;
     }
   }

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -70,7 +70,7 @@ class StubLibqaulWorker implements LibqaulWorker {
       },
     );
     final hasMore = end < _mockTotalUsers;
-    final pagination = UsersPaginationState(
+    final pagination = PaginationState(
       hasMore: hasMore,
       total: _mockTotalUsers,
       offset: requestedOffset,
@@ -78,11 +78,11 @@ class StubLibqaulWorker implements LibqaulWorker {
     );
     final notifier = ref.read(usersProvider.notifier);
     if (requestedOffset == 0) {
-      notifier.state = mockUsers;
+      notifier.replaceAll(mockUsers, pagination: pagination);
     } else {
       notifier.appendMany(mockUsers);
+      notifier.setPagination(pagination);
     }
-    ref.read(usersPaginationStateProvider.notifier).setPagination(pagination);
   }
 
   // -------------------------------------------

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -82,7 +82,7 @@ class StubLibqaulWorker implements LibqaulWorker {
     } else {
       notifier.appendMany(mockUsers);
     }
-    ref.read(usersPaginationStateProvider.notifier).state = pagination;
+    ref.read(usersPaginationStateProvider.notifier).setPagination(pagination);
   }
 
   // -------------------------------------------

--- a/qaul_ui/test/users_tab_test.dart
+++ b/qaul_ui/test/users_tab_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
-import 'package:qaul_ui/providers/providers.dart';
 import 'package:qaul_ui/screens/home/tabs/tab.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/qaul_ui/test/users_tab_test.dart
+++ b/qaul_ui/test/users_tab_test.dart
@@ -35,7 +35,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 150));
     await tester.pumpAndSettle();
 
-    final users = container.read(usersProvider);
+    final users = container.read(usersProvider).data;
     expect(users.length, 50);
     expect(users.first.name, 'Mock User 1');
     expect(find.byType(ListView), findsOneWidget);
@@ -61,8 +61,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 150));
     await tester.pumpAndSettle();
 
-    expect(container.read(usersProvider).length, 50);
-    expect(container.read(usersProvider).first.name, 'Mock User 1');
+    expect(container.read(usersProvider).data.length, 50);
+    expect(container.read(usersProvider).data.first.name, 'Mock User 1');
 
     for (int i = 0; i < 6; i++) {
       await tester.drag(find.byType(ListView), const Offset(0, -500));
@@ -71,7 +71,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
     await tester.pumpAndSettle();
 
-    final usersAfterScroll = container.read(usersProvider);
+    final usersAfterScroll = container.read(usersProvider).data;
     expect(usersAfterScroll.length, greaterThan(50));
     expect(
       usersAfterScroll.any((user) => user.name == 'Mock User 51'),
@@ -98,14 +98,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 150));
     await tester.pumpAndSettle();
 
-    final pagination = container.read(usersPaginationStateProvider);
+    final pagination = container.read(usersProvider).pagination;
     expect(pagination, isNotNull);
     expect(pagination!.hasMore, isTrue);
     expect(pagination.total, 125);
     expect(pagination.offset, 0);
     expect(pagination.limit, 50);
 
-    final users = container.read(usersProvider);
+    final users = container.read(usersProvider).data;
     expect(users.length, 50);
   });
 }

--- a/qaul_ui/test/users_tab_test.dart
+++ b/qaul_ui/test/users_tab_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/screens/home/tabs/tab.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'chat_tab/chat_tab_test.dart';
+import 'test_utils/test_utils.dart';
+
+void main() {
+  late Key usersKey;
+
+  setUp(() {
+    usersKey = UniqueKey();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('Users tab loads first page and shows mock users', (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final widget = UncontrolledProviderScope(
+      container: container,
+      child: materialAppWithLocalizations(BaseTab.users(key: usersKey)),
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.pumpAndSettle();
+
+    final users = container.read(usersProvider);
+    expect(users.length, 50);
+    expect(users.first.name, 'Mock User 1');
+    expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('Users tab loads more users when scrolling near bottom',
+      (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final widget = UncontrolledProviderScope(
+      container: container,
+      child: materialAppWithLocalizations(BaseTab.users(key: usersKey)),
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.pumpAndSettle();
+
+    expect(container.read(usersProvider).length, 50);
+    expect(container.read(usersProvider).first.name, 'Mock User 1');
+
+    for (int i = 0; i < 6; i++) {
+      await tester.drag(find.byType(ListView), const Offset(0, -500));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+
+    final usersAfterScroll = container.read(usersProvider);
+    expect(usersAfterScroll.length, greaterThan(50));
+    expect(
+      usersAfterScroll.any((user) => user.name == 'Mock User 51'),
+      isTrue,
+    );
+  });
+
+  testWidgets('Users tab shows pagination state after first load', (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final widget = UncontrolledProviderScope(
+      container: container,
+      child: materialAppWithLocalizations(BaseTab.users(key: usersKey)),
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.pumpAndSettle();
+
+    final pagination = container.read(usersPaginationStateProvider);
+    expect(pagination, isNotNull);
+    expect(pagination!.hasMore, isTrue);
+    expect(pagination.total, 125);
+    expect(pagination.offset, 0);
+    expect(pagination.limit, 50);
+
+    final users = container.read(usersProvider);
+    expect(users.length, 50);
+  });
+}


### PR DESCRIPTION
## Description

This PR adds pagination to the user list in the Users tab. Instead of loading all users at once, the app now requests users in pages ([thanks to this change](https://github.com/qaul/qaul.net/pull/745)). When the user scrolls near the bottom of the list, the next page is loaded and appended. Pull-to-refresh resets to the first page. This reduces initial load and memory use when many users are present.

## Changes

### Users tab UI (`users_tab.dart`)
- Initial load requests the first page (`offset: 0`, `limit: _pageSize` with `_pageSize = 50`) in a post-frame callback.
- Scroll listener triggers `_loadMoreUsers()` when the user reaches 80% of the scroll extent; it requests the next page using the current offset and the same limit.
- Pull-to-refresh resets offset and `hasMore`, then requests the first page again.
- `ref.listen(usersPaginationStateProvider)` updates `_hasMore` when the backend reports no more pages.
- `_updatePaginationState()` keeps `_currentOffset` and `_hasMore` in sync with the last pagination response (including after `getUsers` returns).
- List shows a loading indicator at the bottom while a page is loading and hides it when there are no more pages.
