### PR TITLE
Adjust fetch of user prior to use

### DIFF
--- a/qaul_ui/lib/decorators/deeplink_decorator.dart
+++ b/qaul_ui/lib/decorators/deeplink_decorator.dart
@@ -75,9 +75,10 @@ class _DeepLinkWrapperState extends ConsumerState<DeepLinkWrapper> {
 
   void _navigateToChat(String id) {
     final usr = ref.read(defaultUserProvider)!;
-    final otherUser = _userWithId(id);
     final room = _roomWithId(id);
-    if (otherUser == null || room == null) return;
+    if (room == null) return;
+    final otherUser = room.isGroupChatRoom ? null : _otherUserForRoom(room, usr);
+    if (!room.isGroupChatRoom && otherUser == null) return;
     openChat(room, ref: ref, context: context, user: usr, otherUser: otherUser);
   }
 
@@ -86,5 +87,13 @@ class _DeepLinkWrapperState extends ConsumerState<DeepLinkWrapper> {
   ChatRoom? _roomWithId(String id) =>
       ref.read(chatRoomsProvider).firstWhereOrNull((r) => r.idBase58 == id);
 
-  User? _userWithId(String id) => ref.read(usersStoreProvider).firstWhereOrNull((u) => u.idBase58 == id);
+  User? _otherUserForRoom(ChatRoom room, User defaultUser) {
+    final users = ref.read(usersStoreProvider);
+    final fromStore = users.firstWhereOrNull(
+      (u) => u.conversationId?.equals(room.conversationId) ?? false,
+    );
+    if (fromStore != null) return fromStore;
+    return room.members
+        .firstWhereOrNull((member) => member.idBase58 != defaultUser.idBase58);
+  }
 }

--- a/qaul_ui/lib/decorators/deeplink_decorator.dart
+++ b/qaul_ui/lib/decorators/deeplink_decorator.dart
@@ -73,12 +73,26 @@ class _DeepLinkWrapperState extends ConsumerState<DeepLinkWrapper> {
     }
   }
 
-  void _navigateToChat(String id) {
+  Future<void> _navigateToChat(String id) async {
     final usr = ref.read(defaultUserProvider)!;
     final room = _roomWithId(id);
     if (room == null) return;
-    final otherUser = room.isGroupChatRoom ? null : _otherUserForRoom(room, usr);
-    if (!room.isGroupChatRoom && otherUser == null) return;
+
+    User? otherUser;
+    if (!room.isGroupChatRoom) {
+      final store = ref.read(usersStoreProvider.notifier);
+      // Try the sync store lookup first; if missing, fetch via RPC.
+      otherUser = store.otherUserInDirectRoom(room, usr);
+      if (otherUser == null) {
+        final otherMember = room.members
+            .firstWhereOrNull((m) => m.idBase58 != usr.idBase58);
+        if (otherMember == null) return;
+        otherUser = await store.getByUserID(otherMember.idBase58);
+      }
+      if (otherUser == null) return;
+    }
+
+    if (!mounted) return;
     openChat(room, ref: ref, context: context, user: usr, otherUser: otherUser);
   }
 
@@ -86,14 +100,4 @@ class _DeepLinkWrapperState extends ConsumerState<DeepLinkWrapper> {
 
   ChatRoom? _roomWithId(String id) =>
       ref.read(chatRoomsProvider).firstWhereOrNull((r) => r.idBase58 == id);
-
-  User? _otherUserForRoom(ChatRoom room, User defaultUser) {
-    final users = ref.read(usersStoreProvider);
-    final fromStore = users.firstWhereOrNull(
-      (u) => u.conversationId?.equals(room.conversationId) ?? false,
-    );
-    if (fromStore != null) return fromStore;
-    return room.members
-        .firstWhereOrNull((member) => member.idBase58 != defaultUser.idBase58);
-  }
 }

--- a/qaul_ui/lib/main.dart
+++ b/qaul_ui/lib/main.dart
@@ -15,7 +15,17 @@ import 'l10n/app_localizations.dart';
 import 'qaul_app.dart';
 import 'stores/stores.dart';
 
-final _container = ProviderContainer();
+final _container = ProviderContainer(
+  overrides: [
+    fetchUserByIdForRpcProvider.overrideWith(
+      (ref) => (id) => ref.read(qaulWorkerProvider).getUserById(id),
+    ),
+    onGroupMemberUserResolvedProvider.overrideWith(
+      (ref) => (u) =>
+          ref.read(usersStoreProvider.notifier).mergeResolvedRpcUser(u),
+    ),
+  ],
+);
 
 void main() async {
   runZonedGuarded<Future<void>>(() async {

--- a/qaul_ui/lib/main.dart
+++ b/qaul_ui/lib/main.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
+import 'package:fast_base58/fast_base58.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -15,10 +17,27 @@ import 'l10n/app_localizations.dart';
 import 'qaul_app.dart';
 import 'stores/stores.dart';
 
+final _inFlightUserFetchById = <String, Future<User?>>{};
+
 final _container = ProviderContainer(
   overrides: [
     fetchUserByIdForRpcProvider.overrideWith(
-      (ref) => (id) => ref.read(qaulWorkerProvider).getUserById(id),
+      (ref) => (id) {
+        final idBase58 = Base58Encode(id);
+        final inStore = ref
+            .read(usersStoreProvider)
+            .firstWhereOrNull((u) => u.idBase58 == idBase58);
+        if (inStore != null) return Future.value(inStore);
+
+        final inFlight = _inFlightUserFetchById[idBase58];
+        if (inFlight != null) return inFlight;
+
+        final request = ref.read(qaulWorkerProvider).getUserById(id);
+        _inFlightUserFetchById[idBase58] = request;
+        return request.whenComplete(() {
+          _inFlightUserFetchById.remove(idBase58);
+        });
+      },
     ),
     onGroupMemberUserResolvedProvider.overrideWith(
       (ref) => (u) =>

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -119,9 +119,8 @@ class _ChatState extends _BaseTabState<_Chat> {
                 );
               }
 
-              final otherUser = users.firstWhereOrNull((u) =>
-                  u.conversationId != null &&
-                  u.conversationId!.equals(room.conversationId));
+              final otherUser =
+                  _resolveOtherUserForDirectRoom(room, users, defaultUser);
 
               if (otherUser == null) {
                 _log.warning('single-person room with unknown otherUser');
@@ -133,6 +132,7 @@ class _ChatState extends _BaseTabState<_Chat> {
                 content: _contentFromOverview(
                   room.lastMessagePreview,
                   theme,
+                  room: room,
                   users: users,
                   l10n: l10n,
                 ),
@@ -200,7 +200,7 @@ class _ChatState extends _BaseTabState<_Chat> {
                   : ChatScreen(
                       currentOpenChat,
                       defaultUser,
-                      otherUser: getOtherUser(currentOpenChat, users),
+                      otherUser: getOtherUser(currentOpenChat, users, defaultUser),
                     ),
             ),
           ),
@@ -209,9 +209,8 @@ class _ChatState extends _BaseTabState<_Chat> {
     );
   }
 
-  User? getOtherUser(ChatRoom chat, List<User> users) {
-    final otherUser = users.firstWhereOrNull(
-        (u) => u.conversationId?.equals(chat.conversationId) ?? false);
+  User? getOtherUser(ChatRoom chat, List<User> users, User defaultUser) {
+    final otherUser = _resolveOtherUserForDirectRoom(chat, users, defaultUser);
 
     if (otherUser == null && !chat.isGroupChatRoom) {
       _log.warning('single-person room with unknown otherUser');
@@ -222,6 +221,7 @@ class _ChatState extends _BaseTabState<_Chat> {
   Widget _contentFromOverview(
     MessageContent? message,
     TextTheme theme, {
+    ChatRoom? room,
     required List<User> users,
     required AppLocalizations l10n,
   }) {
@@ -233,7 +233,13 @@ class _ChatState extends _BaseTabState<_Chat> {
         overflow: TextOverflow.ellipsis,
       );
     } else if (message is GroupEventContent) {
-      return _contentFromGroupEvent(message, theme, users: users, l10n: l10n);
+      return _contentFromGroupEvent(
+        message,
+        theme,
+        room: room,
+        users: users,
+        l10n: l10n,
+      );
     } else if (message is FileShareContent) {
       return Text(
         '${message.fileName} · ${fileSize(message.size)}',
@@ -250,6 +256,7 @@ class _ChatState extends _BaseTabState<_Chat> {
   Widget _contentFromGroupEvent(
     GroupEventContent message,
     TextTheme theme, {
+    ChatRoom? room,
     required List<User> users,
     required AppLocalizations l10n,
   }) {
@@ -272,11 +279,17 @@ class _ChatState extends _BaseTabState<_Chat> {
         overflow: TextOverflow.ellipsis,
       );
     } else {
-      final u =
-          users.firstWhereOrNull((e) => e.idBase58 == message.userIdBase58);
+      final u = users.firstWhereOrNull((e) => e.idBase58 == message.userIdBase58) ??
+          room?.members
+              .firstWhereOrNull((member) => member.idBase58 == message.userIdBase58);
       if (u == null) {
         _log.warning('group event message from unknown user');
-        return const SizedBox.shrink();
+        return Text(
+          l10n.unknown,
+          style: theme.bodyLarge!.copyWith(fontStyle: FontStyle.italic),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        );
       }
 
       String event = '';
@@ -309,6 +322,17 @@ class _ChatState extends _BaseTabState<_Chat> {
         overflow: TextOverflow.ellipsis,
       );
     }
+  }
+
+  User? _resolveOtherUserForDirectRoom(
+      ChatRoom room, List<User> users, User defaultUser) {
+    final fromStore = users.firstWhereOrNull(
+      (u) => u.conversationId?.equals(room.conversationId) ?? false,
+    );
+    if (fromStore != null) return fromStore;
+
+    return room.members
+        .firstWhereOrNull((u) => u.idBase58 != defaultUser.idBase58);
   }
 }
 

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -96,7 +96,7 @@ class _ChatState extends _BaseTabState<_Chat> {
                   content: _contentFromOverview(
                     room.lastMessagePreview,
                     theme,
-                    users: users,
+                    room: room,
                     l10n: l10n,
                   ),
                   trailingMetadata: Row(
@@ -119,8 +119,9 @@ class _ChatState extends _BaseTabState<_Chat> {
                 );
               }
 
-              final otherUser =
-                  _resolveOtherUserForDirectRoom(room, users, defaultUser);
+              final otherUser = ref
+                  .read(usersStoreProvider.notifier)
+                  .otherUserInDirectRoom(room, defaultUser);
 
               if (otherUser == null) {
                 _log.warning('single-person room with unknown otherUser');
@@ -133,7 +134,6 @@ class _ChatState extends _BaseTabState<_Chat> {
                   room.lastMessagePreview,
                   theme,
                   room: room,
-                  users: users,
                   l10n: l10n,
                 ),
                 trailingMetadata: Row(
@@ -200,7 +200,7 @@ class _ChatState extends _BaseTabState<_Chat> {
                   : ChatScreen(
                       currentOpenChat,
                       defaultUser,
-                      otherUser: getOtherUser(currentOpenChat, users, defaultUser),
+                      otherUser: getOtherUser(currentOpenChat, defaultUser),
                     ),
             ),
           ),
@@ -209,8 +209,10 @@ class _ChatState extends _BaseTabState<_Chat> {
     );
   }
 
-  User? getOtherUser(ChatRoom chat, List<User> users, User defaultUser) {
-    final otherUser = _resolveOtherUserForDirectRoom(chat, users, defaultUser);
+  User? getOtherUser(ChatRoom chat, User defaultUser) {
+    final otherUser = ref
+        .read(usersStoreProvider.notifier)
+        .otherUserInDirectRoom(chat, defaultUser);
 
     if (otherUser == null && !chat.isGroupChatRoom) {
       _log.warning('single-person room with unknown otherUser');
@@ -221,8 +223,7 @@ class _ChatState extends _BaseTabState<_Chat> {
   Widget _contentFromOverview(
     MessageContent? message,
     TextTheme theme, {
-    ChatRoom? room,
-    required List<User> users,
+    required ChatRoom room,
     required AppLocalizations l10n,
   }) {
     if (message is TextMessageContent) {
@@ -237,7 +238,6 @@ class _ChatState extends _BaseTabState<_Chat> {
         message,
         theme,
         room: room,
-        users: users,
         l10n: l10n,
       );
     } else if (message is FileShareContent) {
@@ -256,8 +256,7 @@ class _ChatState extends _BaseTabState<_Chat> {
   Widget _contentFromGroupEvent(
     GroupEventContent message,
     TextTheme theme, {
-    ChatRoom? room,
-    required List<User> users,
+    required ChatRoom room,
     required AppLocalizations l10n,
   }) {
     if (message.type == GroupEventContentType.none) {
@@ -279,9 +278,9 @@ class _ChatState extends _BaseTabState<_Chat> {
         overflow: TextOverflow.ellipsis,
       );
     } else {
-      final u = users.firstWhereOrNull((e) => e.idBase58 == message.userIdBase58) ??
-          room?.members
-              .firstWhereOrNull((member) => member.idBase58 == message.userIdBase58);
+      final u = ref
+          .read(usersStoreProvider.notifier)
+          .findMemberInRoom(message.userId, room);
       if (u == null) {
         _log.warning('group event message from unknown user');
         return Text(
@@ -324,16 +323,6 @@ class _ChatState extends _BaseTabState<_Chat> {
     }
   }
 
-  User? _resolveOtherUserForDirectRoom(
-      ChatRoom room, List<User> users, User defaultUser) {
-    final fromStore = users.firstWhereOrNull(
-      (u) => u.conversationId?.equals(room.conversationId) ?? false,
-    );
-    if (fromStore != null) return fromStore;
-
-    return room.members
-        .firstWhereOrNull((u) => u.idBase58 != defaultUser.idBase58);
-  }
 }
 
 class _GroupInviteTile extends HookConsumerWidget {

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -551,16 +551,23 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
   }
 
-  User _author(Message e) => e.senderId.equals(user.id)
-      ? user
-      : ref.read(usersStoreProvider).firstWhere((usr) => usr.id.equals(e.senderId));
+  User _author(Message e, AppLocalizations l10n) {
+    if (e.senderId.equals(user.id)) return user;
+    final store = ref.read(usersStoreProvider);
+    final fromStore = store.firstWhereOrNull((usr) => usr.id.equals(e.senderId));
+    if (fromStore != null) return fromStore;
+    final fromRoom =
+        room.members.firstWhereOrNull((m) => m.id.equals(e.senderId));
+    if (fromRoom != null) return fromRoom;
+    return User(name: l10n.unknown, id: e.senderId);
+  }
 
   List<types.Message>? messages(ChatRoom room,
       {required AppLocalizations l10n}) {
     return room.messages
         ?.sorted()
-        .map(
-            (e) => e.toInternalMessage(_author(e), ref, l10n: l10n, room: room))
+        .map((e) =>
+            e.toInternalMessage(_author(e, l10n), ref, l10n: l10n, room: room))
         .toList();
   }
 

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -553,13 +553,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   User _author(Message e, AppLocalizations l10n) {
     if (e.senderId.equals(user.id)) return user;
-    final store = ref.read(usersStoreProvider);
-    final fromStore = store.firstWhereOrNull((usr) => usr.id.equals(e.senderId));
-    if (fromStore != null) return fromStore;
-    final fromRoom =
-        room.members.firstWhereOrNull((m) => m.id.equals(e.senderId));
-    if (fromRoom != null) return fromRoom;
-    return User(name: l10n.unknown, id: e.senderId);
+    final store = ref.read(usersStoreProvider.notifier);
+    return store.findMemberInRoom(e.senderId, room) ??
+        User(name: l10n.unknown, id: e.senderId);
   }
 
   List<types.Message>? messages(ChatRoom room,

--- a/qaul_ui/lib/stores/stores.dart
+++ b/qaul_ui/lib/stores/stores.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:fast_base58/fast_base58.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -53,6 +53,11 @@ class UsersStore extends Notifier<List<User>> {
     }
   }
 
+  void mergeResolvedRpcUser(User u) {
+    _updateMany([u]);
+    _syncLookup();
+  }
+
   /// Always hits the RPC, bypassing the local-first check in [getByUserID].
   /// Updates the user in state via merge if found.
   Future<User?> refreshUser(String idBase58) async {

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -41,6 +41,22 @@ class UsersStore extends Notifier<List<User>> {
   // Single-user lookups
   // ---------------------------------------------------------------------------
 
+  /// Resolves a user by [id] from the store, falling back to
+  /// [ChatRoom.members] if not found.
+  User? findMemberInRoom(Uint8List id, ChatRoom room) {
+    return state.firstWhereOrNull((u) => u.id.equals(id)) ??
+        room.members.firstWhereOrNull((m) => m.id.equals(id));
+  }
+
+  /// Resolves the other participant in a direct (1-to-1) chat room.
+  User? otherUserInDirectRoom(ChatRoom room, User defaultUser) {
+    final otherMember = room.members.firstWhereOrNull(
+      (m) => m.idBase58 != defaultUser.idBase58,
+    );
+    if (otherMember == null) return null;
+    return findMemberInRoom(otherMember.id, room);
+  }
+
   Future<User?> getByUserID(String idBase58) async {
     final match = state.where((u) => u.idBase58 == idBase58);
     if (match.isNotEmpty) return match.first;

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart';
 import 'package:fast_base58/fast_base58.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:hooks_riverpod/legacy.dart';
 
 final defaultUserProvider = StateProvider<User?>((ref) => null);
@@ -12,6 +13,16 @@ final defaultUserProvider = StateProvider<User?>((ref) => null);
 /// (which live in the `qaul_rpc` package and cannot import app-layer stores)
 /// can look up users during message decoding.
 final userLookupProvider = StateProvider<List<User>>((ref) => []);
+
+/// Resolves a user by raw id bytes when they are missing from [userLookupProvider].
+///
+/// The app must override this (typically to call [LibqaulWorker.getUserById]) so group
+/// and chat decoding can load members that are not in the paginated user list.
+final fetchUserByIdForRpcProvider =
+    Provider<Future<User?> Function(Uint8List userId)?>((ref) => null);
+
+/// When a user is fetched during group decoding, the app may merge them into [UsersStore].
+final onGroupMemberUserResolvedProvider = Provider<void Function(User)?>((ref) => null);
 
 class PaginationState {
   const PaginationState({

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
@@ -1,19 +1,59 @@
 part of 'abstract_rpc_module_translator.dart';
 
+Future<List<User>> _resolveUsersForGroupInfo(
+  GroupInfo g,
+  List<User> knownUsers,
+  Ref ref,
+) async {
+  final fetch = ref.read(fetchUserByIdForRpcProvider);
+  final onResolved = ref.read(onGroupMemberUserResolvedProvider);
+  final memberIdSet =
+      g.members.map((m) => Base58Encode(Uint8List.fromList(m.userId))).toSet();
+  final result = <User>[];
+  for (final user in knownUsers) {
+    if (memberIdSet.contains(user.idBase58)) {
+      result.add(user);
+    }
+  }
+  if (fetch == null) return result;
+
+  final resolvedIds = result.map((u) => u.idBase58).toSet();
+  final toFetch = <Uint8List>[];
+  for (final m in g.members) {
+    final idBytes = Uint8List.fromList(m.userId);
+    if (resolvedIds.contains(Base58Encode(idBytes))) continue;
+    resolvedIds.add(Base58Encode(idBytes));
+    toFetch.add(idBytes);
+  }
+  if (toFetch.isEmpty) return result;
+
+  final fetched = await Future.wait(toFetch.map(fetch));
+  for (var i = 0; i < toFetch.length; i++) {
+    final u = fetched[i];
+    if (u != null) {
+      result.add(u);
+      onResolved?.call(u);
+    }
+  }
+  return result;
+}
+
 class GroupTranslator extends RpcModuleTranslator {
   @override
   Modules get type => Modules.GROUP;
 
   @override
   Future<RpcTranslatorResponse?> decodeMessageBytes(List<int> data, Ref ref) async {
-    final users = ref.read(userLookupProvider);
+    final knownUsers = ref.read(userLookupProvider);
     final message = Group.fromBuffer(data);
 
     switch (message.whichMessage()) {
       case Group_Message.groupInfoResponse:
+        final info = message.ensureGroupInfoResponse();
+        final users = await _resolveUsersForGroupInfo(info, knownUsers, ref);
         return RpcTranslatorResponse(
           type,
-          ChatRoom.fromRpcGroupInfo(message.ensureGroupInfoResponse(), users),
+          ChatRoom.fromRpcGroupInfo(info, users),
         );
       case Group_Message.groupCreateResponse:
         final createResult = message.ensureGroupCreateResponse().result;
@@ -31,18 +71,20 @@ class GroupTranslator extends RpcModuleTranslator {
         final replyResult = message.ensureGroupReplyInviteResponse().result;
         return _receiveGroupResultResponse(replyResult);
       case Group_Message.groupListResponse:
-        final groups = message
-            .ensureGroupListResponse()
-            .groups
-            .map((g) => ChatRoom.fromRpcGroupInfo(g, users))
-            .toList();
-        return RpcTranslatorResponse(type, groups);
+        final groupsPb = message.ensureGroupListResponse().groups;
+        final rooms = <ChatRoom>[];
+        for (final g in groupsPb) {
+          final users = await _resolveUsersForGroupInfo(g, knownUsers, ref);
+          rooms.add(ChatRoom.fromRpcGroupInfo(g, users));
+        }
+        return RpcTranslatorResponse(type, rooms);
       case Group_Message.groupInvitedResponse:
-        final invites = message
-            .ensureGroupInvitedResponse()
-            .invited
-            .map((e) => GroupInvite.fromRpcGroupInvited(e, users))
-            .toList();
+        final invited = message.ensureGroupInvitedResponse().invited;
+        final invites = <GroupInvite>[];
+        for (final e in invited) {
+          final users = await _resolveUsersForGroupInfo(e.group, knownUsers, ref);
+          invites.add(GroupInvite.fromRpcGroupInvited(e, users));
+        }
         return RpcTranslatorResponse(type, invites);
       default:
         return super.decodeMessageBytes(data, ref);

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
@@ -2,36 +2,45 @@ part of 'abstract_rpc_module_translator.dart';
 
 Future<List<User>> _resolveUsersForGroupInfo(
   GroupInfo g,
-  List<User> knownUsers,
+  Map<String, User> knownUsersById,
+  Map<String, User?> resolvedCache,
   Ref ref,
 ) async {
   final fetch = ref.read(fetchUserByIdForRpcProvider);
   final onResolved = ref.read(onGroupMemberUserResolvedProvider);
-  final memberIdSet =
-      g.members.map((m) => Base58Encode(Uint8List.fromList(m.userId))).toSet();
   final result = <User>[];
-  for (final user in knownUsers) {
-    if (memberIdSet.contains(user.idBase58)) {
-      result.add(user);
-    }
-  }
-  if (fetch == null) return result;
+  final missingIds = <String>[];
+  final missingIdBytes = <Uint8List>[];
 
-  final resolvedIds = result.map((u) => u.idBase58).toSet();
-  final toFetch = <Uint8List>[];
   for (final m in g.members) {
     final idBytes = Uint8List.fromList(m.userId);
-    if (resolvedIds.contains(Base58Encode(idBytes))) continue;
-    resolvedIds.add(Base58Encode(idBytes));
-    toFetch.add(idBytes);
+    final idBase58 = Base58Encode(idBytes);
+    final known = knownUsersById[idBase58];
+    if (known != null) {
+      result.add(known);
+      continue;
+    }
+    if (resolvedCache.containsKey(idBase58)) {
+      final cached = resolvedCache[idBase58];
+      if (cached != null) {
+        result.add(cached);
+      }
+      continue;
+    }
+    missingIds.add(idBase58);
+    missingIdBytes.add(idBytes);
   }
-  if (toFetch.isEmpty) return result;
 
-  final fetched = await Future.wait(toFetch.map(fetch));
-  for (var i = 0; i < toFetch.length; i++) {
+  if (fetch == null || missingIdBytes.isEmpty) return result;
+
+  final fetched = await Future.wait(missingIdBytes.map(fetch));
+  for (var i = 0; i < missingIdBytes.length; i++) {
+    final idBase58 = missingIds[i];
     final u = fetched[i];
+    resolvedCache[idBase58] = u;
     if (u != null) {
       result.add(u);
+      knownUsersById[idBase58] = u;
       onResolved?.call(u);
     }
   }
@@ -45,12 +54,17 @@ class GroupTranslator extends RpcModuleTranslator {
   @override
   Future<RpcTranslatorResponse?> decodeMessageBytes(List<int> data, Ref ref) async {
     final knownUsers = ref.read(userLookupProvider);
+    final knownUsersById = <String, User>{
+      for (final u in knownUsers) u.idBase58: u,
+    };
+    final resolvedCache = <String, User?>{};
     final message = Group.fromBuffer(data);
 
     switch (message.whichMessage()) {
       case Group_Message.groupInfoResponse:
         final info = message.ensureGroupInfoResponse();
-        final users = await _resolveUsersForGroupInfo(info, knownUsers, ref);
+        final users =
+            await _resolveUsersForGroupInfo(info, knownUsersById, resolvedCache, ref);
         return RpcTranslatorResponse(
           type,
           ChatRoom.fromRpcGroupInfo(info, users),
@@ -74,7 +88,8 @@ class GroupTranslator extends RpcModuleTranslator {
         final groupsPb = message.ensureGroupListResponse().groups;
         final rooms = <ChatRoom>[];
         for (final g in groupsPb) {
-          final users = await _resolveUsersForGroupInfo(g, knownUsers, ref);
+          final users =
+              await _resolveUsersForGroupInfo(g, knownUsersById, resolvedCache, ref);
           rooms.add(ChatRoom.fromRpcGroupInfo(g, users));
         }
         return RpcTranslatorResponse(type, rooms);
@@ -82,7 +97,12 @@ class GroupTranslator extends RpcModuleTranslator {
         final invited = message.ensureGroupInvitedResponse().invited;
         final invites = <GroupInvite>[];
         for (final e in invited) {
-          final users = await _resolveUsersForGroupInfo(e.group, knownUsers, ref);
+          final users = await _resolveUsersForGroupInfo(
+            e.group,
+            knownUsersById,
+            resolvedCache,
+            ref,
+          );
           invites.add(GroupInvite.fromRpcGroupInvited(e, users));
         }
         return RpcTranslatorResponse(type, invites);

--- a/qaul_ui/test/chat_user_resolution_test.dart
+++ b/qaul_ui/test/chat_user_resolution_test.dart
@@ -1,0 +1,176 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:local_notifications/src/local_notifications.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/screens/home/tabs/tab.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'test_utils/test_utils.dart';
+
+class _NoopWorker implements LibqaulWorker {
+  _NoopWorker(this.ref);
+  final Ref ref;
+
+  @override
+  Future<List<ChatRoom>> getAllChatRooms() async => [];
+
+  @override
+  Future<List<GroupInvite>> getGroupInvitesReceived() async => [];
+
+  @override
+  Future<bool> get initialized => Future.value(true);
+
+  @override
+  Future<PaginatedUsers?> getUsers({int? offset, int? limit}) async {
+    return PaginatedUsers(users: []);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _NoopChatNotificationController implements ChatNotificationController {
+  @override
+  String get cacheKey => '';
+
+  @override
+  TabType get currentVisibleHomeTab => TabType.chat;
+
+  @override
+  User get localUser =>
+      User(name: 'noop', id: Uint8List.fromList('noop'.codeUnits));
+
+  @override
+  SharedPreferences get preferences =>
+      throw UnimplementedError('Not used in tests');
+
+  @override
+  Ref get ref => throw UnimplementedError('Not used in tests');
+
+  @override
+  MapEntry<dynamic, void Function(List<ChatRoom>?, List<ChatRoom>)>
+      get strategy => const MapEntry(null, _noopStrategy);
+
+  static void _noopStrategy(List<ChatRoom>? _, List<ChatRoom> _) {}
+
+  @override
+  ValueNotifier<int?> newNotificationCount = ValueNotifier<int?>(null);
+
+  @override
+  void close() {}
+
+  @override
+  Iterable<ChatRoom> entriesToBeProcessed(List<ChatRoom> values) => const [];
+
+  @override
+  void execute(List<ChatRoom>? previous, List<ChatRoom> current) {}
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  LocalNotification? process(ChatRoom value) => null;
+
+  @override
+  void removeNotifications() {}
+
+  @override
+  void updatePersistentCachedData() {}
+}
+
+class _DirectRoomNotifier extends ChatRoomListNotifier {
+  @override
+  List<ChatRoom> build() {
+    final defaultUser =
+        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
+    final otherUser =
+        User(name: 'Peer', id: Uint8List.fromList('peer-user'.codeUnits));
+    return [
+      ChatRoom(
+        conversationId: Uint8List.fromList('dm-room'.codeUnits),
+        isDirectChat: true,
+        members: [
+          ChatRoomUser(defaultUser, joinedAt: DateTime(2024)),
+          ChatRoomUser(otherUser, joinedAt: DateTime(2024)),
+        ],
+        name: 'DM',
+      ),
+    ];
+  }
+}
+
+class _GroupRoomWithUnknownEventNotifier extends ChatRoomListNotifier {
+  @override
+  List<ChatRoom> build() {
+    final defaultUser =
+        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
+    return [
+      ChatRoom(
+        conversationId: Uint8List.fromList('group-room'.codeUnits),
+        isDirectChat: false,
+        members: [
+          ChatRoomUser(defaultUser, joinedAt: DateTime(2024)),
+        ],
+        name: 'Group',
+        lastMessagePreview: GroupEventContent(
+          userId: Uint8List.fromList('unknown-user'.codeUnits),
+          type: GroupEventContentType.joined,
+        ),
+      ),
+    ];
+  }
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('direct room renders using member fallback when users store is empty',
+      (tester) async {
+    final defaultUser =
+        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          chatNotificationControllerProvider
+              .overrideWithValue(_NoopChatNotificationController()),
+          chatRoomsProvider.overrideWith(_DirectRoomNotifier.new),
+          qaulWorkerProvider.overrideWith((ref) => _NoopWorker(ref)),
+        ],
+        child: materialAppWithLocalizations(BaseTab.chat()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Peer'), findsOneWidget);
+  });
+
+  testWidgets('group event with missing user shows unknown fallback',
+      (tester) async {
+    final defaultUser =
+        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          chatNotificationControllerProvider
+              .overrideWithValue(_NoopChatNotificationController()),
+          chatRoomsProvider.overrideWith(_GroupRoomWithUnknownEventNotifier.new),
+          qaulWorkerProvider.overrideWith((ref) => _NoopWorker(ref)),
+        ],
+        child: materialAppWithLocalizations(BaseTab.chat()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unknown'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Description
This PR addresses chat/group issues seen on older installations where conversations reference users that are not preloaded in usersStore, which was causing:

- collapsed / non-rendered group or DM rows,
- empty group event previews,
- Bad state: No element during author lookup,
- and repeated getUserById calls under polling/list scenarios.