### PR TITLE
Implement Bubble Redesign

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -18,11 +18,13 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart'
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' hide context, Context;
 import 'package:path_provider/path_provider.dart';
+import 'package:qaul_components/qaul_components.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:record/record.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -179,6 +181,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   User? get otherUser => widget.otherUser;
 
   final Map<String, String> _overflowMenuOptions = {};
+  Map<String, QaulChatBubbleDisplayItem> _bubbleDisplayItems = {};
 
   void _handleClick(String value) {
     switch (value) {
@@ -295,9 +298,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         child: SafeArea(
           bottom: false,
           child: Chat(
-            showUserAvatars: true,
+            showUserAvatars: false,
             showUserNames: room.isGroupChatRoom,
             user: user.toInternalUser(),
+            useTopSafeAreaInset: false,
+            dateHeaderThreshold: const Duration(days: 365).inMilliseconds,
+            groupMessagesThreshold: const Duration(days: 365).inMilliseconds,
             messages: messages(room, l10n: l10n) ?? [],
             onSendPressed: sendMessage,
             inputOptions: const InputOptions(
@@ -527,11 +533,22 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 isDefaultUser: message.author.id == user.idBase58,
               );
             },
+            customDateHeaderText: (dt) =>
+                DateFormat('EEEE, MMMM d, yyyy', 'en').format(dt.toLocal()),
             theme: DefaultChatTheme(
               userAvatarNameColors: [
                 colorGenerationStrategy(otherUser?.idBase58 ?? room.idBase58),
               ],
               backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+              messageInsetsVertical: 0,
+              messageInsetsHorizontal: 0,
+              dateDividerTextStyle: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w300,
+                height: 1.2,
+                color: Colors.white,
+              ),
+              bubbleMargin: EdgeInsets.zero,
               sentMessageBodyTextStyle: const TextStyle(
                 fontSize: 17,
                 color: Colors.white,
@@ -553,11 +570,59 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   List<types.Message>? messages(ChatRoom room,
       {required AppLocalizations l10n}) {
-    return room.messages
-        ?.sorted()
-        .map(
-            (e) => e.toInternalMessage(_author(e), ref, l10n: l10n, room: room))
-        .toList();
+    final domainMessages = room.messages?.sorted();
+    if (domainMessages == null) return null;
+
+    final internalMessages = <types.Message>[];
+    final textMessages = <Message>[];
+
+    for (final m in domainMessages) {
+      final author = _author(m);
+      final internal =
+          m.toInternalMessage(author, ref, l10n: l10n, room: room);
+
+      if (m.content is TextMessageContent && internal is types.TextMessage) {
+        internalMessages.add(internal.copyWith(status: null));
+        textMessages.add(m);
+      } else {
+        internalMessages.add(internal);
+      }
+    }
+
+    final bubbleSources = [...textMessages]
+      ..sort((a, b) => a.sentAt.compareTo(b.sentAt));
+
+    final bubbleMessages = <QaulChatBubbleMessage>[];
+    final bubbleIds = <String>[];
+
+    for (final m in bubbleSources) {
+      final isMe = m.senderId.equals(user.id);
+      bubbleMessages.add(
+        QaulChatBubbleMessage(
+          content: (m.content as TextMessageContent).content,
+          sentAt: m.sentAt,
+          receivedAt: m.receivedAt,
+          status: m.status == MessageState.sent
+              ? MessageStatus.sent
+              : (m.status == MessageState.confirmed ||
+                      m.status == MessageState.confirmedByAll
+                  ? MessageStatus.read
+                  : MessageStatus.notSent),
+          messageType: isMe ? MessageType.primary : MessageType.secondary,
+          edges: const [],
+        ),
+      );
+      bubbleIds.add(m.messageIdBase58);
+    }
+
+    final displayItems = computeChatBubbleDisplayItems(bubbleMessages);
+    final map = <String, QaulChatBubbleDisplayItem>{};
+    for (var i = 0; i < bubbleIds.length; i++) {
+      map[bubbleIds[i]] = displayItems[i];
+    }
+    _bubbleDisplayItems = map;
+
+    return internalMessages;
   }
 
   Widget _bubbleBuilder(
@@ -574,6 +639,30 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             border: Border.all(color: Colors.grey, width: 0.5),
             borderRadius: const BorderRadius.all(Radius.circular(20))),
         child: child,
+      );
+    }
+
+    if (message is types.TextMessage) {
+      final currentRoom = ref.read(currentOpenChatRoom);
+      final roomMessages = currentRoom?.messages;
+      if (roomMessages == null) return child;
+
+      final domainMessage = roomMessages
+          .firstWhereOrNull((m) => m.messageIdBase58 == message.id);
+      if (domainMessage == null) return child;
+
+      final display = _bubbleDisplayItems[domainMessage.messageIdBase58];
+      if (display == null) return child;
+
+      return Padding(
+        padding: EdgeInsets.only(
+          top: display.marginTop,
+          left: 16,
+        ),
+        child: QaulChatBubble(
+          message: display.message,
+          showTimestamp: display.showTimestamp,
+        ),
       );
     }
 

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,2 +1,3 @@
+export 'widgets/qaul_chat_bubble.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_navbar.dart';

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+enum TailEdge { topStart, topEnd, bottomStart, bottomEnd }
+
+enum MessageStatus { notSent, sent, read }
+
+enum MessageType { primary, secondary }
+
+// ---------------------------------------------------------------------------
+// Public constants & style
+// ---------------------------------------------------------------------------
+
+/// Width breakpoint: below this value use mobile bubble width, at or above use tablet/desktop.
+const double kChatBubbleWidthBreakpoint = 500.0;
+
+class ChatBubbleStyle {
+  static const maxBubbleWidthMobile = 272.0;
+  static const maxBubbleWidthExtended = 392.0;
+  static const minBubbleWidth = 32.0;
+
+  static const horizontalPadding = 10.0;
+  static const verticalPadding = 6.0;
+
+  static const gapBetweenTextAndDate = 4.0;
+
+  static const radius = Radius.circular(10);
+
+  static const primaryColor = Color(0xFF0288D1);
+  static const secondaryColor = Color(0xFF424242);
+
+  static const textStyle = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w300,
+    height: 1.2,
+    letterSpacing: 0.1,
+    color: Colors.white,
+  );
+
+  static const timeStyle = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w400,
+    height: 1.2,
+    letterSpacing: 0.1,
+    color: Colors.white70,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// QaulChatBubbleMessage
+// ---------------------------------------------------------------------------
+
+class QaulChatBubbleMessage {
+  const QaulChatBubbleMessage({
+    required this.content,
+    required this.sentAt,
+    required this.receivedAt,
+    required this.status,
+    required this.messageType,
+    required this.edges,
+  });
+
+  final String content;
+  final DateTime sentAt;
+  final DateTime receivedAt;
+  final MessageStatus status;
+  final MessageType messageType;
+  final List<TailEdge> edges;
+
+  QaulChatBubbleMessage copyWith({
+    String? content,
+    DateTime? sentAt,
+    DateTime? receivedAt,
+    MessageStatus? status,
+    MessageType? messageType,
+    List<TailEdge>? edges,
+  }) {
+    return QaulChatBubbleMessage(
+      content: content ?? this.content,
+      sentAt: sentAt ?? this.sentAt,
+      receivedAt: receivedAt ?? this.receivedAt,
+      status: status ?? this.status,
+      messageType: messageType ?? this.messageType,
+      edges: edges ?? this.edges,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// QaulChatBubble widget
+// ---------------------------------------------------------------------------
+
+class QaulChatBubble extends StatelessWidget {
+  const QaulChatBubble({
+    super.key,
+    required this.message,
+    this.showTimestamp = true,
+  });
+
+  final QaulChatBubbleMessage message;
+  final bool showTimestamp;
+
+  String _formatTime(BuildContext context) {
+    final diff = DateTime.now().difference(message.sentAt);
+
+    if (diff.inMinutes < 1) return 'Now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes} min';
+
+    return TimeOfDay.fromDateTime(message.sentAt).format(context);
+  }
+
+  Widget? _buildStatusIcon(Color textColor) {
+    switch (message.status) {
+      case MessageStatus.notSent:
+        return null;
+
+      case MessageStatus.sent:
+        return Icon(
+          Icons.check,
+          size: 14,
+          color: textColor.withValues(alpha: 0.8),
+        );
+
+      case MessageStatus.read:
+        return Icon(
+          Icons.done_all,
+          size: 14,
+          color: textColor.withValues(alpha: 0.9),
+        );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isPrimary = message.messageType == MessageType.primary;
+
+    final width = MediaQuery.sizeOf(context).width;
+    final isMobile = width < kChatBubbleWidthBreakpoint;
+    final maxBubbleWidth = isMobile
+        ? ChatBubbleStyle.maxBubbleWidthMobile
+        : ChatBubbleStyle.maxBubbleWidthExtended;
+    final maxTextWidth =
+        maxBubbleWidth - ChatBubbleStyle.horizontalPadding * 2;
+
+    final backgroundColor = isPrimary
+        ? ChatBubbleStyle.primaryColor
+        : ChatBubbleStyle.secondaryColor;
+
+    const textColor = Colors.white;
+
+    final edges = message.edges.toSet();
+
+    final borderRadius = BorderRadiusDirectional.only(
+      topStart: edges.contains(TailEdge.topStart)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+      topEnd: edges.contains(TailEdge.topEnd)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+      bottomStart: edges.contains(TailEdge.bottomStart)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+      bottomEnd: edges.contains(TailEdge.bottomEnd)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+    );
+
+    final timeLabel = _formatTime(context);
+    final statusIcon = _buildStatusIcon(textColor);
+
+    return Align(
+      alignment: isPrimary ? Alignment.centerRight : Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          minWidth: ChatBubbleStyle.minBubbleWidth,
+          maxWidth: maxBubbleWidth,
+        ),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: borderRadius,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: ChatBubbleStyle.horizontalPadding,
+              vertical: ChatBubbleStyle.verticalPadding,
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Flexible(
+                  fit: FlexFit.loose,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: maxTextWidth),
+                    child: Text(
+                      message.content.trim().replaceAll(RegExp(r'\s+'), ' '),
+                      textAlign: TextAlign.left,
+                      textWidthBasis: TextWidthBasis.longestLine,
+                      style: ChatBubbleStyle.textStyle,
+                    ),
+                  ),
+                ),
+                if (showTimestamp)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 1.5),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        const SizedBox(
+                          width: ChatBubbleStyle.gapBetweenTextAndDate,
+                        ),
+                        Text(timeLabel, style: ChatBubbleStyle.timeStyle),
+                        if (isPrimary && statusIcon != null) ...[
+                          const SizedBox(width: 4),
+                          statusIcon,
+                        ],
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Display item & layout constants
+// ---------------------------------------------------------------------------
+
+const double kChatBubbleLinkedGap = 4.0;
+const double kChatBubbleSeparatedGap = 12.0;
+
+class QaulChatBubbleDisplayItem {
+  const QaulChatBubbleDisplayItem({
+    required this.message,
+    required this.showTimestamp,
+    required this.marginTop,
+  });
+
+  final QaulChatBubbleMessage message;
+  final bool showTimestamp;
+  final double marginTop;
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
+  if (a.messageType != b.messageType) return false;
+
+  final ta = a.sentAt;
+  final tb = b.sentAt;
+
+  return ta.year == tb.year &&
+      ta.month == tb.month &&
+      ta.day == tb.day &&
+      ta.hour == tb.hour &&
+      ta.minute == tb.minute;
+}
+
+List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
+  List<QaulChatBubbleMessage> messages,
+) {
+  if (messages.isEmpty) return [];
+
+  final result = <QaulChatBubbleDisplayItem>[];
+
+  for (var i = 0; i < messages.length; i++) {
+    final prev = i > 0 ? messages[i - 1] : null;
+    final curr = messages[i];
+    final next = i < messages.length - 1 ? messages[i + 1] : null;
+
+    final prevLinked = prev != null && isChatBubbleLinked(prev, curr);
+    final nextLinked = next != null && isChatBubbleLinked(curr, next);
+
+    final isPrimary = curr.messageType == MessageType.primary;
+
+    final edges = isPrimary
+        ? _edgesForPrimary(prevLinked, nextLinked)
+        : _edgesForSecondary(prevLinked, nextLinked);
+
+    final showTimestamp = !nextLinked;
+
+    final marginTop = i == 0
+        ? 0.0
+        : (prevLinked ? kChatBubbleLinkedGap : kChatBubbleSeparatedGap);
+
+    result.add(
+      QaulChatBubbleDisplayItem(
+        message: curr.copyWith(edges: edges),
+        showTimestamp: showTimestamp,
+        marginTop: marginTop,
+      ),
+    );
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+List<TailEdge> _edgesForPrimary(bool hasPreviousLinked, bool hasNextLinked) {
+  if (!hasPreviousLinked && !hasNextLinked) return const [TailEdge.bottomEnd];
+
+  if (hasPreviousLinked && hasNextLinked) {
+    return const [TailEdge.topEnd, TailEdge.bottomEnd];
+  }
+
+  if (!hasPreviousLinked && hasNextLinked) return const [TailEdge.bottomEnd];
+
+  return const [TailEdge.topEnd];
+}
+
+List<TailEdge> _edgesForSecondary(bool hasPreviousLinked, bool hasNextLinked) {
+  if (!hasPreviousLinked && !hasNextLinked) {
+    return const [TailEdge.bottomStart];
+  }
+
+  if (hasPreviousLinked && hasNextLinked) {
+    return const [TailEdge.topStart, TailEdge.bottomStart];
+  }
+
+  if (!hasPreviousLinked && hasNextLinked) {
+    return const [TailEdge.bottomStart];
+  }
+
+  return const [TailEdge.topStart];
+}

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -14,7 +14,6 @@ enum MessageType { primary, secondary }
 // Public constants & style
 // ---------------------------------------------------------------------------
 
-/// Width breakpoint: below this value use mobile bubble width, at or above use tablet/desktop.
 const double kChatBubbleWidthBreakpoint = 500.0;
 
 class ChatBubbleStyle {
@@ -26,6 +25,8 @@ class ChatBubbleStyle {
   static const verticalPadding = 6.0;
 
   static const gapBetweenTextAndDate = 4.0;
+
+  static const gapBetweenTimeAndStatusIcon = 3.0;
 
   static const radius = Radius.circular(10);
 
@@ -44,7 +45,7 @@ class ChatBubbleStyle {
     fontSize: 11,
     fontWeight: FontWeight.w400,
     height: 1.2,
-    letterSpacing: 0.1,
+    letterSpacing: 0,
     color: Colors.white70,
   );
 }
@@ -103,13 +104,40 @@ class QaulChatBubble extends StatelessWidget {
   final QaulChatBubbleMessage message;
   final bool showTimestamp;
 
+  static int _daysBetween(DateTime from, DateTime to) {
+    final fromDate = DateTime(from.year, from.month, from.day);
+    final toDate = DateTime(to.year, to.month, to.day);
+    return toDate.difference(fromDate).inDays;
+  }
+
   String _formatTime(BuildContext context) {
-    final diff = DateTime.now().difference(message.sentAt);
+    final isPrimary = message.messageType == MessageType.primary;
+    final baseTime = isPrimary ? message.sentAt : message.receivedAt;
+    final diffFromNow = DateTime.now().difference(baseTime);
 
-    if (diff.inMinutes < 1) return 'Now';
-    if (diff.inMinutes < 60) return '${diff.inMinutes} min';
+    String timeLabel;
+    if (diffFromNow.inMinutes < 1) {
+      timeLabel = 'Now';
+    } else if (diffFromNow.inMinutes < 60) {
+      timeLabel = '${diffFromNow.inMinutes} min';
+    } else {
+      final h = baseTime.hour.toString().padLeft(2, '0');
+      final m = baseTime.minute.toString().padLeft(2, '0');
+      timeLabel = '$h:$m';
+    }
 
-    return TimeOfDay.fromDateTime(message.sentAt).format(context);
+    if (message.status != MessageStatus.read) return timeLabel;
+
+    final days = _daysBetween(message.sentAt, message.receivedAt);
+    if (days < 1) return timeLabel;
+
+    if (isPrimary) {
+      final dayText = days == 1 ? '1 day' : '$days days';
+      return '$timeLabel + $dayText';
+    } else {
+      final dayText = days == 1 ? '1 day ago' : '$days days ago';
+      return '$timeLabel $dayText';
+    }
   }
 
   Widget? _buildStatusIcon(Color textColor) {
@@ -188,41 +216,101 @@ class QaulChatBubble extends StatelessWidget {
               horizontal: ChatBubbleStyle.horizontalPadding,
               vertical: ChatBubbleStyle.verticalPadding,
             ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Flexible(
-                  fit: FlexFit.loose,
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(maxWidth: maxTextWidth),
-                    child: Text(
-                      message.content.trim().replaceAll(RegExp(r'\s+'), ' '),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: maxTextWidth),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final content = message.content
+                      .trim()
+                      .replaceAll(RegExp(r'\s+'), ' ');
+                  final messageSpan = TextSpan(
+                    style: ChatBubbleStyle.textStyle,
+                    text: content,
+                  );
+                  final gap = ChatBubbleStyle.gapBetweenTextAndDate;
+                  final timeLabelPainter = TextPainter(
+                    text: TextSpan(
+                      text: timeLabel,
+                      style: ChatBubbleStyle.timeStyle,
+                    ),
+                    textDirection: TextDirection.ltr,
+                  );
+                  timeLabelPainter.layout();
+                  var timeBlockWidth = timeLabelPainter.width +
+                      ChatBubbleStyle.gapBetweenTimeAndStatusIcon;
+                  if (isPrimary && statusIcon != null) {
+                    timeBlockWidth += 14.0;
+                  }
+                  final maxMessageWidth =
+                      (constraints.maxWidth - gap - timeBlockWidth)
+                          .clamp(0.0, double.infinity);
+
+                  final painter = TextPainter(
+                    text: messageSpan,
+                    textDirection: TextDirection.ltr,
+                  );
+                  painter.layout(maxWidth: maxMessageWidth);
+                  final lineHeight = ChatBubbleStyle.textStyle.fontSize! *
+                      (ChatBubbleStyle.textStyle.height ?? 1.2);
+                  final fitsOnOneLine = painter.height <= lineHeight * 1.1;
+
+                  Widget timeRow = Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(timeLabel, style: ChatBubbleStyle.timeStyle),
+                      const SizedBox(
+                          width:
+                              ChatBubbleStyle.gapBetweenTimeAndStatusIcon),
+                      if (isPrimary && statusIcon != null) statusIcon,
+                    ],
+                  );
+
+                  if (!showTimestamp) {
+                    return RichText(
                       textAlign: TextAlign.left,
                       textWidthBasis: TextWidthBasis.longestLine,
-                      style: ChatBubbleStyle.textStyle,
-                    ),
-                  ),
-                ),
-                if (showTimestamp)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 1.5),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
+                      text: messageSpan,
+                    );
+                  }
+
+                  if (fitsOnOneLine) {
+                    return Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        const SizedBox(
-                          width: ChatBubbleStyle.gapBetweenTextAndDate,
+                        Flexible(
+                          child: RichText(
+                            textAlign: TextAlign.left,
+                            textWidthBasis: TextWidthBasis.longestLine,
+                            text: messageSpan,
+                          ),
                         ),
-                        Text(timeLabel, style: ChatBubbleStyle.timeStyle),
-                        if (isPrimary && statusIcon != null) ...[
-                          const SizedBox(width: 4),
-                          statusIcon,
-                        ],
+                        SizedBox(width: gap),
+                        timeRow,
                       ],
-                    ),
-                  ),
-              ],
+                    );
+                  }
+
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: isPrimary
+                        ? CrossAxisAlignment.end
+                        : CrossAxisAlignment.start,
+                    children: [
+                      RichText(
+                        textAlign: TextAlign.left,
+                        textWidthBasis: TextWidthBasis.longestLine,
+                        text: messageSpan,
+                      ),
+                      Padding(
+                        padding: EdgeInsets.only(top: gap),
+                        child: timeRow,
+                      ),
+                    ],
+                  );
+                },
+              ),
             ),
           ),
         ),

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+void main() {
+  group('computeChatBubbleDisplayItems', () {
+    test('links messages from same sender and same minute', () {
+      final base = DateTime(2026, 4, 19, 19, 23);
+
+      final messages = [
+        QaulChatBubbleMessage(
+          content: 'first',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'middle',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'last',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+      ];
+
+      final items = computeChatBubbleDisplayItems(messages);
+      expect(items, hasLength(3));
+
+      expect(items[0].message.edges, const [TailEdge.bottomEnd]);
+      expect(items[1].message.edges,
+          const [TailEdge.topEnd, TailEdge.bottomEnd]);
+      expect(items[2].message.edges, const [TailEdge.topEnd]);
+
+      expect(items[0].showTimestamp, isFalse);
+      expect(items[1].showTimestamp, isFalse);
+      expect(items[2].showTimestamp, isTrue);
+
+      expect(items[0].marginTop, 0.0);
+      expect(items[1].marginTop, kChatBubbleLinkedGap);
+      expect(items[2].marginTop, kChatBubbleLinkedGap);
+    });
+
+    test('does not link messages from different sender or minute', () {
+      final base = DateTime(2026, 4, 19, 19, 23);
+
+      final messages = [
+        QaulChatBubbleMessage(
+          content: 'primary',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'primary later',
+          sentAt: base.add(const Duration(minutes: 1)),
+          receivedAt: base.add(const Duration(minutes: 1)),
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'secondary same minute as second',
+          sentAt: base.add(const Duration(minutes: 1)),
+          receivedAt: base.add(const Duration(minutes: 1)),
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
+        ),
+      ];
+
+      final items = computeChatBubbleDisplayItems(messages);
+      expect(items, hasLength(3));
+
+      expect(items[0].message.edges, const [TailEdge.bottomEnd]);
+      expect(items[1].message.edges, const [TailEdge.bottomEnd]);
+      expect(items[2].message.edges, const [TailEdge.bottomStart]);
+
+      expect(items[0].showTimestamp, isTrue);
+      expect(items[1].showTimestamp, isTrue);
+      expect(items[2].showTimestamp, isTrue);
+
+      expect(items[0].marginTop, 0.0);
+      expect(items[1].marginTop, kChatBubbleSeparatedGap);
+      expect(items[2].marginTop, kChatBubbleSeparatedGap);
+    });
+  });
+
+  group('QaulChatBubble timestamp formatting', () {
+    testWidgets('shows minutes when sent less than an hour ago',
+        (tester) async {
+      final now = DateTime.now();
+      final fiveMinutesAgo = now.subtract(const Duration(minutes: 5));
+
+      final message = QaulChatBubbleMessage(
+        content: 'recent message',
+        sentAt: fiveMinutesAgo,
+        receivedAt: fiveMinutesAgo,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('5 min'), findsOneWidget);
+    });
+
+    testWidgets('shows absolute time when sent more than an hour ago',
+        (tester) async {
+      final now = DateTime.now();
+      final ninetyMinutesAgo = now.subtract(const Duration(minutes: 90));
+
+      final message = QaulChatBubbleMessage(
+        content: 'older message',
+        sentAt: ninetyMinutesAgo,
+        receivedAt: ninetyMinutesAgo,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampFinder = find.byType(Text).at(1);
+      final timestampText = tester.widget<Text>(timestampFinder);
+      final label = timestampText.data ?? '';
+      expect(label.contains('min'), isFalse);
+      expect(label.contains(':'), isTrue);
+    });
+  });
+}

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -2,6 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qaul_components/qaul_components.dart';
 
+Finder _findTimestampText(WidgetTester tester) {
+  return find.byWidgetPredicate(
+    (w) =>
+        w is Text &&
+        (w.data == null || w.data!.contains('min') || w.data!.contains(':') || w.data!.contains('Now') || w.data!.contains('day')),
+  );
+}
+
 void main() {
   group('computeChatBubbleDisplayItems', () {
     test('links messages from same sender and same minute', () {
@@ -152,11 +160,130 @@ void main() {
         ),
       );
 
-      final timestampFinder = find.byType(Text).at(1);
-      final timestampText = tester.widget<Text>(timestampFinder);
+      final timestampText = tester.widget<Text>(_findTimestampText(tester).first);
       final label = timestampText.data ?? '';
       expect(label.contains('min'), isFalse);
       expect(label.contains(':'), isTrue);
+    });
+
+    testWidgets('sender (primary) read message shows sent time + days when received later',
+        (tester) async {
+      final sentAt = DateTime(2026, 4, 19, 14, 50);
+      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sentAt,
+        receivedAt: receivedAt,
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText = tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('+ 1 day'), isTrue);
+    });
+
+    testWidgets('receiver (secondary) read message shows received time + days ago',
+        (tester) async {
+      final sentAt = DateTime(2026, 4, 19, 14, 50);
+      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sentAt,
+        receivedAt: receivedAt,
+        status: MessageStatus.read,
+        messageType: MessageType.secondary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText = tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('1 day ago'), isTrue);
+    });
+
+    testWidgets('read message same day has no days suffix', (tester) async {
+      final sameDay = DateTime(2026, 4, 19, 14, 50);
+      final receivedSameDay = DateTime(2026, 4, 19, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sameDay,
+        receivedAt: receivedSameDay,
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText = tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('+ '), isFalse);
+      expect(label.contains(' ago'), isFalse);
+    });
+
+    testWidgets('sent (not read) message has no days suffix', (tester) async {
+      final sentAt = DateTime(2026, 4, 19, 14, 50);
+      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sentAt,
+        receivedAt: receivedAt,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText = tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('+ 1 day'), isFalse);
+      expect(label.contains(' ago'), isFalse);
     });
   });
 }

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -10,6 +10,8 @@
 // **************************************************************************
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:qaul_components_widgetbook/use_cases/qaul_chat_bubble.dart'
+    as _qaul_components_widgetbook_use_cases_qaul_chat_bubble;
 import 'package:qaul_components_widgetbook/use_cases/qaul_fab.dart'
     as _qaul_components_widgetbook_use_cases_qaul_fab;
 import 'package:qaul_components_widgetbook/use_cases/qaul_navbar.dart'
@@ -20,6 +22,16 @@ final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
     name: 'widgets',
     children: [
+      _widgetbook.WidgetbookComponent(
+        name: 'QaulChatBubble',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Conversation preview',
+            builder: _qaul_components_widgetbook_use_cases_qaul_chat_bubble
+                .buildChatBubbleConversationUseCase,
+          ),
+        ],
+      ),
       _widgetbook.WidgetbookComponent(
         name: 'QaulFAB',
         useCases: [

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(name: 'Conversation preview', type: QaulChatBubble)
+Widget buildChatBubbleConversationUseCase(BuildContext context) {
+  const dateLabels = ['Friday, April 17, 2026 ', 'Saturday, April 18, 2026 '];
+
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+
+  final rawMessages = [
+    QaulChatBubbleMessage(
+      content: 'Hello in 16px 300 font',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content:
+          'This is a longer message with no own timestamp followed by another message with timestamp',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.sent,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'This one is it',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Chatpartner is answering',
+      sentAt: yesterday.copyWith(hour: 18, minute: 9),
+      receivedAt: yesterday.copyWith(hour: 18, minute: 9),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Another answer',
+      sentAt: yesterday.copyWith(hour: 18, minute: 29),
+      receivedAt: yesterday.copyWith(hour: 18, minute: 29),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Message',
+      sentAt: yesterday.copyWith(hour: 19, minute: 23),
+      receivedAt: yesterday.copyWith(hour: 19, minute: 23),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Longer message from the chatpartner',
+      sentAt: yesterday.copyWith(hour: 21, minute: 19),
+      receivedAt: yesterday.copyWith(hour: 21, minute: 19),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'followed by one with time',
+      sentAt: yesterday.copyWith(hour: 21, minute: 19),
+      receivedAt: yesterday.copyWith(hour: 21, minute: 19),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Out and delivered',
+      sentAt: now.subtract(const Duration(minutes: 12)),
+      receivedAt: now.subtract(const Duration(minutes: 12)),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Out but not delivered yet',
+      sentAt: now.subtract(const Duration(minutes: 1)),
+      receivedAt: now.subtract(const Duration(minutes: 1)),
+      status: MessageStatus.sent,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'New Message not out',
+      sentAt: now,
+      receivedAt: now,
+      status: MessageStatus.notSent,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+  ];
+
+  final items = computeChatBubbleDisplayItems(rawMessages);
+
+  var dateLabelIndex = 0;
+  final children = <Widget>[
+    const SizedBox(height: 16),
+  ];
+
+  for (final item in items) {
+    bool addedSeparator = false;
+    if (dateLabelIndex == 0) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 16.5),
+          child: Center(
+            child: Text(
+              dateLabels[dateLabelIndex++],
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.2,
+                color: Colors.white.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ),
+      );
+      addedSeparator = true;
+    } else if (item.message.content == 'Out and delivered' &&
+        dateLabelIndex == 1) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 16.5),
+          child: Center(
+            child: Text(
+              dateLabels[dateLabelIndex++],
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.2,
+                color: Colors.white.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ),
+      );
+      addedSeparator = true;
+    }
+
+    children.add(
+      Padding(
+        padding: EdgeInsets.only(top: addedSeparator ? 0 : item.marginTop),
+        child: QaulChatBubble(
+          message: item.message,
+          showTimestamp: item.showTimestamp,
+        ),
+      ),
+    );
+  }
+
+  return Container(
+    color: Colors.black,
+    padding: const EdgeInsets.all(16),
+    child: Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 500),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: children,
+        ),
+      ),
+    ),
+  );
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
@@ -77,6 +77,16 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       edges: const [],
     ),
     QaulChatBubbleMessage(
+      content: 'Message with delay',
+      sentAt: today
+          .subtract(const Duration(days: 4))
+          .copyWith(hour: 12, minute: 14),
+      receivedAt: today.copyWith(hour: 12, minute: 30),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
       content: 'Out and delivered',
       sentAt: now.subtract(const Duration(minutes: 12)),
       receivedAt: now.subtract(const Duration(minutes: 12)),


### PR DESCRIPTION
## Description
This PR brings the chat bubble redesign onto the current main branch and wires it into the chat screen. After the navbar redesign and related main changes (file history, stores, PaginatedData providers), the bubble UI and its layout logic were re-integrated so that text messages use the new bubbles, timestamps, and linking behaviour.

## Evidence 
<img width="1190" height="838" alt="Screenshot 2026-03-15 at 21 27 04" src="https://github.com/user-attachments/assets/3bed6ed0-455e-4222-9722-c9242345acd0" />

<img width="1277" height="678" alt="Screenshot 2026-03-15 at 21 27 44" src="https://github.com/user-attachments/assets/7addb92b-335d-4c8c-a8e9-f30c7254994f" />
