### PR TITLE
[Part 2] Navbar Redesign - Refactor

### DIFF
--- a/qaul_ui/test/decorators/qaul_nav_bar_decorator_test.dart
+++ b/qaul_ui/test/decorators/qaul_nav_bar_decorator_test.dart
@@ -49,24 +49,12 @@ void main() {
   }
 
   group('QaulNavBarDecorator', () {
-    testWidgets('on mobile shows nav bar and five tab items', (tester) async {
+    testWidgets('composes nav bar and content area', (tester) async {
       await tester.binding.setSurfaceSize(const Size(400, 800));
       await tester.pumpWidget(buildDecorator());
 
+      expect(find.byType(QaulNavBar), findsOneWidget);
       expect(find.byType(QaulNavBarItem), findsNWidgets(5));
-    });
-
-    testWidgets('on mobile shows overflow menu', (tester) async {
-      await tester.binding.setSurfaceSize(const Size(400, 800));
-      await tester.pumpWidget(buildDecorator());
-
-      expect(find.byType(PopupMenuButton<String>), findsOneWidget);
-    });
-
-    testWidgets('on mobile shows main content area', (tester) async {
-      await tester.binding.setSurfaceSize(const Size(400, 800));
-      await tester.pumpWidget(buildDecorator());
-
       expect(find.byType(Expanded), findsWidgets);
     });
 
@@ -104,7 +92,7 @@ void main() {
       expect(find.byKey(capturedKey!), findsOneWidget);
     });
 
-    testWidgets('on mobile shows notification badge when public count is non-zero', (tester) async {
+    testWidgets('decorator shows notification badge when public count is non-zero', (tester) async {
       await tester.binding.setSurfaceSize(const Size(400, 800));
       late StubPublicNotificationController publicStub;
       await tester.pumpWidget(
@@ -138,16 +126,6 @@ void main() {
       expect(find.text('2'), findsOneWidget);
     });
 
-    testWidgets('overflow menu opens and shows six options', (tester) async {
-      await tester.binding.setSurfaceSize(const Size(400, 800));
-      await tester.pumpWidget(buildDecorator());
-
-      await tester.tap(find.byType(PopupMenuButton<String>));
-      await tester.pumpAndSettle();
-
-      expect(find.byType(PopupMenuItem<String>), findsNWidgets(6));
-    });
-
     testWidgets('selecting overflow menu item navigates to route', (tester) async {
       await tester.binding.setSurfaceSize(const Size(400, 800));
       const settingsKey = Key('settings_placeholder');
@@ -179,11 +157,11 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.tap(find.byWidgetPredicate((w) => w is PopupMenuButton));
       await tester.pumpAndSettle();
 
       await tester.tap(find.byWidgetPredicate(
-        (w) => w is PopupMenuItem<String> && w.value == 'settings',
+        (w) => w is PopupMenuItem<NavBarOverflowOption> && w.value == NavBarOverflowOption.settings,
       ));
       await tester.pumpAndSettle();
 

--- a/qaul_ui/test/widgets/qaul_nav_bar_test.dart
+++ b/qaul_ui/test/widgets/qaul_nav_bar_test.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/decorators/qaul_nav_bar_decorator.dart';
+import 'package:qaul_ui/l10n/app_localizations.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/qaul_app.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../decorators/nav_bar_test_stubs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final testUser = User(
+    name: 'Test User',
+    id: Uint8List.fromList('testUserId'.codeUnits),
+  );
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Map<NavBarOverflowOption, String> stubOverflowLabels() => {
+        NavBarOverflowOption.settings: 'Settings',
+        NavBarOverflowOption.about: 'About',
+        NavBarOverflowOption.license: 'License',
+        NavBarOverflowOption.support: 'Support',
+        NavBarOverflowOption.oldNetwork: 'Routing',
+        NavBarOverflowOption.files: 'Files',
+      };
+
+  Widget buildNavBar({required bool vertical}) {
+    return ProviderScope(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => testUser),
+        publicNotificationControllerProvider.overrideWith(
+          (ref) => StubPublicNotificationController(ref),
+        ),
+        chatNotificationControllerProvider.overrideWith(
+          (ref) => StubChatNotificationController(ref),
+        ),
+      ],
+      child: MaterialApp(
+        theme: QaulApp.lightTheme,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Material(
+          child: QaulNavBar(
+            vertical: vertical,
+            overflowMenuLabels: stubOverflowLabels(),
+            onOverflowSelected: (_) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('QaulNavBar', () {
+    testWidgets('shows five tab items', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildNavBar(vertical: false));
+
+      expect(find.byType(QaulNavBarItem), findsNWidgets(5));
+    });
+
+    testWidgets('shows overflow menu', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildNavBar(vertical: false));
+
+      expect(find.byWidgetPredicate((w) => w is PopupMenuButton), findsOneWidget);
+    });
+
+    testWidgets('overflow menu shows six options when opened', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(buildNavBar(vertical: false));
+
+      await tester.tap(find.byWidgetPredicate((w) => w is PopupMenuButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byWidgetPredicate((w) => w is PopupMenuItem), findsNWidgets(6));
+    });
+
+    testWidgets('invokes onOverflowSelected when menu item is tapped', (tester) async {
+      NavBarOverflowOption? selected;
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            defaultUserProvider.overrideWith((_) => testUser),
+            publicNotificationControllerProvider.overrideWith(
+              (ref) => StubPublicNotificationController(ref),
+            ),
+            chatNotificationControllerProvider.overrideWith(
+              (ref) => StubChatNotificationController(ref),
+            ),
+          ],
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Material(
+              child: QaulNavBar(
+                vertical: false,
+                overflowMenuLabels: stubOverflowLabels(),
+                onOverflowSelected: (option) => selected = option,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byWidgetPredicate((w) => w is PopupMenuButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('About'));
+      await tester.pumpAndSettle();
+
+      expect(selected, NavBarOverflowOption.about);
+    });
+  });
+}


### PR DESCRIPTION
## Description

### Replace magic strings with enums

#### Current behaviour:
`_overflowMenuOptions` and `_handleClick` use plain strings for menu/tab-related values even though `TabTyp`e (and similar concepts) already exist.

#### Required change:
Stop using string literals for these cases; use enums instead.
Note: Enums can be turned into strings via the .name property (e.g. Color.blue.name → 'blue'), so there is no need to keep string-based workarounds.

---

### Replace private bar builders with SafeArea + LayoutBuilder and extract QaulNavBar
Current behaviour: build delegates to _buildHorizontalBar and _buildVerticalBar, which rely on MediaQuery for layout/safe area.

#### Required change:

Use a `SafeArea` + `LayoutBuilder` so layout and safe insets are driven by the widget tree instead of manual `MediaQuery` checks.
Extract a `QaulNavBar` widget from the logic currently inside `_buildHorizontalBar` / `_buildVerticalBar`, so the bar is a single, reusable component that can be tested in isolation.

----

### Adjust tests
`QaulNavBarDecorator` tests: Refocus on integration: decorator composes the bar and content, manages global navigation state (e.g. overflow menu → routes), and passes the correct key to the child.