### PR TITLE
Feed message and user store improvements

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -19,6 +19,7 @@ import '../../../decorators/loading_decorator.dart';
 import '../../../decorators/search_user_decorator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../providers/providers.dart';
+import '../../../stores/stores.dart';
 import '../../../utils.dart';
 import '../../../widgets/qaul_dialog.dart';
 import '../../../widgets/qaul_fab.dart';

--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: no_logic_in_create_state
-import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -65,14 +65,9 @@ class _UsersState extends _BaseTabState<_Users> {
 
   Future<void> _refreshUsers() async {
     _currentOffset = 0;
-<<<<<<< HEAD
     setState(() => _hasMore = true);
     final worker = ref.read(qaulWorkerProvider);
     await worker.getUsers(offset: 0, limit: _pageSize);
-=======
-    _hasMore.value = true;
-    await ref.read(usersStoreProvider.notifier).getMoreUsers(0, limit: _pageSize);
->>>>>>> 000a7772 (refactor: update user loading logic to use usersStore and implement pagination handling)
     _updatePaginationState();
   }
 

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -53,8 +53,10 @@ class _UsersState extends _BaseTabState<_Users> {
 
     setState(() => _isLoadingMore = true);
     try {
-      final worker = ref.read(qaulWorkerProvider);
-      await worker.getUsers(offset: _currentOffset, limit: _pageSize);
+      await ref.read(usersStoreProvider.notifier).getMoreUsers(
+            _currentOffset,
+            limit: _pageSize,
+          );
       _updatePaginationState();
     } finally {
       if (mounted) setState(() => _isLoadingMore = false);
@@ -63,9 +65,14 @@ class _UsersState extends _BaseTabState<_Users> {
 
   Future<void> _refreshUsers() async {
     _currentOffset = 0;
+<<<<<<< HEAD
     setState(() => _hasMore = true);
     final worker = ref.read(qaulWorkerProvider);
     await worker.getUsers(offset: 0, limit: _pageSize);
+=======
+    _hasMore.value = true;
+    await ref.read(usersStoreProvider.notifier).getMoreUsers(0, limit: _pageSize);
+>>>>>>> 000a7772 (refactor: update user loading logic to use usersStore and implement pagination handling)
     _updatePaginationState();
   }
 

--- a/qaul_ui/lib/screens/home/tabs/users_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/users_tab.dart
@@ -84,18 +84,18 @@ class _UsersState extends _BaseTabState<_Users> {
       body: LoadingDecorator(
         isLoading: _isLoadingMore,
         child: RefreshIndicator(
-            onRefresh: () async => await _refreshUsers(),
-            child: SearchUserDecorator(builder: (_, users) {
-              return EmptyStateTextDecorator(
-                l10n.emptyUsersList,
-                isEmpty: users.isEmpty,
-                child: ListView.separated(
-                  controller: _scrollController,
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  itemCount: users.length,
-                  separatorBuilder: (_, _) => const Divider(height: 12.0),
-                  itemBuilder: (_, i) {
-                    final user = users[i];
+          onRefresh: () async => await _refreshUsers(),
+          child: SearchUserDecorator(builder: (_, users) {
+            return EmptyStateTextDecorator(
+              l10n.emptyUsersList,
+              isEmpty: users.isEmpty,
+              child: ListView.separated(
+                controller: _scrollController,
+                physics: const AlwaysScrollableScrollPhysics(),
+                itemCount: users.length,
+                separatorBuilder: (_, _) => const Divider(height: 12.0),
+                itemBuilder: (_, i) {
+                  final user = users[i];
                   var theme = Theme.of(context).textTheme;
                   var hasConnections =
                       user.availableTypes != null && user.availableTypes!.isNotEmpty;
@@ -130,12 +130,12 @@ class _UsersState extends _BaseTabState<_Users> {
                       tapRoutesToDetailsScreen: true,
                     ),
                   );
-                  },
-                ),
-              );
-            }),
-          ),
+                },
+              ),
+            );
+          }),
         ),
+      ),
     );
   }
 }

--- a/qaul_ui/lib/stores/feed_message_store.dart
+++ b/qaul_ui/lib/stores/feed_message_store.dart
@@ -1,0 +1,58 @@
+part of 'stores.dart';
+
+final feedMessageStoreProvider =
+    NotifierProvider<FeedMessageStore, List<FeedMessage>>(FeedMessageStore.new);
+
+class FeedMessage extends PublicPost {
+  final User author;
+  final String sentTimestamp;
+
+  // TODO
+  FeedMessage(PublicPost message, this.author, this.sentTimestamp) : super();
+}
+
+class FeedMessageStore extends Notifier<List<FeedMessage>> {
+  @override
+  build() {
+    _asyncInit();
+    return [];
+  }
+
+  void _asyncInit() async {
+    // TODO verify if should be .listen() instead of .watch()
+    final messages = ref.watch(publicMessagesProvider);
+    final users = ref.watch(usersStoreProvider);
+    final messagesWithUsers = messages.where(
+      (m) => users.map((u) => u.idBase58).contains(m.senderIdBase58 ?? ''),
+    );
+
+    final feedMessages = <FeedMessage>[];
+
+    for (final m in messagesWithUsers) {
+      if (m.senderIdBase58 == null) continue;
+      final author = await ref
+          .read(usersStoreProvider.notifier)
+          .getByUserID(m.senderIdBase58!);
+      if (author == null) continue;
+      var sentAt = describeFuzzyTimestamp(
+        m.sendTime,
+        locale: Locale.parse(Intl.defaultLocale ?? 'en'),
+      );
+      feedMessages.add(FeedMessage(m, author, sentAt));
+    }
+    state = feedMessages;
+  }
+
+  Future<void> refreshPublic() async {
+    final worker = ref.read(qaulWorkerProvider);
+    final indexes = state.map((e) => e.index ?? 1);
+    await worker.requestPublicMessages(
+      lastIndex: indexes.isEmpty ? null : indexes.reduce(math.max),
+    );
+  }
+
+  Future<void> sendMessage(String messageText) async {
+    final worker = ref.read(qaulWorkerProvider);
+    await worker.sendPublicMessage(messageText);
+  }
+}

--- a/qaul_ui/lib/stores/feed_message_store.dart
+++ b/qaul_ui/lib/stores/feed_message_store.dart
@@ -7,8 +7,17 @@ class FeedMessage extends PublicPost {
   final User author;
   final String sentTimestamp;
 
-  // TODO
-  FeedMessage(PublicPost message, this.author, this.sentTimestamp) : super();
+  FeedMessage(PublicPost message, this.author, this.sentTimestamp)
+      : super(
+          senderId: message.senderId,
+          index: message.index,
+          senderIdBase58: message.senderIdBase58,
+          messageId: message.messageId,
+          messageIdBase58: message.messageIdBase58,
+          content: message.content,
+          sendTime: message.sendTime,
+          receiveTime: message.receiveTime,
+        );
 }
 
 class FeedMessageStore extends Notifier<List<FeedMessage>> {
@@ -56,3 +65,5 @@ class FeedMessageStore extends Notifier<List<FeedMessage>> {
     await worker.sendPublicMessage(messageText);
   }
 }
+
+// 

--- a/qaul_ui/lib/stores/feed_message_store.dart
+++ b/qaul_ui/lib/stores/feed_message_store.dart
@@ -23,14 +23,15 @@ class FeedMessage extends PublicPost {
 class FeedMessageStore extends Notifier<List<FeedMessage>> {
   @override
   build() {
+    ref.listen(publicMessagesProvider, (_, _) => _asyncInit());
+    ref.listen(usersStoreProvider, (_, _) => _asyncInit());
     _asyncInit();
     return [];
   }
 
   void _asyncInit() async {
-    // TODO verify if should be .listen() instead of .watch()
-    final messages = ref.watch(publicMessagesProvider);
-    final users = ref.watch(usersStoreProvider);
+    final messages = ref.read(publicMessagesProvider);
+    final users = ref.read(usersStoreProvider);
     final messagesWithUsers = messages.where(
       (m) => users.map((u) => u.idBase58).contains(m.senderIdBase58 ?? ''),
     );

--- a/qaul_ui/lib/stores/feed_message_store.dart
+++ b/qaul_ui/lib/stores/feed_message_store.dart
@@ -31,20 +31,22 @@ class FeedMessageStore extends Notifier<List<FeedMessage>> {
 
   void _asyncInit() async {
     final messages = ref.read(publicMessagesProvider);
-    final users = ref.read(usersStoreProvider);
-    final messagesWithUsers = messages.where(
-      (m) => users.map((u) => u.idBase58).contains(m.senderIdBase58 ?? ''),
-    );
-
+    final knownUsers = ref.read(usersStoreProvider);
+    final authorById = <String, User>{
+      for (final u in knownUsers) u.idBase58: u,
+    };
+    final usersStore = ref.read(usersStoreProvider.notifier);
     final feedMessages = <FeedMessage>[];
 
-    for (final m in messagesWithUsers) {
+    for (final m in messages) {
       if (m.senderIdBase58 == null) continue;
-      final author = await ref
-          .read(usersStoreProvider.notifier)
-          .getByUserID(m.senderIdBase58!);
+      User? author = authorById[m.senderIdBase58];
+      if (author == null) {
+        author = await usersStore.getByUserID(m.senderIdBase58!);
+        if (author != null) authorById[m.senderIdBase58!] = author;
+      }
       if (author == null) continue;
-      var sentAt = describeFuzzyTimestamp(
+      final sentAt = describeFuzzyTimestamp(
         m.sendTime,
         locale: Locale.parse(Intl.defaultLocale ?? 'en'),
       );

--- a/qaul_ui/lib/stores/stores.dart
+++ b/qaul_ui/lib/stores/stores.dart
@@ -1,12 +1,14 @@
 // Barrel file
 
 import 'dart:math' as math;
+import 'dart:typed_data';
 
+import 'package:fast_base58/fast_base58.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:intl/locale.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:utils/utils.dart';
-import 'package:intl/locale.dart';
 
 part 'users_store.dart';
 part 'feed_message_store.dart';

--- a/qaul_ui/lib/stores/stores.dart
+++ b/qaul_ui/lib/stores/stores.dart
@@ -1,0 +1,12 @@
+// Barrel file
+
+import 'dart:math' as math;
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:utils/utils.dart';
+import 'package:intl/locale.dart';
+
+part 'users_store.dart';
+part 'feed_message_store.dart';

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -5,16 +5,14 @@ final usersStoreProvider = NotifierProvider<UsersStore, List<User>>(
 );
 
 class UsersStore extends Notifier<List<User>> {
+  static const int _firstPageLimit = 50;
+
   @override
   List<User> build() {
-    // TODO should only get first users page
-    // TODO (refactor out of users tab, i.e. anything that calls qaulWorker directly on qaul_ui/lib/screens/home/tabs/users_tab.dart)
-    final users = ref
-        .watch(usersProvider)
-        .data
-        .where((u) => !(u.isBlocked ?? false))
-        .toList();
-    return users;
+    final paginated = ref.watch(usersProvider);
+    final limit = paginated.pagination?.limit ?? _firstPageLimit;
+    final firstPage = paginated.data.take(limit).toList();
+    return firstPage.where((u) => !(u.isBlocked ?? false)).toList();
   }
 
   Future<User?> getByUserID(String idBase58) async {
@@ -29,8 +27,8 @@ class UsersStore extends Notifier<List<User>> {
     }
   }
 
-  Future<List<User>> getMoreUsers(int offset) async {
-    // TODO: needs to be refactored from qaul_ui/lib/screens/home/tabs/users_tab.dart
-    throw UnimplementedError("TODO must call libqaul worker with pagination controls");
+  Future<void> getMoreUsers(int offset, {int limit = 50}) async {
+    final worker = ref.read(qaulWorkerProvider);
+    await worker.getUsers(offset: offset, limit: limit);
   }
 }

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -1,0 +1,28 @@
+part of 'stores.dart';
+
+final usersStoreProvider = NotifierProvider<UsersStore, List<User>>(
+  UsersStore.new,
+);
+
+class UsersStore extends Notifier<List<User>> {
+  @override
+  List<User> build() {
+    // TODO should only get first users page
+    // TODO (refactor out of users tab, i.e. anything that calls qaulWorker directly on qaul_ui/lib/screens/home/tabs/users_tab.dart)
+    final users = ref
+        .watch(usersProvider)
+        .where((u) => !(u.isBlocked ?? false))
+        .toList();
+    return users;
+  }
+
+  Future<User?> getByUserID(String idBase58) async {
+    // TODO: first verify if user is in store state, otherwise fetch that individual using the new libqaul message
+    throw UnimplementedError("TODO must call libqaul worker with new message (to be created)");
+  }
+
+  Future<List<User>> getMoreUsers(int offset) async {
+    // TODO: needs to be refactored from qaul_ui/lib/screens/home/tabs/users_tab.dart
+    throw UnimplementedError("TODO must call libqaul worker with pagination controls");
+  }
+}

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -11,14 +11,22 @@ class UsersStore extends Notifier<List<User>> {
     // TODO (refactor out of users tab, i.e. anything that calls qaulWorker directly on qaul_ui/lib/screens/home/tabs/users_tab.dart)
     final users = ref
         .watch(usersProvider)
+        .data
         .where((u) => !(u.isBlocked ?? false))
         .toList();
     return users;
   }
 
   Future<User?> getByUserID(String idBase58) async {
-    // TODO: first verify if user is in store state, otherwise fetch that individual using the new libqaul message
-    throw UnimplementedError("TODO must call libqaul worker with new message (to be created)");
+    final match = state.where((u) => u.idBase58 == idBase58);
+    if (match.isNotEmpty) return match.first;
+    try {
+      final worker = ref.read(qaulWorkerProvider);
+      final userId = Uint8List.fromList(Base58Decode(idBase58));
+      return worker.getUserById(userId);
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<List<User>> getMoreUsers(int offset) async {

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -5,14 +5,10 @@ final usersStoreProvider = NotifierProvider<UsersStore, List<User>>(
 );
 
 class UsersStore extends Notifier<List<User>> {
-  static const int _firstPageLimit = 50;
-
   @override
   List<User> build() {
     final paginated = ref.watch(usersProvider);
-    final limit = paginated.pagination?.limit ?? _firstPageLimit;
-    final firstPage = paginated.data.take(limit).toList();
-    return firstPage.where((u) => !(u.isBlocked ?? false)).toList();
+    return paginated.data.where((u) => !(u.isBlocked ?? false)).toList();
   }
 
   Future<User?> getByUserID(String idBase58) async {

--- a/qaul_ui/packages/qaul_rpc/lib/src/generated/router/users.pb.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/generated/router/users.pb.dart
@@ -27,6 +27,8 @@ enum Users_Message {
   userUpdate,
   securityNumberRequest,
   securityNumberResponse,
+  getUserByIdRequest,
+  getUserByIdResponse,
   notSet
 }
 
@@ -39,6 +41,8 @@ class Users extends $pb.GeneratedMessage {
     UserEntry? userUpdate,
     SecurityNumberRequest? securityNumberRequest,
     SecurityNumberResponse? securityNumberResponse,
+    GetUserByIDRequest? getUserByIdRequest,
+    GetUserByIDResponse? getUserByIdResponse,
   }) {
     final result = create();
     if (userRequest != null) result.userRequest = userRequest;
@@ -49,6 +53,10 @@ class Users extends $pb.GeneratedMessage {
       result.securityNumberRequest = securityNumberRequest;
     if (securityNumberResponse != null)
       result.securityNumberResponse = securityNumberResponse;
+    if (getUserByIdRequest != null)
+      result.getUserByIdRequest = getUserByIdRequest;
+    if (getUserByIdResponse != null)
+      result.getUserByIdResponse = getUserByIdResponse;
     return result;
   }
 
@@ -68,13 +76,15 @@ class Users extends $pb.GeneratedMessage {
     4: Users_Message.userUpdate,
     5: Users_Message.securityNumberRequest,
     6: Users_Message.securityNumberResponse,
+    7: Users_Message.getUserByIdRequest,
+    8: Users_Message.getUserByIdResponse,
     0: Users_Message.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       _omitMessageNames ? '' : 'Users',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'qaul.rpc.users'),
       createEmptyInstance: create)
-    ..oo(0, [1, 2, 3, 4, 5, 6])
+    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8])
     ..aOM<UserRequest>(1, _omitFieldNames ? '' : 'userRequest',
         subBuilder: UserRequest.create)
     ..aOM<UserOnlineRequest>(2, _omitFieldNames ? '' : 'userOnlineRequest',
@@ -89,6 +99,10 @@ class Users extends $pb.GeneratedMessage {
     ..aOM<SecurityNumberResponse>(
         6, _omitFieldNames ? '' : 'securityNumberResponse',
         subBuilder: SecurityNumberResponse.create)
+    ..aOM<GetUserByIDRequest>(7, _omitFieldNames ? '' : 'getUserByIdRequest',
+        subBuilder: GetUserByIDRequest.create)
+    ..aOM<GetUserByIDResponse>(8, _omitFieldNames ? '' : 'getUserByIdResponse',
+        subBuilder: GetUserByIDResponse.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -115,6 +129,8 @@ class Users extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   @$pb.TagNumber(5)
   @$pb.TagNumber(6)
+  @$pb.TagNumber(7)
+  @$pb.TagNumber(8)
   Users_Message whichMessage() => _Users_MessageByTag[$_whichOneof(0)]!;
   @$pb.TagNumber(1)
   @$pb.TagNumber(2)
@@ -122,6 +138,8 @@ class Users extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   @$pb.TagNumber(5)
   @$pb.TagNumber(6)
+  @$pb.TagNumber(7)
+  @$pb.TagNumber(8)
   void clearMessage() => $_clearField($_whichOneof(0));
 
   /// User Request returns a user list
@@ -223,6 +241,142 @@ class Users extends $pb.GeneratedMessage {
   void clearSecurityNumberResponse() => $_clearField(6);
   @$pb.TagNumber(6)
   SecurityNumberResponse ensureSecurityNumberResponse() => $_ensure(5);
+
+  @$pb.TagNumber(7)
+  GetUserByIDRequest get getUserByIdRequest => $_getN(6);
+  @$pb.TagNumber(7)
+  set getUserByIdRequest(GetUserByIDRequest value) => $_setField(7, value);
+  @$pb.TagNumber(7)
+  $core.bool hasGetUserByIdRequest() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearGetUserByIdRequest() => $_clearField(7);
+  @$pb.TagNumber(7)
+  GetUserByIDRequest ensureGetUserByIdRequest() => $_ensure(6);
+
+  @$pb.TagNumber(8)
+  GetUserByIDResponse get getUserByIdResponse => $_getN(7);
+  @$pb.TagNumber(8)
+  set getUserByIdResponse(GetUserByIDResponse value) => $_setField(8, value);
+  @$pb.TagNumber(8)
+  $core.bool hasGetUserByIdResponse() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearGetUserByIdResponse() => $_clearField(8);
+  @$pb.TagNumber(8)
+  GetUserByIDResponse ensureGetUserByIdResponse() => $_ensure(7);
+}
+
+class GetUserByIDRequest extends $pb.GeneratedMessage {
+  factory GetUserByIDRequest({
+    $core.List<$core.int>? userId,
+  }) {
+    final result = create();
+    if (userId != null) result.userId = userId;
+    return result;
+  }
+
+  GetUserByIDRequest._();
+
+  factory GetUserByIDRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetUserByIDRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GetUserByIDRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'qaul.rpc.users'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        10, _omitFieldNames ? '' : 'userId', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetUserByIDRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetUserByIDRequest copyWith(
+          void Function(GetUserByIDRequest) updates) =>
+      super.copyWith((message) => updates(message as GetUserByIDRequest))
+          as GetUserByIDRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetUserByIDRequest create() => GetUserByIDRequest._();
+  @$core.override
+  GetUserByIDRequest createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static GetUserByIDRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GetUserByIDRequest>(create);
+  static GetUserByIDRequest? _defaultInstance;
+
+  @$pb.TagNumber(10)
+  $core.List<$core.int> get userId => $_getN(0);
+  @$pb.TagNumber(10)
+  set userId($core.List<$core.int> value) => $_setBytes(0, value);
+  @$pb.TagNumber(10)
+  $core.bool hasUserId() => $_has(0);
+  @$pb.TagNumber(10)
+  void clearUserId() => $_clearField(10);
+}
+
+class GetUserByIDResponse extends $pb.GeneratedMessage {
+  factory GetUserByIDResponse({
+    UserEntry? user,
+  }) {
+    final result = create();
+    if (user != null) result.user = user;
+    return result;
+  }
+
+  GetUserByIDResponse._();
+
+  factory GetUserByIDResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetUserByIDResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GetUserByIDResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'qaul.rpc.users'),
+      createEmptyInstance: create)
+    ..aOM<UserEntry>(10, _omitFieldNames ? '' : 'user',
+        subBuilder: UserEntry.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetUserByIDResponse clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetUserByIDResponse copyWith(
+          void Function(GetUserByIDResponse) updates) =>
+      super.copyWith((message) => updates(message as GetUserByIDResponse))
+          as GetUserByIDResponse;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetUserByIDResponse create() => GetUserByIDResponse._();
+  @$core.override
+  GetUserByIDResponse createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static GetUserByIDResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GetUserByIDResponse>(create);
+  static GetUserByIDResponse? _defaultInstance;
+
+  @$pb.TagNumber(10)
+  UserEntry get user => $_getN(0);
+  @$pb.TagNumber(10)
+  set user(UserEntry value) => $_setField(10, value);
+  @$pb.TagNumber(10)
+  $core.bool hasUser() => $_has(0);
+  @$pb.TagNumber(10)
+  void clearUser() => $_clearField(10);
+  @$pb.TagNumber(10)
+  UserEntry ensureUser() => $_ensure(0);
 }
 
 /// UI request for some users

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -214,13 +214,16 @@ class UserListNotifier extends PaginatedDataNotifier<User> {
 
   @override
   void update(User item) {
+    final data = <User>[];
+    for (final usr in state.data) {
+      if (usr.id != item.id && usr.idBase58 != item.idBase58) {
+        data.add(usr);
+      } else {
+        data.add(_mergeUser(usr, item));
+      }
+    }
     state = PaginatedData(
-      data: state.data.map((usr) {
-        if (usr.id != item.id && usr.idBase58 != item.idBase58) {
-          return usr;
-        }
-        return _mergeUser(usr, item);
-      }).toList(),
+      data: data,
       pagination: state.pagination,
     );
   }

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -214,16 +214,13 @@ class UserListNotifier extends PaginatedDataNotifier<User> {
 
   @override
   void update(User item) {
-    final data = <User>[];
-    for (final usr in state.data) {
-      if (usr.id != item.id && usr.idBase58 != item.idBase58) {
-        data.add(usr);
-      } else {
-        data.add(_mergeUser(usr, item));
-      }
-    }
     state = PaginatedData(
-      data: data,
+      data: state.data.map((usr) {
+        if (usr.id != item.id && usr.idBase58 != item.idBase58) {
+          return usr;
+        }
+        return _mergeUser(usr, item);
+      }).toList(),
       pagination: state.pagination,
     );
   }

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -243,6 +243,14 @@ class UserListNotifier extends PaginatedDataNotifier<User> {
       pagination: state.pagination,
     );
   }
+
+  @override
+  void replaceAll(List<User> users, {PaginationState? pagination}) {
+    state = PaginatedData(
+      data: users,
+      pagination: pagination ?? state.pagination,
+    );
+  }
 }
 
 class PaginatedUsers {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -245,9 +245,9 @@ class UserListNotifier extends PaginatedDataNotifier<User> {
   }
 
   @override
-  void replaceAll(List<User> users, {PaginationState? pagination}) {
+  void replaceAll(List<User> items, {PaginationState? pagination}) {
     state = PaginatedData(
-      data: users,
+      data: items,
       pagination: pagination ?? state.pagination,
     );
   }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -1,5 +1,10 @@
 part of 'abstract_rpc_module_translator.dart';
 
+class GetUserByIdResult {
+  final User? user;
+  GetUserByIdResult(this.user);
+}
+
 class UsersTranslator extends RpcModuleTranslator {
   @override
   Modules get type => Modules.USERS;
@@ -47,6 +52,23 @@ class UsersTranslator extends RpcModuleTranslator {
           securityNumberBlocks: res.securityNumberBlocks,
         );
         return RpcTranslatorResponse(type, secNo);
+      case Users_Message.getUserByIdResponse:
+        final res = message.ensureGetUserByIdResponse();
+        if (!res.hasUser()) {
+          return RpcTranslatorResponse(type, GetUserByIdResult(null));
+        }
+        final u = res.user;
+        final user = User(
+          name: u.name,
+          id: Uint8List.fromList(u.id),
+          conversationId: Uint8List.fromList(u.groupId),
+          keyBase58: u.keyBase58,
+          isBlocked: u.blocked,
+          isVerified: u.verified,
+          status: _mapFrom(u.connectivity),
+          availableTypes: _mapFromRoutingTable(u.connections),
+        );
+        return RpcTranslatorResponse(type, GetUserByIdResult(user));
       default:
         return super.decodeMessageBytes(data, ref);
     }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -97,12 +97,17 @@ class UsersTranslator extends RpcModuleTranslator {
       final usersNotifier = ref.read(usersProvider.notifier);
       final isFirstPage = paginatedUsers.pagination?.offset == 0;
       if (isFirstPage) {
-        usersNotifier.replaceAll(paginatedUsers.users, pagination: paginatedUsers.pagination);
+        usersNotifier.replaceAll(
+          paginatedUsers.users,
+          pagination: paginatedUsers.pagination,
+        );
       } else {
         usersNotifier.appendMany(paginatedUsers.users);
         usersNotifier.setPagination(paginatedUsers.pagination);
       }
-    } else if (res.data is SecurityNumber) {
+    }
+
+    if (res.data is SecurityNumber) {
       ref.read(currentSecurityNoProvider.notifier).state = res.data;
     }
   }

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -122,6 +122,9 @@ class StubLibqaulWorker implements LibqaulWorker {
   void getGroupInfo(Uint8List id) => throw UnimplementedError();
 
   @override
+  Future<User?> getUserById(Uint8List userId) => Future.value(null);
+
+  @override
   Future<void> getNodeInfo() => throw UnimplementedError();
 
   @override

--- a/qaul_ui/test/feed_message_store_test.dart
+++ b/qaul_ui/test/feed_message_store_test.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/stores/stores.dart';
+
+void main() {
+  group('FeedMessage (feed display and refresh)', () {
+    test('forwards message fields so feed shows content and refresh uses correct index', () {
+      final sendTime = DateTime(2025, 1, 15, 10, 0);
+      final receiveTime = DateTime(2025, 1, 15, 10, 1);
+      final message = PublicPost(
+        senderId: Uint8List.fromList([1, 2, 3]),
+        index: 42,
+        senderIdBase58: 'sender58',
+        messageId: Uint8List.fromList([4, 5, 6]),
+        messageIdBase58: 'msg58',
+        content: 'Hello feed',
+        sendTime: sendTime,
+        receiveTime: receiveTime,
+      );
+      final author = User(
+        name: 'Author',
+        id: Uint8List.fromList('author_id'.codeUnits),
+      );
+      const sentTimestamp = '2 min ago';
+
+      final feedMessage = FeedMessage(message, author, sentTimestamp);
+
+      expect(feedMessage.index, 42);
+      expect(feedMessage.content, 'Hello feed');
+      expect(feedMessage.author, author);
+      expect(feedMessage.sentTimestamp, sentTimestamp);
+    });
+  });
+}

--- a/qaul_ui/test/feed_message_store_test.dart
+++ b/qaul_ui/test/feed_message_store_test.dart
@@ -1,36 +1,186 @@
 import 'dart:typed_data';
 
+import 'package:fast_base58/fast_base58.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:qaul_ui/stores/stores.dart';
 
+import 'chat_tab/chat_tab_test.dart';
+
+List<PublicPost> _testPublicMessages = [];
+List<User> _testUsersForStore = [];
+PaginationState? _testPagination;
+Map<String, User?> _getUserByIdByBase58 = {};
+
+class _TestPublicPostListNotifier extends PublicPostListNotifier {
+  @override
+  List<PublicPost> build() => _testPublicMessages;
+}
+
+class _TestPaginatedUsersNotifier extends PaginatedDataNotifier<User> {
+  @override
+  PaginatedData<User> build() =>
+      PaginatedData(data: _testUsersForStore, pagination: _testPagination);
+}
+
+class _MockWorkerForGetByUserID extends StubLibqaulWorker {
+  _MockWorkerForGetByUserID(super.ref);
+  @override
+  Future<User?> getUserById(Uint8List userId) =>
+      Future.value(_getUserByIdByBase58[Base58Encode(userId)]);
+}
+
+ProviderContainer _container() => ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        publicMessagesProvider.overrideWith(() => _TestPublicPostListNotifier()),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith((ref) => _MockWorkerForGetByUserID(ref)),
+      ],
+    );
+
+Future<List<FeedMessage>> _readFeedAfterInit(ProviderContainer container) async {
+  container.read(feedMessageStoreProvider);
+  await Future.delayed(const Duration(milliseconds: 50));
+  return container.read(feedMessageStoreProvider);
+}
+
+PublicPost _post({
+  required String senderIdBase58,
+  required String content,
+  int index = 1,
+}) =>
+    PublicPost(
+      senderId: Uint8List.fromList(senderIdBase58.codeUnits),
+      index: index,
+      senderIdBase58: senderIdBase58,
+      messageId: Uint8List.fromList([index]),
+      messageIdBase58: 'msg_$index',
+      content: content,
+      sendTime: DateTime(2025, 1, 1),
+      receiveTime: DateTime(2025, 1, 1),
+    );
+
+User _user(String name, String id) => User(
+      name: name,
+      id: Uint8List.fromList(id.codeUnits),
+    );
+
 void main() {
-  group('FeedMessage (feed display and refresh)', () {
-    test('forwards message fields so feed shows content and refresh uses correct index', () {
-      final sendTime = DateTime(2025, 1, 15, 10, 0);
-      final receiveTime = DateTime(2025, 1, 15, 10, 1);
-      final message = PublicPost(
-        senderId: Uint8List.fromList([1, 2, 3]),
+  setUpAll(() async {
+    await initializeDateFormatting('en');
+  });
+
+  setUp(() {
+    Intl.defaultLocale = 'en';
+    _testPublicMessages = [];
+    _testUsersForStore = [];
+    _testPagination = null;
+    _getUserByIdByBase58 = {};
+  });
+
+  group('FeedMessage', () {
+    test('forwards index and content for feed and refresh', () {
+      final msg = PublicPost(
+        senderId: Uint8List.fromList([1]),
         index: 42,
-        senderIdBase58: 'sender58',
-        messageId: Uint8List.fromList([4, 5, 6]),
-        messageIdBase58: 'msg58',
-        content: 'Hello feed',
-        sendTime: sendTime,
-        receiveTime: receiveTime,
+        senderIdBase58: 's58',
+        messageId: Uint8List.fromList([2]),
+        messageIdBase58: 'm58',
+        content: 'Hi',
+        sendTime: DateTime(2025, 1, 1),
+        receiveTime: DateTime(2025, 1, 1),
       );
-      final author = User(
-        name: 'Author',
-        id: Uint8List.fromList('author_id'.codeUnits),
-      );
-      const sentTimestamp = '2 min ago';
+      final author = _user('A', 'id_a');
+      final fm = FeedMessage(msg, author, '1 min ago');
+      expect(fm.index, 42);
+      expect(fm.content, 'Hi');
+      expect(fm.author.idBase58, author.idBase58);
+    });
+  });
 
-      final feedMessage = FeedMessage(message, author, sentTimestamp);
+  group('FeedMessageStore', () {
+    test('empty messages → empty feed', () async {
+      _testPublicMessages = [];
+      final container = _container();
+      addTearDown(container.dispose);
+      final state = await _readFeedAfterInit(container);
+      expect(state, isEmpty);
+    });
 
-      expect(feedMessage.index, 42);
-      expect(feedMessage.content, 'Hello feed');
-      expect(feedMessage.author, author);
-      expect(feedMessage.sentTimestamp, sentTimestamp);
+    test('skips message when senderIdBase58 is null', () async {
+      _testPublicMessages = [
+        PublicPost(
+          senderId: null,
+          index: 1,
+          senderIdBase58: null,
+          messageId: Uint8List.fromList([1]),
+          messageIdBase58: 'm1',
+          content: 'No sender',
+          sendTime: DateTime(2025, 1, 1),
+          receiveTime: DateTime(2025, 1, 1),
+        ),
+      ];
+      final container = _container();
+      addTearDown(container.dispose);
+      final state = await _readFeedAfterInit(container);
+      expect(state, isEmpty);
+    });
+
+    test('excludes message when getByUserID returns null', () async {
+      _testPublicMessages = [_post(senderIdBase58: 'unknown', content: 'X')];
+      final container = _container();
+      addTearDown(container.dispose);
+      final state = await _readFeedAfterInit(container);
+      expect(state, isEmpty);
+    });
+
+    test('all unknown senders → empty feed', () async {
+      _testPublicMessages = [
+        _post(senderIdBase58: 'u1', content: 'A'),
+        _post(senderIdBase58: 'u2', content: 'B'),
+      ];
+      final container = _container();
+      addTearDown(container.dispose);
+      final state = await _readFeedAfterInit(container);
+      expect(state, isEmpty);
+    });
+
+    test('resolves author from store or getByUserID and excludes unknown', () async {
+      final u1 = _user('U1', 'id1');
+      final u2 = _user('U2', 'id2');
+      _testPublicMessages = [
+        _post(senderIdBase58: u1.idBase58, content: 'M1', index: 1),
+        _post(senderIdBase58: u2.idBase58, content: 'M2', index: 2),
+        _post(senderIdBase58: 'unknown', content: 'M3', index: 3),
+      ];
+      _testUsersForStore = [u1];
+      _getUserByIdByBase58 = {u2.idBase58: u2};
+
+      final container = _container();
+      addTearDown(container.dispose);
+      final state = await _readFeedAfterInit(container);
+
+      expect(state.length, 2);
+      expect(state.map((e) => e.author.idBase58), containsAll([u1.idBase58, u2.idBase58]));
+      expect(state.any((e) => e.content == 'M3'), isFalse);
+    });
+
+    test('single message with author from getByUserID', () async {
+      final u = _user('Single', 'single_id');
+      _testPublicMessages = [_post(senderIdBase58: u.idBase58, content: 'Only')];
+      _getUserByIdByBase58 = {u.idBase58: u};
+
+      final container = _container();
+      addTearDown(container.dispose);
+      final state = await _readFeedAfterInit(container);
+
+      expect(state.length, 1);
+      expect(state.single.author.idBase58, u.idBase58);
+      expect(state.single.content, 'Only');
     });
   });
 }

--- a/qaul_ui/test/users_store_test.dart
+++ b/qaul_ui/test/users_store_test.dart
@@ -8,11 +8,12 @@ import 'package:qaul_ui/stores/stores.dart';
 import 'chat_tab/chat_tab_test.dart';
 
 List<User> _testUsersForStore = [];
+PaginationState? _testPagination;
 
 class _TestPaginatedUsersNotifier extends PaginatedDataNotifier<User> {
   @override
   PaginatedData<User> build() =>
-      PaginatedData(data: _testUsersForStore, pagination: null);
+      PaginatedData(data: _testUsersForStore, pagination: _testPagination);
 }
 
 class _MockWorkerForGetByUserID extends StubLibqaulWorker {
@@ -23,12 +24,25 @@ class _MockWorkerForGetByUserID extends StubLibqaulWorker {
       Future.value(getUserByIdResult);
 }
 
+class _MockWorkerForGetMoreUsers extends StubLibqaulWorker {
+  _MockWorkerForGetMoreUsers(super.ref);
+  int? lastOffset;
+  int? lastLimit;
+  @override
+  Future<void> getUsers({int? offset, int? limit}) async {
+    lastOffset = offset;
+    lastLimit = limit;
+    return super.getUsers(offset: offset, limit: limit);
+  }
+}
+
 void main() {
   setUp(() {
     _testUsersForStore = [];
+    _testPagination = null;
   });
 
-  test('getByUserID returns user when found in store state', () async {
+  test('getByUserID returns author from first page so feed can display message', () async {
     final userInState = User(
       name: 'In State',
       id: Uint8List.fromList('user_in_state_id'.codeUnits),
@@ -53,7 +67,7 @@ void main() {
     expect(result.name, userInState.name);
   });
 
-  test('getByUserID calls worker and returns user when not in state', () async {
+  test('getByUserID fetches author via worker when not in first page', () async {
     final userFromWorker = User(
       name: 'From Worker',
       id: Uint8List.fromList('user_from_worker_id'.codeUnits),
@@ -80,8 +94,7 @@ void main() {
     expect(result.name, userFromWorker.name);
   });
 
-  test('getByUserID returns null when not in state and worker returns null',
-      () async {
+  test('getByUserID returns null when author unknown so feed skips message', () async {
     _testUsersForStore = [];
     final unknownIdBase58 =
         User(name: 'X', id: Uint8List.fromList('unknown'.codeUnits)).idBase58;
@@ -102,26 +115,7 @@ void main() {
     expect(result, isNull);
   });
 
-  test('getByUserID returns null on invalid base58', () async {
-    _testUsersForStore = [];
-
-    final container = ProviderContainer(
-      overrides: [
-        defaultUserProvider.overrideWith((_) => defaultUser),
-        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
-        qaulWorkerProvider.overrideWith(
-            (ref) => _MockWorkerForGetByUserID(ref, getUserByIdResult: null)),
-      ],
-    );
-    addTearDown(container.dispose);
-
-    final store = container.read(usersStoreProvider.notifier);
-    final result = await store.getByUserID('!!!invalid-base58!!!');
-
-    expect(result, isNull);
-  });
-
-  test('store state excludes blocked users', () async {
+  test('store state excludes blocked users so feed and list do not show them', () async {
     final normalUser = User(
       name: 'Normal',
       id: Uint8List.fromList('normal_id'.codeUnits),
@@ -148,5 +142,58 @@ void main() {
     expect(state.length, 1);
     expect(state.single.idBase58, normalUser.idBase58);
     expect(state.any((u) => u.idBase58 == blockedUser.idBase58), isFalse);
+  });
+
+  test('store state is first page only so feed uses getByUserID for rest', () async {
+    _testUsersForStore = List<User>.generate(
+      60,
+      (i) => User(
+        name: 'User $i',
+        id: Uint8List.fromList('user_$i'.codeUnits),
+      ),
+    );
+    _testPagination = const PaginationState(
+      hasMore: true,
+      total: 60,
+      offset: 0,
+      limit: 50,
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith(
+            (ref) => _MockWorkerForGetByUserID(ref, getUserByIdResult: null)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final state = container.read(usersStoreProvider);
+
+    expect(state.length, 50);
+  });
+
+  test('getMoreUsers calls worker with offset and limit so users tab can load more', () async {
+    _testUsersForStore = [];
+
+    late _MockWorkerForGetMoreUsers mockWorker;
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith((ref) {
+          mockWorker = _MockWorkerForGetMoreUsers(ref);
+          return mockWorker;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(usersStoreProvider.notifier).getMoreUsers(23,
+        limit: 10);
+
+    expect(mockWorker.lastOffset, 23);
+    expect(mockWorker.lastLimit, 10);
   });
 }

--- a/qaul_ui/test/users_store_test.dart
+++ b/qaul_ui/test/users_store_test.dart
@@ -1,0 +1,152 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/stores/stores.dart';
+
+import 'chat_tab/chat_tab_test.dart';
+
+List<User> _testUsersForStore = [];
+
+class _TestPaginatedUsersNotifier extends PaginatedDataNotifier<User> {
+  @override
+  PaginatedData<User> build() =>
+      PaginatedData(data: _testUsersForStore, pagination: null);
+}
+
+class _MockWorkerForGetByUserID extends StubLibqaulWorker {
+  _MockWorkerForGetByUserID(super.ref, {this.getUserByIdResult});
+  final User? getUserByIdResult;
+  @override
+  Future<User?> getUserById(Uint8List userId) =>
+      Future.value(getUserByIdResult);
+}
+
+void main() {
+  setUp(() {
+    _testUsersForStore = [];
+  });
+
+  test('getByUserID returns user when found in store state', () async {
+    final userInState = User(
+      name: 'In State',
+      id: Uint8List.fromList('user_in_state_id'.codeUnits),
+    );
+    _testUsersForStore = [userInState];
+
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith(
+            (ref) => _MockWorkerForGetByUserID(ref, getUserByIdResult: null)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final store = container.read(usersStoreProvider.notifier);
+    final result = await store.getByUserID(userInState.idBase58);
+
+    expect(result, isNotNull);
+    expect(result!.idBase58, userInState.idBase58);
+    expect(result.name, userInState.name);
+  });
+
+  test('getByUserID calls worker and returns user when not in state', () async {
+    final userFromWorker = User(
+      name: 'From Worker',
+      id: Uint8List.fromList('user_from_worker_id'.codeUnits),
+    );
+    _testUsersForStore = [];
+
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith(
+          (ref) =>
+              _MockWorkerForGetByUserID(ref, getUserByIdResult: userFromWorker),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final store = container.read(usersStoreProvider.notifier);
+    final result = await store.getByUserID(userFromWorker.idBase58);
+
+    expect(result, isNotNull);
+    expect(result!.idBase58, userFromWorker.idBase58);
+    expect(result.name, userFromWorker.name);
+  });
+
+  test('getByUserID returns null when not in state and worker returns null',
+      () async {
+    _testUsersForStore = [];
+    final unknownIdBase58 =
+        User(name: 'X', id: Uint8List.fromList('unknown'.codeUnits)).idBase58;
+
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith(
+            (ref) => _MockWorkerForGetByUserID(ref, getUserByIdResult: null)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final store = container.read(usersStoreProvider.notifier);
+    final result = await store.getByUserID(unknownIdBase58);
+
+    expect(result, isNull);
+  });
+
+  test('getByUserID returns null on invalid base58', () async {
+    _testUsersForStore = [];
+
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith(
+            (ref) => _MockWorkerForGetByUserID(ref, getUserByIdResult: null)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final store = container.read(usersStoreProvider.notifier);
+    final result = await store.getByUserID('!!!invalid-base58!!!');
+
+    expect(result, isNull);
+  });
+
+  test('store state excludes blocked users', () async {
+    final normalUser = User(
+      name: 'Normal',
+      id: Uint8List.fromList('normal_id'.codeUnits),
+    );
+    final blockedUser = User(
+      name: 'Blocked',
+      id: Uint8List.fromList('blocked_id'.codeUnits),
+      isBlocked: true,
+    );
+    _testUsersForStore = [normalUser, blockedUser];
+
+    final container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        usersProvider.overrideWith(() => _TestPaginatedUsersNotifier()),
+        qaulWorkerProvider.overrideWith(
+            (ref) => _MockWorkerForGetByUserID(ref, getUserByIdResult: null)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final state = container.read(usersStoreProvider);
+
+    expect(state.length, 1);
+    expect(state.single.idBase58, normalUser.idBase58);
+    expect(state.any((u) => u.idBase58 == blockedUser.idBase58), isFalse);
+  });
+}

--- a/qaul_ui/test/users_store_test.dart
+++ b/qaul_ui/test/users_store_test.dart
@@ -144,7 +144,7 @@ void main() {
     expect(state.any((u) => u.idBase58 == blockedUser.idBase58), isFalse);
   });
 
-  test('store state is first page only so feed uses getByUserID for rest', () async {
+  test('store state includes all loaded users so list and feed can use them', () async {
     _testUsersForStore = List<User>.generate(
       60,
       (i) => User(
@@ -171,7 +171,7 @@ void main() {
 
     final state = container.read(usersStoreProvider);
 
-    expect(state.length, 50);
+    expect(state.length, 60);
   });
 
   test('getMoreUsers calls worker with offset and limit so users tab can load more', () async {


### PR DESCRIPTION
## Description

This refactor moves feed and users list logic into a dedicated **stores** layer so the UI only consumes state. The public feed resolves authors on demand (from store or backend); the users list shows all loaded pages so new users appear at the end when scrolling. Tests for both stores were added or updated accordingly.

<details>
<summary><strong>Folder restructuring</strong></summary>

### New: `lib/stores/`

A new `lib/stores/` folder holds all store code that used to live in the UI or providers:

- **`lib/stores/stores.dart`** – Barrel file: imports shared deps (Riverpod, qaul_rpc, utils, intl) and declares `part 'users_store.dart';` and `part 'feed_message_store.dart';`. Store code is accessed via `package:qaul_ui/stores/stores.dart` (or relative `../../../stores/stores.dart` from tabs).
- **`lib/stores/users_store.dart`** – `UsersStore` (Notifier) and `usersStoreProvider`. Exposes the filtered list of users and `getByUserID` / `getMoreUsers`.
- **`lib/stores/feed_message_store.dart`** – `FeedMessageStore` (Notifier), `FeedMessage` model, and `feedMessageStoreProvider`. Builds the feed from public messages and resolved authors.

Only the tabs that need stores import them: `tab.dart` imports `stores.dart` (so `public_tab` and `users_tab` use the stores); `public_tab.dart` uses `feedMessageStoreProvider`, `users_tab.dart` uses `usersStoreProvider.notifier.getMoreUsers`. The rest of the app (providers, decorators, screens) stays unchanged except where it consumes these providers.

</details>

<details>
<summary><strong>FeedMessageStore</strong></summary>

### Before
The feed only showed messages whose sender was already in the users list. That list was filled when the user opened the Users tab, so the feed stayed empty or small until then.

### After
- FeedMessageStore builds the feed from all `publicMessagesProvider` messages.
- For each message it resolves the author: first from users already in `usersStoreProvider`, then via `usersStore.getByUserID(senderIdBase58)` when not in the map. Unknown authors are skipped.
- The feed works without opening the Users tab; authors are resolved on demand from the store or the backend.

</details>

<details>
<summary><strong>UsersStore and users list</strong></summary>

### Before
- UsersStore only exposed the first page of users (`paginated.data.take(limit)`), so when the user scrolled and loaded more, the new users were not shown.
- Feed depended on that same list, so it only showed messages from those first-page users.

### After
- UsersStore returns all loaded users from `usersProvider.data` (still filtered by non-blocked). Scrolling and `getMoreUsers` append pages; new users appear at the end of the list.
- Feed no longer depends on “having opened the Users tab”; it resolves authors via the store or getByUserID.

</details>

<details>
<summary><strong>Other changes</strong></summary>

- **UserListNotifier.replaceAll**: Parameter renamed from `users` to `items` to match the overridden method (fixes `avoid_renaming_method_parameters`).
- **users_store_test.dart**: “store state includes all loaded users” expects 60 when 60 users are loaded (store exposes full list, not first page only).

</details>