### PR TITLE
Adjust status check

### DIFF
--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -124,21 +124,42 @@ class ChatRoom with EquatableMixin implements Comparable {
     return '$room)';
   }
 
-  ChatRoom mergeWithConversationList(ChatConversationList c) {
+  ChatRoom copyWith({
+    Uint8List? conversationId,
+    Uint8List? lastMessageSenderId,
+    int? lastMessageIndex,
+    String? name,
+    DateTime? lastMessageTime,
+    MessageContent? lastMessagePreview,
+    List<Message>? messages,
+    int? unreadCount,
+    DateTime? createdAt,
+    bool? isDirectChat,
+    List<ChatRoomUser>? members,
+    int? revisionNumber,
+    ChatRoomStatus? status,
+  }) =>
+      ChatRoom(
+        conversationId: conversationId ?? this.conversationId,
+        lastMessageSenderId: lastMessageSenderId ?? this.lastMessageSenderId,
+        lastMessageIndex: lastMessageIndex ?? this.lastMessageIndex,
+        name: name ?? this.name,
+        lastMessageTime: lastMessageTime ?? this.lastMessageTime,
+        lastMessagePreview: lastMessagePreview ?? this.lastMessagePreview,
+        messages: messages ?? this.messages,
+        unreadCount: unreadCount ?? this.unreadCount,
+        createdAt: createdAt ?? this.createdAt,
+        isDirectChat: isDirectChat ?? this.isDirectChat,
+        members: members ?? this.members,
+        revisionNumber: revisionNumber ?? this.revisionNumber,
+        status: status ?? this.status,
+      );
+
+  ChatRoom copyWithMessages(ChatConversationList c) {
     assert(conversationId.equals(Uint8List.fromList(c.groupId)));
-    return ChatRoom(
-      conversationId: conversationId,
+    return copyWith(
       messages: c.messageList.map((e) => Message.fromChatMessage(e)).toList(),
       lastMessageIndex: c.messageList.fold<int>(0, maxIndex),
-      name: name,
-      lastMessageTime: lastMessageTime,
-      unreadCount: unreadCount,
-      lastMessagePreview: lastMessagePreview,
-      lastMessageSenderId: lastMessageSenderId,
-      createdAt: createdAt,
-      isDirectChat: isDirectChat,
-      members: members,
-      status: status,
     );
   }
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -113,7 +113,7 @@ class ChatRoom with EquatableMixin implements Comparable {
   }
 
   @override
-  List<Object?> get props => [idBase58, lastMessageIndex];
+  List<Object?> get props => [idBase58, lastMessageIndex, messages];
 
   @override
   String toString() {

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
@@ -8,8 +8,27 @@ class ChatRoomListNotifier extends Notifier<List<ChatRoom>> {
 
   void update(ChatRoom room) {
     assert(contains(room), 'State does not contain room $room');
+    final existing = state.firstWhere((r) => r.idBase58 == room.idBase58);
+
+    final merged = (room.messages == null && existing.messages != null)
+        ? ChatRoom(
+            conversationId: room.conversationId,
+            lastMessageSenderId: room.lastMessageSenderId,
+            lastMessageIndex: existing.lastMessageIndex,
+            name: room.name,
+            lastMessageTime: room.lastMessageTime,
+            lastMessagePreview: room.lastMessagePreview,
+            messages: existing.messages,
+            unreadCount: room.unreadCount,
+            createdAt: room.createdAt,
+            isDirectChat: room.isDirectChat,
+            members: room.members,
+            revisionNumber: room.revisionNumber,
+            status: room.status,
+          )
+        : room;
     final filtered = state.where((r) => r.idBase58 != room.idBase58);
-    state = [room, ...filtered];
+    state = [merged, ...filtered];
   }
 
   bool contains(ChatRoom room) =>

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
@@ -10,27 +10,18 @@ class ChatRoomListNotifier extends Notifier<List<ChatRoom>> {
     assert(contains(room), 'State does not contain room $room');
     final existing = state.firstWhere((r) => r.idBase58 == room.idBase58);
 
-    final merged = (room.messages == null && existing.messages != null)
-        ? ChatRoom(
-            conversationId: room.conversationId,
-            lastMessageSenderId: room.lastMessageSenderId,
+    final isPartialUpdate = room.messages == null && existing.messages != null;
+
+    // if room only has metadata updates, keep the existing messages
+    final merged = isPartialUpdate
+        ? room.copyWith(
             lastMessageIndex: existing.lastMessageIndex,
-            name: room.name,
-            lastMessageTime: room.lastMessageTime,
-            lastMessagePreview: room.lastMessagePreview,
             messages: existing.messages,
-            unreadCount: room.unreadCount,
-            createdAt: room.createdAt,
-            isDirectChat: room.isDirectChat,
-            members: room.members,
-            revisionNumber: room.revisionNumber,
-            status: room.status,
           )
         : room;
     final filtered = state.where((r) => r.idBase58 != room.idBase58);
     state = [merged, ...filtered];
   }
 
-  bool contains(ChatRoom room) =>
-      state.any((r) => r.idBase58 == room.idBase58);
+  bool contains(ChatRoom room) => state.any((r) => r.idBase58 == room.idBase58);
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/message/message.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/message/message.dart
@@ -29,7 +29,7 @@ class Message with EquatableMixin implements Comparable<Message> {
         ? [m.index.hashCode, m.sentAt.toInt()]
         : m.messageId;
 
-    final result = Message(
+    return Message(
       senderId: Uint8List.fromList(m.senderId),
       messageId: Uint8List.fromList(id),
       content: MessageContent.fromBuffer(m.content),
@@ -38,15 +38,6 @@ class Message with EquatableMixin implements Comparable<Message> {
       sentAt: DateTime.fromMillisecondsSinceEpoch(m.sentAt.toInt()),
       receivedAt: DateTime.fromMillisecondsSinceEpoch(m.receivedAt.toInt()),
     );
-    if (kDebugMode) {
-      debugPrint(
-        '[chat_message_state] index=${result.index} '
-        'proto=${m.status.name} -> model=${result.status.name} '
-        'confirmations=${m.messageReceptionConfirmed.length} '
-        'msgId=${result.messageIdBase58}',
-      );
-    }
-    return result;
   }
 
   @override

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/message/message.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/message/message.dart
@@ -29,7 +29,7 @@ class Message with EquatableMixin implements Comparable<Message> {
         ? [m.index.hashCode, m.sentAt.toInt()]
         : m.messageId;
 
-    return Message(
+    final result = Message(
       senderId: Uint8List.fromList(m.senderId),
       messageId: Uint8List.fromList(id),
       content: MessageContent.fromBuffer(m.content),
@@ -38,6 +38,15 @@ class Message with EquatableMixin implements Comparable<Message> {
       sentAt: DateTime.fromMillisecondsSinceEpoch(m.sentAt.toInt()),
       receivedAt: DateTime.fromMillisecondsSinceEpoch(m.receivedAt.toInt()),
     );
+    if (kDebugMode) {
+      debugPrint(
+        '[chat_message_state] index=${result.index} '
+        'proto=${m.status.name} -> model=${result.status.name} '
+        'confirmations=${m.messageReceptionConfirmed.length} '
+        'msgId=${result.messageIdBase58}',
+      );
+    }
+    return result;
   }
 
   @override
@@ -51,5 +60,5 @@ class Message with EquatableMixin implements Comparable<Message> {
   }
 
   @override
-  List<Object?> get props => [senderId, messageId, content];
+  List<Object?> get props => [senderId, messageId, content, status];
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/abstract_rpc_module_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/abstract_rpc_module_translator.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:fast_base58/fast_base58.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
@@ -25,24 +25,26 @@ class ChatTranslator extends RpcModuleTranslator {
           .firstWhereOrNull((r) => r.conversationId.equals(res.data.groupId));
       final currentOpenRoom = ref.read(currentOpenChatRoom.notifier);
 
+      final groupBytes = Uint8List.fromList(res.data.groupId);
+      ChatRoom? roomWithMessages;
       if (room != null) {
-        final roomWithMessages = room.mergeWithConversationList(res.data);
+        roomWithMessages = room.mergeWithConversationList(res.data);
         state.update(roomWithMessages);
-
-        if (_currentOpenRoomEqualsChatConversationList(currentOpenRoom, res)) {
-          currentOpenRoom.state = roomWithMessages;
+      } else {
+        final open = currentOpenRoom.state;
+        if (open != null && open.conversationId.equals(groupBytes)) {
+          roomWithMessages = open.mergeWithConversationList(res.data);
         }
+      }
+
+      final open = currentOpenRoom.state;
+      if (open != null &&
+          roomWithMessages != null &&
+          open.idBase58 == roomWithMessages.idBase58) {
+        currentOpenRoom.state = roomWithMessages;
       }
     } else {
       super.processResponse(res, ref);
     }
   }
-
-  bool _currentOpenRoomEqualsChatConversationList(
-    StateController<ChatRoom?> currentOpenRoomNotifier,
-    RpcTranslatorResponse res,
-  ) =>
-      currentOpenRoomNotifier.state != null &&
-      currentOpenRoomNotifier.state!.conversationId
-          .equals((res.data as ChatConversationList).groupId);
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
@@ -26,22 +26,19 @@ class ChatTranslator extends RpcModuleTranslator {
       final currentOpenRoom = ref.read(currentOpenChatRoom.notifier);
 
       final groupBytes = Uint8List.fromList(res.data.groupId);
-      ChatRoom? roomWithMessages;
-      if (room != null) {
-        roomWithMessages = room.mergeWithConversationList(res.data);
-        state.update(roomWithMessages);
-      } else {
-        final open = currentOpenRoom.state;
-        if (open != null && open.conversationId.equals(groupBytes)) {
-          roomWithMessages = open.mergeWithConversationList(res.data);
-        }
-      }
+      final openRoom = currentOpenRoom.state;
+      final isOpenRoom = openRoom != null &&
+          openRoom.conversationId.equals(groupBytes);
 
-      final open = currentOpenRoom.state;
-      if (open != null &&
-          roomWithMessages != null &&
-          open.idBase58 == roomWithMessages.idBase58) {
-        currentOpenRoom.state = roomWithMessages;
+      final source = room ?? (isOpenRoom ? openRoom : null);
+      if (source == null) return;
+
+      final merged = source.copyWithMessages(res.data);
+
+      if (room != null) state.update(merged);
+
+      if (isOpenRoom) {
+        currentOpenRoom.state = merged;
       }
     } else {
       super.processResponse(res, ref);

--- a/qaul_ui/test/chat_room_equality_and_notifier_test.dart
+++ b/qaul_ui/test/chat_room_equality_and_notifier_test.dart
@@ -27,12 +27,31 @@ void main() {
         lastMessageIndex: lastMessageIndex,
       );
 
-  group('ChatRoom Equatable props (idBase58, lastMessageIndex)', () {
-    test('rooms with same idBase58 and same lastMessageIndex are equal', () {
+  group('ChatRoom Equatable props (idBase58, lastMessageIndex, messages)', () {
+    test('rooms with same idBase58, lastMessageIndex, and messages are equal', () {
       final a = room(messages: [message(1)], lastMessageIndex: 1);
       final b = room(messages: [message(1)], lastMessageIndex: 1);
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('rooms with same id and index but different message status are not equal', () {
+      final a = room(messages: [message(1)], lastMessageIndex: 1);
+      final b = room(
+        messages: [
+          Message(
+            senderId: Uint8List.fromList('sender'.codeUnits),
+            messageId: Uint8List.fromList('msg1'.codeUnits),
+            content: const TextMessageContent('text'),
+            index: 1,
+            sentAt: DateTime(2020, 1, 1),
+            receivedAt: DateTime(2020, 1, 1),
+            status: MessageState.confirmed,
+          ),
+        ],
+        lastMessageIndex: 1,
+      );
+      expect(a, isNot(equals(b)));
     });
 
     test('rooms with same idBase58 but different lastMessageIndex are not equal', () {
@@ -78,6 +97,35 @@ void main() {
       expect(list.single.idBase58, roomA.idBase58);
       expect(list.single.messages!.length, 2);
       expect(list.single.lastMessageIndex, 2);
+    });
+
+    test('update preserves messages when group RPC omits message list', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(chatRoomsProvider.notifier);
+
+      final withChat = ChatRoom(
+        conversationId: conversationId,
+        name: 'G',
+        isDirectChat: false,
+        messages: [message(1)],
+        lastMessageIndex: 1,
+      );
+      notifier.add(withChat);
+
+      final groupOverview = ChatRoom(
+        conversationId: conversationId,
+        name: 'G renamed',
+        isDirectChat: false,
+        messages: null,
+        lastMessageIndex: null,
+      );
+      notifier.update(groupOverview);
+
+      final list = container.read(chatRoomsProvider);
+      expect(list.single.name, 'G renamed');
+      expect(list.single.messages!.length, 1);
+      expect(list.single.lastMessageIndex, 1);
     });
 
     test('contains returns false when no room has that idBase58', () {


### PR DESCRIPTION
## Description
After sending a message, delivery/confirmation checkmarks often did not update until something else changed the UI (another message, navigation, etc.), even though getChatRoomMessages is polled from the open chat screen.

Delivery/confirmation ticks often failed to update until some other interaction because in-memory state did not reliably propagate. 

ChatRoom and Message Equatable props now include the message list and per-message status, so status-only updates are not treated as unchanged. ChatRoomListNotifier.update merges partial group/overview RPC updates: when the incoming room omits messages but the cached room has a loaded conversation, metadata is refreshed while messages and lastMessageIndex are preserved. ChatTranslator applies ChatConversationList merges to currentOpenChatRoom when it matches the RPC group, including when the room is not yet in chatRoomsProvider.

https://github.com/user-attachments/assets/09618424-0497-4eeb-8710-455f2c7d641c

