### PR TITLE
fix: build problem on non-linux OSs

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,9 +4,6 @@ members = [
     # qaul library
     "libqaul",
 
-    # ble module
-    "ble_module",
-    
     # protobuf types
     "qaul-proto",
 
@@ -19,3 +16,4 @@ members = [
     "libp2p_modules/qaul_info",
     "libp2p_modules/qaul_messaging"
 ]
+exclude = ["ble_module"]


### PR DESCRIPTION
exclude linux ble_module from build on non-linux systems