### PR TITLE
Unread message counter doesn’t reset

### DIFF
--- a/qaul_ui/lib/providers/notification_controller/notification_controller.dart
+++ b/qaul_ui/lib/providers/notification_controller/notification_controller.dart
@@ -52,8 +52,14 @@ class NotificationController<T> {
       LocalNotifications.instance.removeNotifications();
 }
 
-mixin DataProcessingStrategy<T> {
+mixin DataProcessingStrategy<T> on NotificationController<List<T>> {
   ValueNotifier<int?> newNotificationCount = ValueNotifier(null);
+
+  @override
+  void removeNotifications() {
+    newNotificationCount.value = null;
+    super.removeNotifications();
+  }
 
   void execute(List<T>? previous, List<T> current) async {
     final queue = Queue<T>()..addAll(entriesToBeProcessed(current));


### PR DESCRIPTION
## Description
The public and chat tab badges kept showing stale counts after switching to those tabs. `removeNotifications()` was only clearing OS/local notifications via LocalNotifications, it never reset newNotificationCount on DataProcessingStrategy, which is what the navbar uses for the badge.

## Evidence

https://github.com/user-attachments/assets/bf84bca1-a75f-47f5-8593-627304570a77

