### PR TITLE
Fix unused code compile warnings in qaul-cli & libqaul's RTC module

### DIFF
--- a/rust/clients/cli/src/ble.rs
+++ b/rust/clients/cli/src/ble.rs
@@ -2,22 +2,27 @@
 // This software is published under the AGPLv3 license.
 
 //! # BLE Module
-//! 
+//!
 //! Control functions for the Bluetooth Low Energy Module.
 
-use prost::Message;
 use super::rpc::Rpc;
+use prost::Message;
 
 /// include generated protobuf RPC rust definition file
-mod proto { include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.ble.rs"); }
-mod proto_sys { include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.sys.ble.rs"); }
+mod proto {
+    include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.ble.rs");
+}
+#[allow(unused)]
+mod proto_sys {
+    include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.sys.ble.rs");
+}
 
 /// BLE Module Function Handling
 pub struct Ble {}
 
 impl Ble {
     /// CLI command interpretation
-    /// 
+    ///
     /// The CLI commands of BLE module are processed here
     pub fn cli(command: &str) {
         match command {
@@ -25,46 +30,40 @@ impl Ble {
             cmd if cmd.starts_with("info") => {
                 // create rpc message
                 let proto_message = proto::Ble {
-                    message: Some(proto::ble::Message::InfoRequest(
-                        proto::InfoRequest{}
-                    )),
+                    message: Some(proto::ble::Message::InfoRequest(proto::InfoRequest {})),
                 };
                 // send the message
                 Self::rpc_send(proto_message);
-            },
+            }
             // send start request for BLE module
             cmd if cmd.starts_with("start") => {
                 // create rpc message
                 let proto_message = proto::Ble {
-                    message: Some(proto::ble::Message::StartRequest(
-                        proto::StartRequest{}
-                    )),
+                    message: Some(proto::ble::Message::StartRequest(proto::StartRequest {})),
                 };
                 // send the message
                 Self::rpc_send(proto_message);
-            },
+            }
             // send stop request for BLE module
             cmd if cmd.starts_with("stop") => {
                 // create rpc message
                 let proto_message = proto::Ble {
-                    message: Some(proto::ble::Message::StopRequest(
-                        proto::StopRequest{}
-                    )),
+                    message: Some(proto::ble::Message::StopRequest(proto::StopRequest {})),
                 };
                 // send the message
                 Self::rpc_send(proto_message);
-            },
+            }
             // request discovered devices
             cmd if cmd.starts_with("discovered") => {
                 // create rpc message
                 let proto_message = proto::Ble {
                     message: Some(proto::ble::Message::DiscoveredRequest(
-                        proto::DiscoveredRequest{}
+                        proto::DiscoveredRequest {},
                     )),
                 };
                 // send the message
                 Self::rpc_send(proto_message);
-            },
+            }
             // unknown command
             _ => log::error!("unknown BLE command"),
         }
@@ -74,7 +73,9 @@ impl Ble {
     fn rpc_send(proto_message: proto::Ble) {
         // encode message
         let mut buf = Vec::with_capacity(proto_message.encoded_len());
-        proto_message.encode(&mut buf).expect("Vec<u8> provides capacity as needed");
+        proto_message
+            .encode(&mut buf)
+            .expect("Vec<u8> provides capacity as needed");
 
         // send message
         Rpc::send_message(buf, super::rpc::proto::Modules::Ble.into(), "".to_string());
@@ -84,7 +85,7 @@ impl Ble {
     fn print_info(info: proto::InfoResponse) {
         println!("Node small BLE ID: {:?}", info.small_id);
         println!("BLE module status: {}", info.status);
-        
+
         // decode device info
         match proto_sys::BleDeviceInfo::decode(&info.device_info[..]) {
             Ok(device) => {
@@ -93,24 +94,41 @@ impl Ble {
                     println!("Device ID: {}", device.id);
                     println!("Device Name: {}", device.name);
                     println!("Bluetooth On: {:?}", device.bluetooth_on);
-                    println!("Extended Advertisement Supported: {:?}", device.adv_extended);
+                    println!(
+                        "Extended Advertisement Supported: {:?}",
+                        device.adv_extended
+                    );
                     if device.adv_extended {
-                        println!("Extended Advertisements Bytes: {:?}", device.adv_extended_bytes);
+                        println!(
+                            "Extended Advertisements Bytes: {:?}",
+                            device.adv_extended_bytes
+                        );
                     }
                     println!("2M Supported: {:?}", device.le_2m);
                     println!("Audio Supported: {:?}", device.le_audio);
-                    println!("Periodic Advertisement Supported: {:?}", device.le_periodic_adv_support);
-                    println!("Multiple Advertisement Supported: {:?}", device.le_multiple_adv_support);
-                    println!("Offload Filer Supported: {:?}", device.offload_filter_support);
-                    println!("Offload Scan Batching Supported: {:?}", device.offload_scan_batching_support);
-                }
-                else {
+                    println!(
+                        "Periodic Advertisement Supported: {:?}",
+                        device.le_periodic_adv_support
+                    );
+                    println!(
+                        "Multiple Advertisement Supported: {:?}",
+                        device.le_multiple_adv_support
+                    );
+                    println!(
+                        "Offload Filer Supported: {:?}",
+                        device.offload_filter_support
+                    );
+                    println!(
+                        "Offload Scan Batching Supported: {:?}",
+                        device.offload_scan_batching_support
+                    );
+                } else {
                     println!("BLE not supported");
                 }
-            },
+            }
             Err(e) => {
                 log::error!("{:?}", e);
-            },
+            }
         }
     }
 
@@ -121,30 +139,28 @@ impl Ble {
     }
 
     /// Process received RPC message
-    /// 
+    ///
     /// Decodes received protobuf encoded binary RPC message
     /// of the BLE module.
     pub fn rpc(data: Vec<u8>) {
         match proto::Ble::decode(&data[..]) {
-            Ok(ble) => {
-                match ble.message {
-                    Some(proto::ble::Message::InfoResponse(info)) => {
-                        Self::print_info(info);
-                    }
-                    Some(proto::ble::Message::DiscoveredResponse(discovered)) => {
-                        Self::print_discovered(discovered);
-                    }
-                    Some(proto::ble::Message::RightsRequest(_)) => {
-                        log::error!("BLE rights requested");
-                    }
-                    _ => {
-                        log::error!("unprocessable RPC debug message");
-                    },
-                }    
+            Ok(ble) => match ble.message {
+                Some(proto::ble::Message::InfoResponse(info)) => {
+                    Self::print_info(info);
+                }
+                Some(proto::ble::Message::DiscoveredResponse(discovered)) => {
+                    Self::print_discovered(discovered);
+                }
+                Some(proto::ble::Message::RightsRequest(_)) => {
+                    log::error!("BLE rights requested");
+                }
+                _ => {
+                    log::error!("unprocessable RPC debug message");
+                }
             },
             Err(error) => {
                 log::error!("{:?}", error);
-            },
+            }
         }
     }
 }

--- a/rust/clients/cli/src/chat.rs
+++ b/rust/clients/cli/src/chat.rs
@@ -10,15 +10,19 @@ use prost::Message;
 use std::fmt;
 
 /// include generated protobuf RPC rust definition file
+#[allow(unused)]
 mod proto {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.chat.rs");
 }
+#[allow(unused)]
 mod proto_message {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.net.messaging.rs");
 }
+#[allow(unused)]
 mod proto_group {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.net.group.rs");
 }
+#[allow(unused)]
 mod proto_file {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.net.chatfile.rs");
 }

--- a/rust/clients/cli/src/group.rs
+++ b/rust/clients/cli/src/group.rs
@@ -13,6 +13,7 @@ mod proto {
 }
 
 /// include chat protobuf RPC file
+#[allow(unused)]
 mod proto_chat {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.chat.rs");
 }

--- a/rust/clients/cli/src/rtc.rs
+++ b/rust/clients/cli/src/rtc.rs
@@ -11,6 +11,7 @@ use std::fmt;
 mod proto {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.rpc.rtc.rs");
 }
+#[allow(unused)]
 mod proto_net {
     include!("../../../libqaul/src/rpc/protobuf_generated/rust/qaul.net.rtc.rs");
 }

--- a/rust/libqaul/src/services/mod.rs
+++ b/rust/libqaul/src/services/mod.rs
@@ -18,6 +18,7 @@ pub mod dtn;
 pub mod feed;
 pub mod group;
 pub mod messaging;
+#[allow(unused)]
 pub mod rtc;
 
 /// qaul Services


### PR DESCRIPTION
In the newest rust version, the compilation of qaul-cli produces many `unused code` compile warnings.
This PR fixes these warnings for qaul-cli and libqaul's RTC module.

part of #728 