### PR TITLE
Tab navigation not syncing

### DIFF
--- a/qaul_ui/lib/providers/home_screen_tab_controller_provider.dart
+++ b/qaul_ui/lib/providers/home_screen_tab_controller_provider.dart
@@ -17,13 +17,18 @@ class HomeScreenTabController extends Notifier<TabType> {
     return _pageController;
   }
 
-  void _goToIndex(int index) {
+  void _setTabIndex(int index) {
     assert(!index.isNegative && index < TabType.values.length);
     state = TabType.values[index];
-    if (_pageController.hasClients) {
-      _pageController.jumpToPage(state.index);
-    }
   }
 
-  void goToTab(TabType tab) => _goToIndex(TabType.values.indexOf(tab));
+  void setTabFromPageIndex(int index) => _setTabIndex(index);
+
+  void goToTab(TabType tab) {
+    final index = TabType.values.indexOf(tab);
+    _setTabIndex(index);
+    if (_pageController.hasClients) {
+      _pageController.jumpToPage(index);
+    }
+  }
 }

--- a/qaul_ui/lib/screens/home/home_screen.dart
+++ b/qaul_ui/lib/screens/home/home_screen.dart
@@ -35,6 +35,7 @@ class HomeScreen extends HookConsumerWidget {
             key: key,
             controller: tabCtrl.controller(),
             allowImplicitScrolling: true,
+            onPageChanged: tabCtrl.setTabFromPageIndex,
             physics: !disablePageViewScroll.value && _isMobile
                 ? const PageScrollPhysics()
                 : const NeverScrollableScrollPhysics(),

--- a/qaul_ui/test/providers/home_screen_controller_test.dart
+++ b/qaul_ui/test/providers/home_screen_controller_test.dart
@@ -66,6 +66,17 @@ void main() {
           expect(state, tab);
         }
       });
+
+    });
+
+    group('setTabFromPageIndex', () {
+      test('updates selected tab state only', () {
+        final notifier = container.read(homeScreenControllerProvider.notifier);
+
+        notifier.setTabFromPageIndex(TabType.chat.index);
+
+        expect(container.read(homeScreenControllerProvider), TabType.chat);
+      });
     });
 
     group('state listener', () {


### PR DESCRIPTION
## Description
Swiping between home tabs updated the PageView but not homeScreenControllerProvider, so QaulNavBar kept the old selectedTab.

## Evidence
https://github.com/user-attachments/assets/ab8eaf23-3feb-4d09-bb90-94ccb274f3e3

