### PR TITLE
BLE GATT Messaging: Replace small_id with q8id

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,8 @@
         "mdns",
         "Merkle",
         "multiaddress",
+        "neighbour",
+        "neighbours",
         "peerid",
         "protobuf",
         "qaul",

--- a/protobuf/generated/rust/qaul.net.ble.rs
+++ b/protobuf/generated/rust/qaul.net.ble.rs
@@ -31,7 +31,7 @@ pub mod ble_message {
         Handshake(super::NoiseHandshake),
     }
 }
-/// Identfication Request
+/// Identification Request
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Identification {
     #[prost(bool, tag = "1")]

--- a/protobuf/generated/rust/qaul.rpc.ble.rs
+++ b/protobuf/generated/rust/qaul.rpc.ble.rs
@@ -39,9 +39,9 @@ pub struct InfoRequest {}
 /// as well as all available BLE devices
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InfoResponse {
-    /// the small 16 byte BLE id
+    /// the small 8 byte BLE id
     #[prost(bytes = "vec", tag = "1")]
-    pub small_id: ::prost::alloc::vec::Vec<u8>,
+    pub q8id: ::prost::alloc::vec::Vec<u8>,
     /// status of the module
     #[prost(string, tag = "2")]
     pub status: ::prost::alloc::string::String,

--- a/protobuf/generated/rust/qaul.sys.ble.rs
+++ b/protobuf/generated/rust/qaul.sys.ble.rs
@@ -166,7 +166,7 @@ pub struct BleDeviceInfo {
 pub struct BleStartRequest {
     /// qaul ID
     ///
-    /// The small 16 byte qaul id
+    /// The small 8 byte qaul id
     /// to be used to identify this node
     #[prost(bytes = "vec", tag = "1")]
     pub qaul_id: ::prost::alloc::vec::Vec<u8>,

--- a/protobuf/proto_definitions/connections/ble/ble.proto
+++ b/protobuf/proto_definitions/connections/ble/ble.proto
@@ -37,9 +37,7 @@ message Ble {
 }
 
 // device information request message
-message BleInfoRequest {
-
-}
+message BleInfoRequest {}
 
 // device information response message
 message BleInfoResponse {
@@ -49,14 +47,14 @@ message BleInfoResponse {
 
 // BLE device information
 message BleDeviceInfo {
-    // Check if Bluetooth / Bluetooth Low Energy is supported 
+    // Check if Bluetooth / Bluetooth Low Energy is supported
     //
     // Android: check if a bluetooth adapter is found
     bool ble_support = 1;
     // Bluetooth device address
     // 48 bit unique Bluetooth device addr
     // e.g. 80:86:F2:08:C7:98
-    // 
+    //
     // Android: BluetoothAdapter getAddress()
     // https://developer.android.com/reference/kotlin/android/bluetooth/BluetoothAdapter#getAddress()
     string id = 2;
@@ -69,7 +67,7 @@ message BleDeviceInfo {
     // Bluetooth is enable / powered on
     //
     // Android: BluetoothAdapter isEnabled()
-    // https://developer.android.com/reference/kotlin/android/bluetooth/BluetoothAdapter#isEnabled() 
+    // https://developer.android.com/reference/kotlin/android/bluetooth/BluetoothAdapter#isEnabled()
     bool bluetooth_on = 4;
     // Is extended advertisement supported?
     //
@@ -78,7 +76,7 @@ message BleDeviceInfo {
     bool adv_extended = 5;
     // what is the maximal amount of bytes sendable via advertising?
     //
-    // Android: BluetoothAdapter getLeMaximumAdvertisingDataLength() 
+    // Android: BluetoothAdapter getLeMaximumAdvertisingDataLength()
     // https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getLeMaximumAdvertisingDataLength()
     uint32 adv_extended_bytes = 6;
     // Is 2M phy supported?
@@ -113,7 +111,7 @@ message BleDeviceInfo {
     // Is multi advertisement supported?
     //
     // When multi advertisement is supported one can have different
-    // advertisement types parallely. Each advertisement has a 
+    // advertisement types parallely. Each advertisement has a
     // different device address.
     // For scanning devices it looks, as if multiple devices devices
     // would advertise themselves.
@@ -126,7 +124,7 @@ message BleDeviceInfo {
     // Android Specific: is Offloaded Filtering Supported?
     //
     // Android: BluetoothAdapter isOffloadedFilteringSupported()
-    // 
+    //
     bool offload_filter_support = 16;
     // Android Specific: is Offloaded Scan Batching Supported?
     //
@@ -143,15 +141,15 @@ message BleDeviceInfo {
 message BleStartRequest {
     // qaul ID
     //
-    // The small 16 byte qaul id
+    // The small 8 byte qaul id
     // to be used to identify this node
     bytes qaul_id = 1;
-    // power settings 
+    // power settings
     BlePowerSetting power_setting = 2;
 }
 
 // power settings
-// 
+//
 // These power settings relate to the android
 // power modes.
 enum BlePowerSetting {
@@ -171,7 +169,7 @@ enum BlePowerSetting {
 
 // Start device result message
 //
-// Feedback from the 
+// Feedback from the
 message BleStartResult {
     // whether the device was successfully started
     bool success = 1;
@@ -184,7 +182,7 @@ message BleStartResult {
 // BLE Error Reasons
 //
 // TODO: this list needs to be completed
-//       if none of the reasons apply, use 
+//       if none of the reasons apply, use
 //       UNKNOWN_ERROR
 enum BleError {
     // undefined error
@@ -199,9 +197,7 @@ enum BleError {
 }
 
 // Stop Bluetooth Device
-message BleStopRequest {
-
-}
+message BleStopRequest {}
 
 // Stop Result
 //
@@ -227,7 +223,7 @@ message BleDeviceDiscovered {
 
 // Device Unavailable
 //
-// A formerly discovered device has become 
+// A formerly discovered device has become
 // unavailable. No messages can be sent to it.
 message BleDeviceUnavailable {
     // qaul id of the device that

--- a/protobuf/proto_definitions/connections/ble/ble_net.proto
+++ b/protobuf/proto_definitions/connections/ble/ble_net.proto
@@ -21,9 +21,9 @@ message BleMessage {
     }
 }
 
-// Identfication Request
+// Identification Request
 message Identification {
-    bool request = 1;
+    bool request            = 1;
     NodeIdentification node = 2;
 }
 

--- a/protobuf/proto_definitions/connections/ble/ble_rpc.proto
+++ b/protobuf/proto_definitions/connections/ble/ble_rpc.proto
@@ -7,28 +7,27 @@ package qaul.rpc.ble;
 // via RPC between the UI and libqaul
 message Ble {
     oneof message {
-        InfoRequest info_request = 1;
-        InfoResponse info_response = 2;
-        StartRequest start_request = 3;
-        StopRequest stop_request = 4;
-        DiscoveredRequest discovered_request = 5;
+        InfoRequest info_request               = 1;
+        InfoResponse info_response             = 2;
+        StartRequest start_request             = 3;
+        StopRequest stop_request               = 4;
+        DiscoveredRequest discovered_request   = 5;
         DiscoveredResponse discovered_response = 6;
-        RightsRequest rights_request = 7;
-        RightsResult rights_result = 8;
+        RightsRequest rights_request           = 7;
+        RightsResult rights_result             = 8;
     }
 }
 
 // UI request for information on devices and module status
-message InfoRequest {
-}
+message InfoRequest {}
 
 // BLE Info Response Message
 //
 // Contains information on the status of the module,
-// as well as all available BLE devices 
+// as well as all available BLE devices
 message InfoResponse {
-    // the small 16 byte BLE id
-    bytes small_id = 1;
+    // the small 8 byte BLE id
+    bytes q8id = 1;
     // status of the module
     string status = 2;
     // devices
@@ -41,8 +40,7 @@ message InfoResponse {
 //
 // This message only has an effect if the module
 // has not already started.
-message StartRequest {
-}
+message StartRequest {}
 
 // Request BLE module to stop
 //
@@ -50,14 +48,12 @@ message StartRequest {
 //
 // This message only has an effect if the module
 // was started earlier and is running.
-message StopRequest {
-}
+message StopRequest {}
 
 // Request Discovered Nodes on BLE
 //
 // Message sent from UI to libqaul.
-message DiscoveredRequest {
-}
+message DiscoveredRequest {}
 
 // All Discovered Nodes
 //
@@ -70,9 +66,7 @@ message DiscoveredResponse {
 }
 
 // Request Rights
-message RightsRequest {
-
-}
+message RightsRequest {}
 
 // Rights Request Results
 message RightsResult {

--- a/qaul_ui/android/blemodule/.gitignore
+++ b/qaul_ui/android/blemodule/.gitignore
@@ -1,2 +1,3 @@
 /build
 /bin
+local.properties

--- a/qaul_ui/android/blemodule/src/main/proto/ble.proto
+++ b/qaul_ui/android/blemodule/src/main/proto/ble.proto
@@ -37,9 +37,7 @@ message Ble {
 }
 
 // device information request message
-message BleInfoRequest {
-
-}
+message BleInfoRequest {}
 
 // device information response message
 message BleInfoResponse {
@@ -59,13 +57,15 @@ message BleDeviceInfo {
     //
     // Android: BluetoothAdapter getAddress()
     // https://developer.android.com/reference/kotlin/android/bluetooth/BluetoothAdapter#getAddress()
-    string id = 2;  //We can not get macAddress of device because of permission issue.
+    // We can not get macAddress of device because of permission issue.
+    string id = 2;
     // Get Bluetooth Name
     // this is field is purely informative
     //
     // Android: BluetoothAdapter getName()
     // https://developer.android.com/reference/kotlin/android/bluetooth/BluetoothAdapter#getName()
-    string name = 3; //On Android 12+ if user not granted permission we can not get adapter name
+    string name = 3;  // On Android 12+ if user not granted permission we can
+                      // not get adapter name
     // Bluetooth is enable / powered on
     //
     // Android: BluetoothAdapter isEnabled()
@@ -143,7 +143,7 @@ message BleDeviceInfo {
 message BleStartRequest {
     // qaul ID
     //
-    // The small 16 byte qaul id
+    // The small 8 byte qaul id
     // to be used to identify this node
     bytes qaul_id = 1;
     // power settings
@@ -196,13 +196,10 @@ enum BleError {
     RIGHTS_MISSING = 1;
     // there was a module timeout
     TIMEOUT = 2;
-
 }
 
 // Stop Bluetooth Device
-message BleStopRequest {
-
-}
+message BleStopRequest {}
 
 // Stop Result
 //

--- a/rust/ble_module/src/ble/ble_service.rs
+++ b/rust/ble_module/src/ble/ble_service.rs
@@ -82,7 +82,7 @@ impl IdleBleService {
         }))
     }
 
-    ///Starts BLE advertisement, scan, and listen.
+    /// Starts BLE advertisement, scan, and listen.
     /// Manages streams for BLE events and messages.
     pub async fn advertise_scan_listen(
         mut self,

--- a/rust/clients/cli/Cargo.toml
+++ b/rust/clients/cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libqaul = { path = "../../libqaul" }
+libqaul = { path = "../../libqaul", features = ["rtc", "ble"] }
 qaul-proto = { path = "../../qaul-proto" }
 tokio = { version = "1", features = ["full", "io-std"] }
 futures = "0.3"

--- a/rust/clients/cli/src/ble.rs
+++ b/rust/clients/cli/src/ble.rs
@@ -78,7 +78,7 @@ impl Ble {
 
     /// Print BLE module information
     fn print_info(info: proto::InfoResponse) {
-        println!("Node small BLE ID: {:?}", info.small_id);
+        println!("Node small BLE ID: {:?}", info.q8id);
         println!("BLE module status: {}", info.status);
 
         // decode device info

--- a/rust/libp2p_modules/qaul_info/src/protocol.rs
+++ b/rust/libp2p_modules/qaul_info/src/protocol.rs
@@ -23,7 +23,7 @@ use crate::types::QaulInfoData;
 /// define maximal message length in bytes
 ///
 /// This length must not be exceeded. Packages exceeding this size will be discarded.
-const MAX_MESSAGE_LEN_BYTES: usize = 65536;
+const MAX_MESSAGE_LEN_BYTES: usize = 65535;
 
 /// create protocol name
 pub const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/qaul_info/1.0.0");

--- a/rust/libp2p_modules/qaul_messaging/src/protocol.rs
+++ b/rust/libp2p_modules/qaul_messaging/src/protocol.rs
@@ -23,7 +23,7 @@ use crate::types::QaulMessagingData;
 /// define maximal message length in bytes
 ///
 /// This length must not be exceeded. Packages exceeding this size will be discarded.
-const MAX_MESSAGE_LEN_BYTES: usize = 65536;
+const MAX_MESSAGE_LEN_BYTES: usize = 65535;
 
 /// create protocol name
 pub const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/qaul_messaging/1.0.0");

--- a/rust/libqaul/src/connections/ble/mod.rs
+++ b/rust/libqaul/src/connections/ble/mod.rs
@@ -26,12 +26,12 @@ use crate::utilities::{qaul_id::QaulId, timestamp::Timestamp};
 pub mod crypto;
 use crypto::BleCrypto;
 
-/// Protobuf BLE system communication with BLE module
-pub use qaul_proto::qaul_sys_ble as proto;
 /// Protobuf BLE network communication
 pub use qaul_proto::qaul_net_ble as proto_net;
 /// Protobuf BLE RPC communication
 pub use qaul_proto::qaul_rpc_ble as proto_rpc;
+/// Protobuf BLE system communication with BLE module
+pub use qaul_proto::qaul_sys_ble as proto;
 
 /// Module State
 static BLE: InitCell<RwLock<Ble>> = InitCell::new();
@@ -48,7 +48,7 @@ static NODES: InitCell<RwLock<BTreeMap<Vec<u8>, BleNode>>> = InitCell::new();
 #[allow(dead_code)]
 pub struct ToConfirm {
     // small id
-    small_id: Vec<u8>,
+    q8id: Vec<u8>,
     // detected at
     detected_at: u64,
     // status of it's detection
@@ -104,8 +104,8 @@ pub struct Ble {
 impl Ble {
     /// initialize the BLE module
     pub async fn init() {
-        // get small BLE ID
-        let ble_id = Node::get_small_id();
+        // get q8id
+        let ble_id = Node::get_q8id();
         #[cfg(all(target_os = "linux", feature = "ble"))]
         tokio::spawn(async move {
             while !ble_module::is_ble_enabled().await {
@@ -179,7 +179,7 @@ impl Ble {
             log::info!("This Devices ID");
             let node_id = Node::get_id();
             log::info!("- Node ID: {}", node_id.to_base58());
-            log::info!("- Small Node ID: {:?}", QaulId::to_small(node_id));
+            log::info!("- Small Node ID: {:?}", QaulId::to_q8id(node_id));
             log::info!("-------------------------");
             log::info!("BLE Supported: {}", device.ble_support);
             log::info!("ID: {}", device.id);
@@ -350,7 +350,7 @@ impl Ble {
     ///
     /// * BLE translation table
     /// * BLE Neighbours list
-    fn node_discovered(small_id: Vec<u8>, node_id: Vec<u8>) {
+    fn node_discovered(q8id: Vec<u8>, node_id: Vec<u8>) {
         log::info!("BLE node discovered");
 
         // create node entry
@@ -365,7 +365,7 @@ impl Ble {
             let mut nodes = NODES.get().write().unwrap();
 
             // add node
-            nodes.insert(small_id, node.clone());
+            nodes.insert(q8id, node.clone());
         }
 
         // add it to neighbours table
@@ -381,16 +381,16 @@ impl Ble {
     }
 
     /// add a node to the available nodes list
-    fn node_to_confirm(small_id: Vec<u8>) {
+    fn node_to_confirm(q8id: Vec<u8>) {
         // check if node confirmation request has already been sent
-        if let true = Self::node_confirmation_in_progress(&small_id) {
+        if let true = Self::node_confirmation_in_progress(&q8id) {
             log::info!("node id confirmation in progress");
             return;
         }
 
         // create node entry
         let confirm = ToConfirm {
-            small_id: small_id.clone(),
+            q8id: q8id.clone(),
             detected_at: Timestamp::get_timestamp(),
             status: 0,
         };
@@ -399,19 +399,19 @@ impl Ble {
         let mut nodes = TO_CONFIRM.get().write().unwrap();
 
         // add node
-        nodes.insert(small_id.clone(), confirm);
+        nodes.insert(q8id.clone(), confirm);
 
         // send identification message
-        Self::identification_send(small_id, true);
+        Self::identification_send(q8id, true);
     }
 
     /// Check if node is already scheduled for confirmation
-    fn node_confirmation_in_progress(small_id: &Vec<u8>) -> bool {
+    fn node_confirmation_in_progress(q8id: &Vec<u8>) -> bool {
         // get state
         let nodes = TO_CONFIRM.get().read().unwrap();
 
         // search node
-        if let Some(to_confirm) = nodes.get(small_id) {
+        if let Some(to_confirm) = nodes.get(q8id) {
             if to_confirm.detected_at > Timestamp::get_timestamp() - (30 * 1000) {
                 return true;
             }
@@ -422,9 +422,9 @@ impl Ble {
 
     /// a new device got discovered via bluetooth
     fn device_discovered(message: proto::BleDeviceDiscovered) {
-        log::info!("BLE device discovered: {:?}", message.qaul_id.clone());
+        log::info!("BLE device discovered: {:x?}", message.qaul_id.clone());
         // check if node is known
-        if let Some(node) = Neighbours::node_from_small_id(message.qaul_id.clone()) {
+        if let Some(node) = Neighbours::node_from_q8id(message.qaul_id.clone()) {
             log::info!(
                 "BLE discovered Node ID: {}",
                 QaulId::bytes_to_log_string(&node.id)
@@ -475,15 +475,15 @@ impl Ble {
     /// Identification Received
     ///
     /// Received identity information from another node
-    fn identification_received(small_id: Vec<u8>, identification: proto_net::Identification) {
-        log::info!("BLE identification received from {:?}", small_id.clone());
+    fn identification_received(q8id: Vec<u8>, identification: proto_net::Identification) {
+        log::info!("BLE identification received from {:?}", q8id.clone());
 
         // add node id
         if let Some(node) = identification.node {
             // remove node from to_confirm
             {
                 let mut to_confirm = TO_CONFIRM.get().write().unwrap();
-                to_confirm.remove_entry(&small_id);
+                to_confirm.remove_entry(&q8id);
             }
 
             // Get the PeerId for the remote node
@@ -496,16 +496,16 @@ impl Ble {
             };
 
             // add node to discovered lists
-            Self::node_discovered(small_id.clone(), node.id);
+            Self::node_discovered(q8id.clone(), node.id);
 
             // check if to send a response
             if identification.request {
-                Self::identification_send(small_id.clone(), false);
+                Self::identification_send(q8id.clone(), false);
             }
 
             // Initiate encrypted handshake after identification
-            if let Some(handshake_msg) = BleCrypto::initiate_handshake(&small_id, remote_id) {
-                Self::send_handshake_message(small_id, handshake_msg);
+            if let Some(handshake_msg) = BleCrypto::initiate_handshake(&q8id, remote_id) {
+                Self::send_handshake_message(q8id, handshake_msg);
             }
         }
     }
@@ -524,7 +524,7 @@ impl Ble {
     /// Send Identification
     ///
     /// Send identity information to another node
-    fn identification_send(receiver_small_id: Vec<u8>, request: bool) {
+    fn identification_send(receiver_q8id: Vec<u8>, request: bool) {
         log::info!("BLE send identity information");
 
         // get node ID
@@ -541,7 +541,7 @@ impl Ble {
         // create unified message
         let message = proto_net::ble_message::Message::Identification(identification);
 
-        Self::create_send_message(receiver_small_id, message);
+        Self::create_send_message(receiver_q8id, message);
     }
 
     /// send message
@@ -550,7 +550,7 @@ impl Ble {
     /// * sender_id: the small qaul id of the sending node (this node)
     /// * data: the binary data of the message to send
     pub fn message_send(receiver_id: Vec<u8>, sender_id: Vec<u8>, data: Vec<u8>) {
-        log::info!("BLE send message to {:?}", receiver_id.clone());
+        log::info!("BLE send message to {:x?}", receiver_id.clone());
         // create a random UUID as message id
         let message_id = Uuid::new_v4().as_bytes().to_vec();
 
@@ -591,7 +591,7 @@ impl Ble {
         log::info!("BLE send routing information");
         let message = proto_net::ble_message::Message::Info(data);
 
-        Self::create_send_message(QaulId::to_small(node_id), message);
+        Self::create_send_message(QaulId::to_q8id(node_id), message);
     }
 
     /// send messaging message
@@ -600,7 +600,7 @@ impl Ble {
 
         let message = proto_net::ble_message::Message::Messaging(data);
 
-        Self::create_send_message(QaulId::to_small(node_id), message);
+        Self::create_send_message(QaulId::to_q8id(node_id), message);
     }
 
     /// send feed message
@@ -615,16 +615,16 @@ impl Ble {
 
         // send it nodes
         for node_id in nodes {
-            Self::create_send_message(QaulId::to_small(node_id), message.clone());
+            Self::create_send_message(QaulId::to_q8id(node_id), message.clone());
         }
     }
 
     /// Create and send an encrypted message if session is established
     ///
     /// If no encrypted session is established, the message is sent unencrypted.
-    fn create_send_message(receiver_small_id: Vec<u8>, message: proto_net::ble_message::Message) {
+    fn create_send_message(receiver_q8id: Vec<u8>, message: proto_net::ble_message::Message) {
         // Check if encrypted session is established
-        if BleCrypto::is_session_established(&receiver_small_id) {
+        if BleCrypto::is_session_established(&receiver_q8id) {
             // Encode inner message
             let proto_message = proto_net::BleMessage {
                 message: Some(message.clone()),
@@ -635,11 +635,11 @@ impl Ble {
                 .expect("encoding failed");
 
             // Encrypt the message
-            match BleCrypto::encrypt(&receiver_small_id, plaintext) {
+            match BleCrypto::encrypt(&receiver_q8id, plaintext) {
                 Ok(encrypted) => {
                     log::trace!("BLE: sending encrypted message");
                     let encrypted_msg = proto_net::ble_message::Message::Encrypted(encrypted);
-                    Self::create_send_message_raw(receiver_small_id, encrypted_msg);
+                    Self::create_send_message_raw(receiver_q8id, encrypted_msg);
                     return;
                 }
                 Err(e) => {
@@ -650,18 +650,15 @@ impl Ble {
         }
 
         // Fallback: send unencrypted (during handshake or if encryption fails)
-        Self::create_send_message_raw(receiver_small_id, message);
+        Self::create_send_message_raw(receiver_q8id, message);
     }
 
     /// Send a message without encryption
     ///
     /// This is used for handshake messages and as fallback when encryption fails.
-    fn create_send_message_raw(
-        receiver_small_id: Vec<u8>,
-        message: proto_net::ble_message::Message,
-    ) {
+    fn create_send_message_raw(receiver_q8id: Vec<u8>, message: proto_net::ble_message::Message) {
         // get small qaul id of this node
-        let sender_id = Node::get_small_id();
+        let sender_id = Node::get_q8id();
 
         // create message
         let proto_message = proto_net::BleMessage {
@@ -675,7 +672,7 @@ impl Ble {
             .expect("Vec<u8> provides capacity as needed");
 
         // send the message
-        Self::message_send(receiver_small_id, sender_id, buf);
+        Self::message_send(receiver_q8id, sender_id, buf);
     }
 
     /// BLE message received
@@ -683,7 +680,7 @@ impl Ble {
         log::info!("BLE message received");
         // get node ID of sender
         let node_id: PeerId;
-        if let Some(node) = Neighbours::node_from_small_id(message.from.clone()) {
+        if let Some(node) = Neighbours::node_from_q8id(message.from.clone()) {
             match PeerId::from_bytes(&node.id) {
                 Ok(id) => node_id = id,
                 Err(e) => {
@@ -825,7 +822,7 @@ impl Ble {
                 // deterministic tiebreaker: the peer with the lexicographically
                 // lower small_id becomes the initiator.
                 if BleCrypto::has_pending_session(&from) {
-                    let local_id = Node::get_small_id();
+                    let local_id = Node::get_q8id();
                     if local_id < from.to_vec() {
                         // We have the lower ID, so we stay as initiator.
                         // Ignore the remote's handshake 1; they will process
@@ -933,7 +930,7 @@ impl Ble {
 
                         // create discovered response message
                         let info = proto_rpc::InfoResponse {
-                            small_id: ble.ble_id.clone(),
+                            q8id: ble.ble_id.clone(),
                             status: ble.status.to_string(),
                             device_info,
                         };

--- a/rust/libqaul/src/node/mod.rs
+++ b/rust/libqaul/src/node/mod.rs
@@ -75,7 +75,7 @@ impl NodeModule {
 
     /// Get the node's small ID
     pub fn small_id(&self) -> Vec<u8> {
-        QaulId::to_small(self.node.id)
+        QaulId::to_q8id(self.node.id)
     }
 
     /// Get the node's topic
@@ -219,9 +219,9 @@ impl Node {
     }
 
     /// get small node ID
-    pub fn get_small_id() -> Vec<u8> {
+    pub fn get_q8id() -> Vec<u8> {
         let node = NODE.get();
-        QaulId::to_small(node.id)
+        QaulId::to_q8id(node.id)
     }
 
     /// get the string of a PeerId

--- a/rust/libqaul/src/router/neighbours.rs
+++ b/rust/libqaul/src/router/neighbours.rs
@@ -224,8 +224,11 @@ impl Neighbours {
     ///
     /// Returns node if it exists in the data base,
     /// otherwise it returns None.
+    #[allow(dead_code)]
+    #[deprecated(since = "2.0.0-rc.4", note = "Use `node_from_q8id` instead.")]
     pub fn node_from_small_id(small_id: Vec<u8>) -> Option<Node> {
         // create search key
+        #[allow(deprecated)]
         let prefix = QaulId::small_to_search_prefix(small_id);
 
         // get data base tree
@@ -246,9 +249,9 @@ impl Neighbours {
     ///
     /// Returns node if it exists in the data base,
     /// otherwise it returns None.
-    pub fn _node_from_q8id(small_id: Vec<u8>) -> Option<Node> {
+    pub fn node_from_q8id(q8id: Vec<u8>) -> Option<Node> {
         // create search key
-        let prefix = QaulId::q8id_to_search_prefix(small_id);
+        let prefix = QaulId::q8id_to_search_prefix(q8id);
 
         // get data base tree
         let tree = NODES.get();

--- a/rust/libqaul/src/rpc/mod.rs
+++ b/rust/libqaul/src/rpc/mod.rs
@@ -221,7 +221,7 @@ impl Rpc {
                         #[cfg(feature = "rtc")]
                         {
                             log::trace!("Message Modules::Rtc received");
-                            Rtc::rpc(message.data, message.user_id);
+                            Rtc::rpc(message.data, message.user_id, message.request_id);
                         }
                         #[cfg(not(feature = "rtc"))]
                         {

--- a/rust/libqaul/src/utilities/qaul_id.rs
+++ b/rust/libqaul/src/utilities/qaul_id.rs
@@ -19,19 +19,21 @@ impl QaulId {
     /// Convert a qaul ID to it's small 16 Byte version
     ///
     /// The small version is used in the BLE module.
-    /// It only uses byte 7 to 24 of the qaul id
+    /// It only uses byte 7 to 23 of the qaul id
+    #[deprecated(since = "2.0.0-rc.4", note = "Use `to_q8id` instead.")]
     pub fn to_small(qaul_id: PeerId) -> Vec<u8> {
         // convert to bytes
         let bytes = qaul_id.to_bytes();
 
-        // only use bytes 7 to 24
-        let small_id = bytes[6..23].to_owned();
+        // only use bytes 7 to 23
+        let small_id = bytes[6..22].to_owned();
 
         // return small id
         small_id
     }
 
     /// Create a search key prefix for a small vector
+    #[deprecated(since = "2.0.0-rc.4", note = "Use `q8id_to_search_prefix` instead.")]
     pub fn small_to_search_prefix(small_id: Vec<u8>) -> Vec<u8> {
         // add chopped prefix to small_id
         let mut key: Vec<u8> = vec![0x0, 0x24, 0x8, 0x1, 0x12, 0x20];

--- a/utilities/scripts/run-android.sh
+++ b/utilities/scripts/run-android.sh
@@ -49,4 +49,5 @@ if [ "$CLEAN" == "true" ]; then
 fi
 
 ## run flutter
-flutter run
+flutter run --verbose
+


### PR DESCRIPTION
This PR  replaces the 16 Byte `qaul_id` with the new 8 Byte `q8id`.

This will allow the new GATT messaging protocol and reduce the amount of qaul ID sizes.