### PR TITLE
New chat room shows own user’s avatar before first message

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -180,6 +180,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   User? get otherUser => widget.otherUser;
 
+  User? _directChatPeer(ChatRoom forRoom) {
+    if (forRoom.isGroupChatRoom) return null;
+    if (otherUser != null) return otherUser;
+    return ref
+        .read(usersStoreProvider.notifier)
+        .otherUserInDirectRoom(forRoom, user);
+  }
+
   final Map<String, String> _overflowMenuOptions = {};
 
   void _handleClick(String value) {
@@ -201,8 +209,6 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void initState() {
     super.initState();
-    assert(otherUser != null || room.isGroupChatRoom,
-        'Must either be a group chat or contain another user');
     _scheduleUpdateCurrentOpenChat();
   }
 
@@ -254,6 +260,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     }, [room]);
 
     final l10n = AppLocalizations.of(context)!;
+    final directPeer = _directChatPeer(room);
     return Scaffold(
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
@@ -263,11 +270,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           children: [
             (room.isGroupChatRoom)
                 ? QaulAvatar.groupSmall()
-                : QaulAvatar.small(user: otherUser),
+                : QaulAvatar.small(user: directPeer),
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                otherUser?.name ?? room.name ?? 'Group',
+                directPeer?.name ?? room.name ?? 'Group',
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -533,7 +540,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             },
             theme: DefaultChatTheme(
               userAvatarNameColors: [
-                colorGenerationStrategy(otherUser?.idBase58 ?? room.idBase58),
+                colorGenerationStrategy(
+                    directPeer?.idBase58 ?? room.idBase58),
               ],
               backgroundColor: Theme.of(context).scaffoldBackgroundColor,
               sentMessageBodyTextStyle: const TextStyle(

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -63,7 +63,15 @@ class ChatRoom with EquatableMixin implements Comparable {
   factory ChatRoom.blank({required User otherUser}) {
     assert(otherUser.conversationId != null);
     return ChatRoom(
-        conversationId: otherUser.conversationId!, name: otherUser.name);
+      conversationId: otherUser.conversationId!,
+      name: otherUser.name,
+      members: [
+        ChatRoomUser(
+          otherUser,
+          joinedAt: DateTime.utc(1970),
+        ),
+      ],
+    );
   }
 
   factory ChatRoom.fromRpcGroupInfo(GroupInfo g, List<User> users) {


### PR DESCRIPTION
## Description
Fixes chat screen crashes and wrong header avatar for new direct chats.

### Problems
Debug assertion: ChatScreen asserted otherUser != null || room.isGroupChatRoom, but valid flows can open a direct chat before the peer is known (e.g. tablet layout only passes getOtherUser(...), mobile can open with only a ChatRoom, or members arrive after navigation).

Wrong avatar on desktop for new DMs: On wide layouts, only currentOpenChatRoom is updated; ChatScreen gets the peer via otherUserInDirectRoom. ChatRoom.blank() had no members, so the peer could not be resolved and QaulAvatar.small fell back to the default user (sender) until after the first message.

## Evidence

https://github.com/user-attachments/assets/95ee68ad-011b-4637-9102-d3fe96e3a0ec

