### PR TITLE
Create Qaul Color Sheet in Widgetbook

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,2 +1,3 @@
+export 'styles/qaul_color_sheet.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_navbar.dart';

--- a/qaul_ui/packages/qaul_components/lib/styles/qaul_color_sheet.dart
+++ b/qaul_ui/packages/qaul_components/lib/styles/qaul_color_sheet.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+enum QaulColorMode { light, dark }
+
+class QaulColorSheet {
+  QaulColorMode mode = QaulColorMode.light;
+
+  Color get background =>
+      mode == QaulColorMode.dark ? const Color(0xFF000000) : Colors.white;
+
+  Color get surfaceContainer => mode == QaulColorMode.dark
+      ? const Color(0xFF333333)
+      : const Color(0xFFE5E5E5);
+}

--- a/qaul_ui/packages/qaul_components/lib/styles/qaul_color_sheet.dart
+++ b/qaul_ui/packages/qaul_components/lib/styles/qaul_color_sheet.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
-enum QaulColorMode { light, dark }
-
 class QaulColorSheet {
-  QaulColorMode mode = QaulColorMode.light;
+  const QaulColorSheet(this.brightness);
 
-  Color get background =>
-      mode == QaulColorMode.dark ? const Color(0xFF000000) : Colors.white;
+  final Brightness brightness;
 
-  Color get surfaceContainer => mode == QaulColorMode.dark
-      ? const Color(0xFF333333)
-      : const Color(0xFFE5E5E5);
+  bool get _isDark => brightness == Brightness.dark;
+
+  Color get background => _isDark ? const Color(0xFF000000) : Colors.white;
+
+  Color get surfaceContainer =>
+      _isDark ? const Color(0xFF333333) : const Color(0xFFE5E5E5);
 }

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_navbar.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_navbar.dart
@@ -1,6 +1,7 @@
 import 'package:badges/badges.dart';
 import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_svg/flutter_svg.dart';
+import '../styles/qaul_color_sheet.dart';
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -59,16 +60,21 @@ String navBarTabIconPath(TabType tab, bool selected) {
 
 @visibleForTesting
 (Color, Color, Color) navBarColors(ThemeData theme) {
+  final colorSheet = QaulColorSheet(
+  );
+  colorSheet.mode = theme.brightness == Brightness.dark
+      ? QaulColorMode.dark
+      : QaulColorMode.light;
   final iconColor = theme.iconTheme.color ?? Colors.white;
   if (theme.brightness == Brightness.dark) {
     return (
-      kNavBarSelectedBackgroundDark,
+      colorSheet.surfaceContainer,
       iconColor,
       theme.navigationBarTheme.surfaceTintColor ?? iconColor,
     );
   }
   return (
-    kNavBarSelectedBackgroundLight,
+    colorSheet.surfaceContainer,
     kNavBarIconColorLight,
     kNavBarIconColorLight,
   );

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_navbar.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_navbar.dart
@@ -60,11 +60,7 @@ String navBarTabIconPath(TabType tab, bool selected) {
 
 @visibleForTesting
 (Color, Color, Color) navBarColors(ThemeData theme) {
-  final colorSheet = QaulColorSheet(
-  );
-  colorSheet.mode = theme.brightness == Brightness.dark
-      ? QaulColorMode.dark
-      : QaulColorMode.light;
+  final colorSheet = QaulColorSheet(theme.brightness);
   final iconColor = theme.iconTheme.color ?? Colors.white;
   if (theme.brightness == Brightness.dark) {
     return (
@@ -83,8 +79,6 @@ String navBarTabIconPath(TabType tab, bool selected) {
 const double _kNavBarSelectedSize = 45.0;
 const double _kNavBarSelectedRadius = 10.0;
 const double _kNavBarVerticalSpacing = 41.5;
-@visibleForTesting
-const Color kNavBarSelectedBackgroundDark = Color(0xFF898989);
 const Color _kNavBarDarkBackground = Color(0xFF000000);
 const double _kNavBarMobileHeight = 100.0;
 const double _kNavBarHorizontalPadding = 8.0;
@@ -110,8 +104,6 @@ Size navBarTabIconSize(TabType tab) =>
     _kNavBarTabIconSizes[tab] ?? (throw StateError('$tab has no icon size'));
 
 const Size _kNavBarMenuIconSize = Size(4.92, 20);
-@visibleForTesting
-const Color kNavBarSelectedBackgroundLight = Color(0xFFE5E5E5);
 @visibleForTesting
 const Color kNavBarIconColorLight = Color(0xFF000000);
 

--- a/qaul_ui/packages/qaul_components/test/qaul_navbar_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_navbar_test.dart
@@ -44,7 +44,7 @@ void main() {
     test('returns dark theme colors for Brightness.dark', () {
       final theme = ThemeData.dark();
       final (selected, icon, active) = navBarColors(theme);
-      expect(selected, kNavBarSelectedBackgroundDark);
+      expect(selected, const Color(0xFF333333));
       expect(icon, theme.iconTheme.color ?? Colors.white);
       expect(active, theme.navigationBarTheme.surfaceTintColor ?? theme.iconTheme.color ?? Colors.white);
     });
@@ -52,7 +52,7 @@ void main() {
     test('returns light theme colors for Brightness.light', () {
       final theme = ThemeData.light();
       final (selected, icon, active) = navBarColors(theme);
-      expect(selected, kNavBarSelectedBackgroundLight);
+      expect(selected, const Color(0xFFE5E5E5));
       expect(icon, kNavBarIconColorLight);
       expect(active, kNavBarIconColorLight);
     });

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -10,15 +10,30 @@
 // **************************************************************************
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:qaul_components_widgetbook/use_cases/qaul_fab.dart'
-    as _qaul_components_widgetbook_use_cases_qaul_fab;
 import 'package:qaul_components_widgetbook/use_cases/qaul_color_sheet.dart'
     as _qaul_components_widgetbook_use_cases_qaul_color_sheet;
+import 'package:qaul_components_widgetbook/use_cases/qaul_fab.dart'
+    as _qaul_components_widgetbook_use_cases_qaul_fab;
 import 'package:qaul_components_widgetbook/use_cases/qaul_navbar.dart'
     as _qaul_components_widgetbook_use_cases_qaul_navbar;
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
 
 final directories = <_widgetbook.WidgetbookNode>[
+  _widgetbook.WidgetbookFolder(
+    name: 'styles',
+    children: [
+      _widgetbook.WidgetbookComponent(
+        name: 'QaulColorSheet',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Palette',
+            builder: _qaul_components_widgetbook_use_cases_qaul_color_sheet
+                .buildColorSheetPaletteUseCase,
+          ),
+        ],
+      ),
+    ],
+  ),
   _widgetbook.WidgetbookFolder(
     name: 'widgets',
     children: [
@@ -34,16 +49,6 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Small (chat)',
             builder: _qaul_components_widgetbook_use_cases_qaul_fab
                 .buildQaulFabSmallUseCase,
-          ),
-        ],
-      ),
-      _widgetbook.WidgetbookComponent(
-        name: 'QaulColorSheet',
-        useCases: [
-          _widgetbook.WidgetbookUseCase(
-            name: 'Palette',
-            builder: _qaul_components_widgetbook_use_cases_qaul_color_sheet
-                .buildColorSheetPaletteUseCase,
           ),
         ],
       ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -12,6 +12,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:qaul_components_widgetbook/use_cases/qaul_fab.dart'
     as _qaul_components_widgetbook_use_cases_qaul_fab;
+import 'package:qaul_components_widgetbook/use_cases/qaul_color_sheet.dart'
+    as _qaul_components_widgetbook_use_cases_qaul_color_sheet;
 import 'package:qaul_components_widgetbook/use_cases/qaul_navbar.dart'
     as _qaul_components_widgetbook_use_cases_qaul_navbar;
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
@@ -32,6 +34,16 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Small (chat)',
             builder: _qaul_components_widgetbook_use_cases_qaul_fab
                 .buildQaulFabSmallUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'QaulColorSheet',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Palette',
+            builder: _qaul_components_widgetbook_use_cases_qaul_color_sheet
+                .buildColorSheetPaletteUseCase,
           ),
         ],
       ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_color_sheet.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_color_sheet.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(name: 'Palette', type: QaulColorSheet)
+Widget buildColorSheetPaletteUseCase(BuildContext context) {
+  return const _ColorSheetPaletteUseCase();
+}
+
+class _ColorSheetPaletteUseCase extends StatefulWidget {
+  const _ColorSheetPaletteUseCase();
+
+  @override
+  State<_ColorSheetPaletteUseCase> createState() => _ColorSheetPaletteUseCaseState();
+}
+
+class _ColorSheetPaletteUseCaseState extends State<_ColorSheetPaletteUseCase> {
+  final _colorSheet = QaulColorSheet();
+
+  String _hex(Color color) =>
+      color.toARGB32().toRadixString(16).padLeft(8, '0').toUpperCase();
+
+  @override
+  Widget build(BuildContext context) {
+    final darkMode = _colorSheet.mode == QaulColorMode.dark;
+    final surfaceContainerColor = _colorSheet.surfaceContainer;
+
+    return Material(
+      color: _colorSheet.background,
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Dark mode',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: darkMode ? Colors.white : Colors.black,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Switch(
+                  value: darkMode,
+                  onChanged: (enabled) {
+                    setState(() {
+                      _colorSheet.mode = enabled
+                          ? QaulColorMode.dark
+                          : QaulColorMode.light;
+                    });
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: 220,
+              height: 88,
+              decoration: BoxDecoration(
+                color: surfaceContainerColor,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: darkMode ? Colors.white24 : Colors.black12,
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Text(
+                      'surfaceContainer',
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '0x${_hex(surfaceContainerColor)}',
+                      style: const TextStyle(color: Colors.black),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_color_sheet.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_color_sheet.dart
@@ -4,87 +4,75 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'Palette', type: QaulColorSheet)
 Widget buildColorSheetPaletteUseCase(BuildContext context) {
-  return const _ColorSheetPaletteUseCase();
-}
+  final colorSheet = QaulColorSheet(Theme.of(context).brightness);
+  final isDark = colorSheet.brightness == Brightness.dark;
+  final textColor = isDark ? Colors.white : Colors.black;
 
-class _ColorSheetPaletteUseCase extends StatefulWidget {
-  const _ColorSheetPaletteUseCase();
-
-  @override
-  State<_ColorSheetPaletteUseCase> createState() => _ColorSheetPaletteUseCaseState();
-}
-
-class _ColorSheetPaletteUseCaseState extends State<_ColorSheetPaletteUseCase> {
-  final _colorSheet = QaulColorSheet();
-
-  String _hex(Color color) =>
+  String hex(Color color) =>
       color.toARGB32().toRadixString(16).padLeft(8, '0').toUpperCase();
+
+  return Material(
+    color: colorSheet.background,
+    child: Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _ColorSwatch(
+            label: 'surfaceContainer',
+            color: colorSheet.surfaceContainer,
+            textColor: textColor,
+            borderColor: isDark ? Colors.white24 : Colors.black12,
+            hex: hex,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _ColorSwatch extends StatelessWidget {
+  const _ColorSwatch({
+    required this.label,
+    required this.color,
+    required this.textColor,
+    required this.borderColor,
+    required this.hex,
+  });
+
+  final String label;
+  final Color color;
+  final Color textColor;
+  final Color borderColor;
+  final String Function(Color) hex;
 
   @override
   Widget build(BuildContext context) {
-    final darkMode = _colorSheet.mode == QaulColorMode.dark;
-    final surfaceContainerColor = _colorSheet.surfaceContainer;
-
-    return Material(
-      color: _colorSheet.background,
+    return Container(
+      width: 220,
+      height: 88,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: borderColor),
+      ),
       child: Padding(
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.all(10),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Row(
-              children: [
-                Text(
-                  'Dark mode',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: darkMode ? Colors.white : Colors.black,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Switch(
-                  value: darkMode,
-                  onChanged: (enabled) {
-                    setState(() {
-                      _colorSheet.mode = enabled
-                          ? QaulColorMode.dark
-                          : QaulColorMode.light;
-                    });
-                  },
-                ),
-              ],
+            Text(
+              label,
+              style: TextStyle(
+                color: textColor,
+                fontWeight: FontWeight.w600,
+              ),
             ),
-            const SizedBox(height: 16),
-            Container(
-              width: 220,
-              height: 88,
-              decoration: BoxDecoration(
-                color: surfaceContainerColor,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: darkMode ? Colors.white24 : Colors.black12,
-                ),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text(
-                      'surfaceContainer',
-                      style: TextStyle(
-                        color: Colors.black,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      '0x${_hex(surfaceContainerColor)}',
-                      style: const TextStyle(color: Colors.black),
-                    ),
-                  ],
-                ),
-              ),
+            const SizedBox(height: 4),
+            Text(
+              '0x${hex(color)}',
+              style: TextStyle(color: textColor),
             ),
           ],
         ),


### PR DESCRIPTION
## Description

Introduce a centralized theme palette component, QaulColorSheet, to manage colors for light/dark mode.
Expose it in WidgetBook via a new interactive use case, then update QaulNavBar to derive the selected tab background color from QaulColorSheet based on ThemeData.brightness.

## Evidence
<img width="400" height="700" alt="image" src="https://github.com/user-attachments/assets/00309441-9b00-4b4e-8b62-c635b0b377ab" />
<img width="400" height="700" alt="image" src="https://github.com/user-attachments/assets/39dd9ea4-66fa-455f-a529-ff8aa337f3bb" />
