### PR TITLE
[Part 1] Navbar Redesign 

### DIFF
--- a/qaul_ui/test/decorators/nav_bar_test_stubs.dart
+++ b/qaul_ui/test/decorators/nav_bar_test_stubs.dart
@@ -1,0 +1,74 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:local_notifications/local_notifications.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final _stubPublicMessagesProvider = Provider<List<PublicPost>>((ref) => []);
+
+final _stubChatRoomsProvider = Provider<List<ChatRoom>>((ref) => []);
+
+class StubPublicNotificationController extends PublicNotificationController {
+  StubPublicNotificationController(super.ref);
+
+  @override
+  String get cacheKey => 'stub_public';
+
+  @override
+  MapEntry<dynamic, void Function(List<PublicPost>?, List<PublicPost>)>
+      get strategy => MapEntry(_stubPublicMessagesProvider, (_, _) {});
+
+  @override
+  Future<void> initialize() async {
+    await super.initialize();
+  }
+
+  @override
+  void updatePersistentCachedData() {}
+
+  @override
+  Iterable<PublicPost> entriesToBeProcessed(List<PublicPost> values) => [];
+
+  @override
+  LocalNotification? process(PublicPost value) => null;
+
+  @override
+  void close() {}
+}
+
+class StubChatNotificationController extends ChatNotificationController {
+  StubChatNotificationController(super.ref);
+
+  @override
+  String get cacheKey => 'stub_chat';
+
+  @override
+  MapEntry<dynamic, void Function(List<ChatRoom>?, List<ChatRoom>)>
+      get strategy => MapEntry(_stubChatRoomsProvider, (_, _) {});
+
+  @override
+  Future<void> initialize() async {
+    await super.initialize();
+  }
+
+  @override
+  Iterable<ChatRoom> entriesToBeProcessed(List<ChatRoom> values) => [];
+
+  @override
+  void execute(List<ChatRoom>? previous, List<ChatRoom> current) {}
+
+  @override
+  User get localUser => throw UnimplementedError();
+
+  @override
+  SharedPreferences get preferences => throw UnimplementedError();
+
+  @override
+  LocalNotification? process(ChatRoom value) => null;
+
+  @override
+  void removeNotifications() {}
+
+  @override
+  void updatePersistentCachedData() {}
+}

--- a/qaul_ui/test/decorators/qaul_nav_bar_decorator_test.dart
+++ b/qaul_ui/test/decorators/qaul_nav_bar_decorator_test.dart
@@ -1,0 +1,193 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/decorators/qaul_nav_bar_decorator.dart';
+import 'package:qaul_ui/l10n/app_localizations.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/qaul_app.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'nav_bar_test_stubs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final testUser = User(
+    name: 'Test User',
+    id: Uint8List.fromList('testUserId'.codeUnits),
+  );
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Widget buildDecorator() {
+    return ProviderScope(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => testUser),
+        publicNotificationControllerProvider.overrideWith(
+          (ref) => StubPublicNotificationController(ref),
+        ),
+        chatNotificationControllerProvider.overrideWith(
+          (ref) => StubChatNotificationController(ref),
+        ),
+      ],
+      child: MaterialApp(
+        theme: QaulApp.lightTheme,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Material(
+          child: QaulNavBarDecorator(
+            child: (pageViewKey) => SizedBox(key: pageViewKey),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('QaulNavBarDecorator', () {
+    testWidgets('on mobile shows nav bar and five tab items', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildDecorator());
+
+      expect(find.byType(QaulNavBarItem), findsNWidgets(5));
+    });
+
+    testWidgets('on mobile shows overflow menu', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildDecorator());
+
+      expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+    });
+
+    testWidgets('on mobile shows main content area', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildDecorator());
+
+      expect(find.byType(Expanded), findsWidgets);
+    });
+
+    testWidgets('child builder is used and receives a key', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      GlobalKey? capturedKey;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            defaultUserProvider.overrideWith((_) => testUser),
+            publicNotificationControllerProvider.overrideWith(
+              (ref) => StubPublicNotificationController(ref),
+            ),
+            chatNotificationControllerProvider.overrideWith(
+              (ref) => StubChatNotificationController(ref),
+            ),
+          ],
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Material(
+              child: QaulNavBarDecorator(
+                child: (key) {
+                  capturedKey = key;
+                  return SizedBox(key: key);
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(capturedKey, isNotNull);
+      expect(find.byKey(capturedKey!), findsOneWidget);
+    });
+
+    testWidgets('on mobile shows notification badge when public count is non-zero', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      late StubPublicNotificationController publicStub;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            defaultUserProvider.overrideWith((_) => testUser),
+            publicNotificationControllerProvider.overrideWith((ref) {
+              publicStub = StubPublicNotificationController(ref);
+              return publicStub;
+            }),
+            chatNotificationControllerProvider.overrideWith(
+              (ref) => StubChatNotificationController(ref),
+            ),
+          ],
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Material(
+              child: QaulNavBarDecorator(
+                child: (pageViewKey) => SizedBox(key: pageViewKey),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      publicStub.newNotificationCount.value = 2;
+      await tester.pump();
+
+      expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets('overflow menu opens and shows six options', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildDecorator());
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PopupMenuItem<String>), findsNWidgets(6));
+    });
+
+    testWidgets('selecting overflow menu item navigates to route', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      const settingsKey = Key('settings_placeholder');
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            defaultUserProvider.overrideWith((_) => testUser),
+            publicNotificationControllerProvider.overrideWith(
+              (ref) => StubPublicNotificationController(ref),
+            ),
+            chatNotificationControllerProvider.overrideWith(
+              (ref) => StubChatNotificationController(ref),
+            ),
+          ],
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            initialRoute: '/',
+            routes: {
+              '/': (_) => Material(
+                child: QaulNavBarDecorator(
+                  child: (key) => SizedBox(key: key),
+                ),
+              ),
+              '/settings': (_) => Material(child: SizedBox(key: settingsKey)),
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byWidgetPredicate(
+        (w) => w is PopupMenuItem<String> && w.value == 'settings',
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(settingsKey), findsOneWidget);
+    });
+  });
+}

--- a/qaul_ui/test/decorators/qaul_nav_bar_item_test.dart
+++ b/qaul_ui/test/decorators/qaul_nav_bar_item_test.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/decorators/qaul_nav_bar_decorator.dart';
+import 'package:qaul_ui/l10n/app_localizations.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/qaul_app.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'nav_bar_test_stubs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final testUser = User(
+    name: 'Test User',
+    id: Uint8List.fromList('testUserId'.codeUnits),
+  );
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Widget wrapNavBarItem(TabType tab) {
+    return ProviderScope(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => testUser),
+        publicNotificationControllerProvider.overrideWith(
+          (ref) => StubPublicNotificationController(ref),
+        ),
+        chatNotificationControllerProvider.overrideWith(
+          (ref) => StubChatNotificationController(ref),
+        ),
+      ],
+      child: MaterialApp(
+        theme: QaulApp.lightTheme,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Material(
+          child: QaulNavBarItem(tab),
+        ),
+      ),
+    );
+  }
+
+  group('QaulNavBarItem', () {
+    testWidgets('account tab shows avatar', (tester) async {
+      await tester.pumpWidget(wrapNavBarItem(TabType.account));
+
+      expect(find.byType(CircleAvatar), findsOneWidget);
+    });
+
+    testWidgets('public tab renders', (tester) async {
+      await tester.pumpWidget(wrapNavBarItem(TabType.public));
+
+      expect(find.byType(QaulNavBarItem), findsOneWidget);
+    });
+
+    testWidgets('users tab renders', (tester) async {
+      await tester.pumpWidget(wrapNavBarItem(TabType.users));
+
+      expect(find.byType(QaulNavBarItem), findsOneWidget);
+    });
+
+    testWidgets('chat tab renders', (tester) async {
+      await tester.pumpWidget(wrapNavBarItem(TabType.chat));
+
+      expect(find.byType(QaulNavBarItem), findsOneWidget);
+    });
+
+    testWidgets('network tab renders', (tester) async {
+      await tester.pumpWidget(wrapNavBarItem(TabType.network));
+
+      expect(find.byType(QaulNavBarItem), findsOneWidget);
+    });
+
+    testWidgets('tapping account tab switches to account', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            defaultUserProvider.overrideWith((_) => testUser),
+            publicNotificationControllerProvider.overrideWith(
+              (ref) => StubPublicNotificationController(ref),
+            ),
+            chatNotificationControllerProvider.overrideWith(
+              (ref) => StubChatNotificationController(ref),
+            ),
+          ],
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Material(
+              child: Column(
+                children: [
+                  QaulNavBarItem(TabType.account),
+                  Expanded(
+                    child: Consumer(
+                      builder: (context, ref, _) {
+                        final currentTab =
+                            ref.watch(homeScreenControllerProvider);
+                        return Text('current:$currentTab');
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('current:TabType.public'), findsOneWidget);
+
+      await tester.tap(find.byType(QaulNavBarItem));
+      await tester.pump();
+
+      expect(find.text('current:TabType.account'), findsOneWidget);
+    });
+  });
+}

--- a/qaul_ui/test/widgets/qaul_avatar_test.dart
+++ b/qaul_ui/test/widgets/qaul_avatar_test.dart
@@ -1,0 +1,79 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/widgets/widgets.dart';
+
+import '../test_utils/test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final testUser = User(
+    name: 'Test User',
+    id: Uint8List.fromList('testUserId'.codeUnits),
+  );
+
+  Widget wrapWithProviders(Widget child) {
+    return ProviderScope(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => testUser),
+      ],
+      child: materialAppWithLocalizations(child),
+    );
+  }
+
+  group('QaulAvatar', () {
+    testWidgets('shows user initials when user is provided', (tester) async {
+      await tester.pumpWidget(
+        wrapWithProviders(QaulAvatar.tiny(user: testUser)),
+      );
+
+      expect(find.text('TU'), findsOneWidget);
+      expect(find.byType(CircleAvatar), findsOneWidget);
+    });
+
+    testWidgets('small and large variants show same initials', (tester) async {
+      await tester.pumpWidget(
+        wrapWithProviders(QaulAvatar.small(user: testUser)),
+      );
+      expect(find.text('TU'), findsOneWidget);
+
+      await tester.pumpWidget(
+        wrapWithProviders(QaulAvatar.large(user: testUser)),
+      );
+      expect(find.text('TU'), findsOneWidget);
+    });
+
+    testWidgets('shows default user initials when user is null', (tester) async {
+      await tester.pumpWidget(wrapWithProviders(QaulAvatar.small()));
+
+      expect(find.text('TU'), findsOneWidget);
+    });
+
+    testWidgets('small without badge still shows initials', (tester) async {
+      await tester.pumpWidget(
+        wrapWithProviders(
+          QaulAvatar.small(user: testUser, badgeEnabled: false),
+        ),
+      );
+
+      expect(find.text('TU'), findsOneWidget);
+      expect(find.byType(CircleAvatar), findsOneWidget);
+    });
+
+    testWidgets('groupSmall builds without throwing', (tester) async {
+      await tester.pumpWidget(wrapWithProviders(QaulAvatar.groupSmall()));
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('groupLarge builds without throwing', (tester) async {
+      await tester.pumpWidget(wrapWithProviders(QaulAvatar.groupLarge()));
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description
Since the navbar in qaul is controlled by the same-name decorator: `qaul_ui/lib/decorators/qaul_nav_bar_decorator.dart`

We will start by introducing widget tests to establish a baseline for the public components:
- `QaulNavBarItem`
- `QaulNavBarDecorator`
- `QaulAvatar`