### PR TITLE
Windows support via TCP fallback for qauld-ctl Unix Socket

### DIFF
--- a/rust/clients/qauld-ctl/src/main.rs
+++ b/rust/clients/qauld-ctl/src/main.rs
@@ -9,12 +9,14 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use futures::{SinkExt, StreamExt};
 use prost::Message;
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    net::UnixStream,
-};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use uuid::Uuid;
+
+#[cfg(windows)]
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
 
 use crate::commands::RpcCommand;
 

--- a/rust/clients/qauld-ctl/src/main.rs
+++ b/rust/clients/qauld-ctl/src/main.rs
@@ -9,7 +9,10 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use futures::{SinkExt, StreamExt};
 use prost::Message;
-use tokio::net::UnixStream;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::UnixStream,
+};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use uuid::Uuid;
 
@@ -21,10 +24,17 @@ pub use qaul_proto::qaul_rpc as proto;
 mod cli;
 mod commands;
 
+/// Default TCP address used for windows
+#[cfg(windows)]
+const DEFAULT_TCP_ADDR: &str = "127.0.0.1:9199";
+
 /// A Pre flight requesst to get the user ID before executing any command
-async fn preflight_request(
-    client: &mut Framed<UnixStream, LengthDelimitedCodec>,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+async fn preflight_request<T>(
+    client: &mut Framed<T, LengthDelimitedCodec>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
     log::info!("executing preflight request");
     let (data, module) = commands::default_user_proto_message();
     let request_id = Uuid::new_v4().to_string();
@@ -59,25 +69,10 @@ async fn preflight_request(
     Ok(user_id_bytes)
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    pretty_env_logger::init();
-
-    let cli = Cli::parse();
-    let qauld_sock = if let Some(socket) = cli.socket {
-        socket
-    } else if let Some(socket_dir) = cli.dir {
-        let path = PathBuf::from(socket_dir).join("qauld.sock");
-        path.to_str()
-            .expect("failed to get name of dir")
-            .to_string()
-    } else {
-        "qauld.sock".to_string()
-    };
-
-    let client = UnixStream::connect(&qauld_sock).await?;
-    println!("qauld-ctl connected to qauld daemon at: {qauld_sock}");
-
+async fn run<T>(client: T, cli: Cli) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
     let mut framed_client = LengthDelimitedCodec::builder()
         .length_field_offset(0)
         .length_field_type::<u16>()
@@ -98,6 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let (data, module) = rpc_command.encode_request()?;
+
     // Create RPC message container
     let proto_message = proto::QaulRpc {
         module: module.into(),
@@ -110,6 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     proto_message
         .encode(&mut rpc_msg)
         .expect("Vec<u8> provides capacity as needed");
+
     framed_client.send(rpc_msg.into()).await?;
 
     if rpc_command.expects_response() {
@@ -119,6 +116,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 _ => {}
             }
         }
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    pretty_env_logger::init();
+    let cli = Cli::parse();
+
+    #[cfg(unix)]
+    {
+        let qauld_sock = if let Some(socket) = &cli.socket {
+            socket.clone()
+        } else if let Some(socket_dir) = &cli.dir {
+            let path = PathBuf::from(socket_dir).join("qauld.sock");
+            path.to_str()
+                .expect("failed to get name of dir")
+                .to_string()
+        } else {
+            "qauld.sock".to_string()
+        };
+
+        let client = UnixStream::connect(&qauld_sock).await?;
+        println!("qauld-ctl connected to qauld daemon at: {qauld_sock}");
+        run(client, cli).await?;
+    }
+
+    #[cfg(windows)]
+    {
+        let addr = if let Some(socket) = &cli.socket {
+            socket.clone()
+        } else {
+            DEFAULT_TCP_ADDR.to_string()
+        };
+
+        let client = TcpStream::connect(&addr).await?;
+        println!("qauld-ctl connected to qauld daemon at: {addr}");
+        run(client, cli).await?;
     }
 
     Ok(())

--- a/rust/clients/qauld/src/socket.rs
+++ b/rust/clients/qauld/src/socket.rs
@@ -1,14 +1,14 @@
 // Copyright (c) 2021 Open Community Project Association https://ocpa.ch
 // This software is published under the AGPLv3 license.
 
-//! Unix socket server for qauld
+//! Socket server for qauld
 
 use futures::{stream::StreamExt, SinkExt};
 use futures_ticker::Ticker;
 use prost::Message;
 use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
 use tokio::{
-    net::UnixListener,
+    io::{AsyncRead, AsyncWrite},
     signal,
     sync::{
         mpsc::{self, Sender},
@@ -18,27 +18,73 @@ use tokio::{
 };
 use tokio_util::{bytes::Bytes, codec::LengthDelimitedCodec};
 
+#[cfg(windows)]
+use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio::net::UnixListener;
+
 /// protobuf RPC definition
 pub use qaul_proto::qaul_rpc as proto;
 
-/// Starts the qauld unix socket server.
-/// Runs infinitely until a shutdown signal is receibed.
-/// It accepts connections on `qauld.sock` in cwd,
-/// forwards requests to libqaul, and sends responses back to clients.
-pub async fn start_server(socket_dir: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let socket_path = socket_dir.join("qauld.sock");
-    if socket_path.exists() {
-        fs::remove_file(&socket_path)?;
+/// Default TCP address used on Windows where Unix sockets are unavailable.
+#[cfg(windows)]
+const DEFAULT_TCP_ADDR: &str = "127.0.0.1:9199";
+
+async fn handle_client<T>(
+    stream: T,
+    register: Arc<Mutex<HashMap<String, Sender<Bytes>>>>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    let (tx, mut rx) = mpsc::channel(100);
+
+    let framed_stream = LengthDelimitedCodec::builder()
+        .length_field_offset(0)
+        .length_field_type::<u16>()
+        .length_adjustment(0)
+        .new_framed(stream);
+    let (mut writer, mut reader) = framed_stream.split();
+
+    loop {
+        tokio::select! {
+            message = reader.next() => {
+                match message {
+                    Some(msg) => {
+                        let data = msg?.to_vec();
+                        match proto::QaulRpc::decode(&data[..]) {
+                            Ok(rpc_msg) => {
+                                let client_request_id = rpc_msg.request_id;
+                                log::trace!("message received from client: {client_request_id}");
+                                {
+                                    let mut reg = register.lock().await;
+                                    reg.insert(client_request_id.clone(), tx.clone());
+                                }
+                            }
+                            Err(error) => {
+                                log::error!("{:?}", error);
+                            }
+                        }
+                        libqaul::api::send_rpc(data);
+                    }
+                    None => { break; }
+                }
+            },
+            res = rx.recv() => {
+                if let Some(data) = res {
+                    writer.send(data.into()).await?;
+                } else {
+                    break;
+                }
+            }
+        };
     }
 
-    let listener = UnixListener::bind(&socket_path)?;
-    println!("qauld unix socket server started");
+    Ok(())
+}
 
-    let client_request_register: Arc<Mutex<HashMap<String, Sender<Bytes>>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-
-    //  Central RPC poller. Polls libqaul for a response
-    let register_clone = client_request_register.clone();
+/// RPC poller which forwards libqaul response
+fn spawn_rpc_poller(register: Arc<Mutex<HashMap<String, Sender<Bytes>>>>) {
     tokio::spawn(async move {
         let mut futures_ticker = Ticker::new(Duration::from_millis(10));
         loop {
@@ -50,8 +96,8 @@ pub async fn start_server(socket_dir: PathBuf) -> Result<(), Box<dyn std::error:
                         let sender;
                         log::info!("received response for client: {client_id}");
                         {
-                            let register = register_clone.lock().await;
-                            sender = register.get(&client_id).cloned();
+                            let reg = register.lock().await;
+                            sender = reg.get(&client_id).cloned();
                         }
                         if let Some(rx) = sender {
                             if let Err(err) = rx.send(data.into()).await {
@@ -63,74 +109,76 @@ pub async fn start_server(socket_dir: PathBuf) -> Result<(), Box<dyn std::error:
                     }
                     _ => {}
                 },
-                // move on to the next tick
                 _ => {}
             }
         }
     });
+}
 
-    loop {
-        tokio::select! {
-            res = listener.accept() => {
-                let (stream, addr) = res?;
-                let register_clone = client_request_register.clone();
-                tokio::spawn(async move {
-                    log::info!("client connected: {addr:#?}");
+/// Starts the qauld socket server.
+/// Runs infinitely until a shutdown signal is received.
+pub async fn start_server(socket_dir: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client_request_register: Arc<Mutex<HashMap<String, Sender<Bytes>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
 
-                    let (tx, mut rx) = mpsc::channel(100);
+    spawn_rpc_poller(client_request_register.clone());
 
-                    let framed_stream = LengthDelimitedCodec::builder().length_field_offset(0)
-                        .length_field_type::<u16>()
-                        .length_adjustment(0)
-                        .new_framed(stream);
-                    let (mut writer, mut reader) = framed_stream.split();
+    #[cfg(unix)]
+    {
+        let socket_path = socket_dir.join("qauld.sock");
+        if socket_path.exists() {
+            fs::remove_file(&socket_path)?;
+        }
 
-                    loop {
-                        tokio::select! {
-                            message = reader.next() => {
-                                match message {
-                                    Some(msg) => {
-                                        let data = msg?.to_vec();
-                                        match proto::QaulRpc::decode(&data[..]) {
-                                            Ok(rpc_msg) => {
-                                                let client_request_id = rpc_msg.request_id;
-                                                log::trace!("message received from client: {client_request_id}");
-                                                {
-                                                    let mut register = register_clone.lock().await;
-                                                    register.insert(client_request_id.clone(), tx.clone());
-                                                }
-                                            }
-                                            Err(error) => {
-                                                log::error!("{:?}", error);
-                                            }
-                                        }
-                                        libqaul::api::send_rpc(data);
-                                    }
-                                    None => { break; }
-                                }
+        let listener = UnixListener::bind(&socket_path)?;
+        println!("qauld unix socket server started");
 
-                            },
-                            res = rx.recv() => {
-                                if let Some(data) = res {
-                                    writer.send(data.into()).await?;
-                                } else {
-                                    break;
-                                }
-                            }
-                        };
-                    };
+        loop {
+            tokio::select! {
+                res = listener.accept() => {
+                    let (stream, addr) = res?;
+                    let register_clone = client_request_register.clone();
+                    tokio::spawn(async move {
+                        log::info!("client connected: {addr:#?}");
+                        if let Err(e) = handle_client(stream, register_clone).await {
+                            log::error!("client error: {e:#?}");
+                        }
+                    });
+                },
+                _ = signal::ctrl_c() => {
+                    log::info!("shutdown triggered");
+                    break;
+                }
+            }
+        }
 
-                   Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
-                });
-            },
-            _ = signal::ctrl_c() => {
-                log::info!("shutdown triggered");
-                break;
+        fs::remove_file(socket_path)?;
+    }
+
+    #[cfg(windows)]
+    {
+        let listener = TcpListener::bind(DEFAULT_TCP_ADDR).await?;
+        println!("qauld TCP socket server started on {DEFAULT_TCP_ADDR}");
+
+        loop {
+            tokio::select! {
+                res = listener.accept() => {
+                    let (stream, addr) = res?;
+                    let register_clone = client_request_register.clone();
+                    tokio::spawn(async move {
+                        log::info!("client connected: {addr:#?}");
+                        if let Err(e) = handle_client(stream, register_clone).await {
+                            log::error!("client error: {e:#?}");
+                        }
+                    });
+                },
+                _ = signal::ctrl_c() => {
+                    log::info!("shutdown triggered");
+                    break;
+                }
             }
         }
     }
-
-    fs::remove_file(socket_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR introduces a fallback mechanism for qauld-ctl to control qauld through TCP on Windows against Unix sockets on Unix-based machines.

Closes: #818 
