### PR TITLE
Feature/async file send

### DIFF
--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -653,7 +653,7 @@ impl ChatFile {
         );
 
         // 2. file data message
-        // read file contents and create and send FileData messages
+        // read file contents and create and send FileData messages in a blocking thread
 
         let user_account_clone = user_account.clone();
 

--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -564,7 +564,7 @@ impl ChatFile {
         let file_path = Self::create_file_path(user_account.id, file_id, extension.as_str());
 
         // TODO: start in new async thread here
-
+                
         // copy file
         if let Err(e) = fs::copy(&path_name, file_path) {
             log::error!("copy file error {}", e);

--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -657,22 +657,22 @@ impl ChatFile {
 
         let user_account_clone = user_account.clone();
         let message_id_clone = message_id.clone();
-        // let file_id = file_id;
-        //let timestamp = timestamp;
-        //let path_name_clone = path_name.clone();
+        let group_clone = group.clone();
+        let mesage_count_clone = mesage_count;
+        let file_path_clone = file_path.clone();
 
-        tokio::spawn(async move {
-            if let Err(e) = Self::send_file_chunks(
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = Self::send_file_chunks_blocking(
                 user_account_clone,
-                group,
+                group_clone,
                 message_id_clone,
                 file_id,
                 timestamp,
                 path_name,
+                file_path_clone,
                 size,
-            )
-            .await
-            {
+                mesage_count_clone,
+            ) {
                 log::error!("File send failed: {}", e);
             }
         });
@@ -680,39 +680,47 @@ impl ChatFile {
         Ok(true)
     }
 
-    async fn send_file_chunks(
+    fn send_file_chunks_blocking(
         user_account: UserAccount,
         group: Group,
         message_id: Vec<u8>,
         file_id: u64,
         timestamp: u64,
         path_name: String,
+        file_path: PathBuf,
         size: u32,
+        message_count: u32,
     ) -> Result<(), String> {
-        use tokio::fs::File;
-        use tokio::io::AsyncReadExt;
+        // do the initial file copy async as well to avoid blocking the main thread
+        if let Err(e) = fs::copy(&path_name, file_path) {
+            log::error!("copy file error {}", e.to_string());
+        }
 
-        let mut file = File::open(path_name).await.map_err(|e| e.to_string())?;
+        let mut file = File::open(path_name).map_err(|e| e.to_string())?;
 
-        let mut buffer = vec![0u8; DEF_PACKAGE_SIZE as usize];
+        let mut buffer: [u8; DEF_PACKAGE_SIZE as usize] = [0; DEF_PACKAGE_SIZE as usize];
         let mut left_size = size;
-        let mut chunk_index = 0;
+        let mut chunk_index: u32 = 0;
 
         while left_size > 0 {
-            let read_size = file.read(&mut buffer).await.map_err(|e| e.to_string())?;
-            if read_size == 0 {
-                break;
+            let mut read_size = left_size;
+            if left_size > DEF_PACKAGE_SIZE {
+                read_size = DEF_PACKAGE_SIZE;
+            };
+            left_size = left_size - read_size;
+
+            if let Err(e) = file.read(&mut buffer) {
+                return Err(e.to_string());
             }
 
-            left_size -= read_size as u32;
-
+            // pack chat file container
             let data = proto_net::ChatFileContainer {
                 message: Some(proto_net::chat_file_container::Message::FileData(
                     proto_net::ChatFileData {
                         file_id,
                         start_index: chunk_index,
-                        message_count: mesage_count,
-                        data: buffer[0..(read_size as usize)].to_vec(),
+                        message_count,
+                        data: buffer[0..(read_size as usize)].iter().cloned().collect(),
                     },
                 )),
             };
@@ -726,8 +734,6 @@ impl ChatFile {
             );
 
             chunk_index += 1;
-
-            tokio::task::yield_now().await;
         }
 
         // set file status to sent

--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -32,9 +32,9 @@ use crate::{
 };
 use crate::{rpc::Rpc, services::group::GroupManage};
 
+pub use qaul_proto::qaul_net_chatfile as proto_net;
 /// Import protobuf message definition
 pub use qaul_proto::qaul_rpc_chatfile as proto_rpc;
-pub use qaul_proto::qaul_net_chatfile as proto_net;
 
 /// Size of the biggest file data package
 pub const DEF_PACKAGE_SIZE: u32 = 64000;
@@ -564,7 +564,7 @@ impl ChatFile {
         let file_path = Self::create_file_path(user_account.id, file_id, extension.as_str());
 
         // TODO: start in new async thread here
-                
+
         // copy file
         if let Err(e) = fs::copy(&path_name, file_path) {
             log::error!("copy file error {}", e);
@@ -654,22 +654,58 @@ impl ChatFile {
 
         // 2. file data message
         // read file contents and create and send FileData messages
-        let mut buffer: [u8; DEF_PACKAGE_SIZE as usize] = [0; DEF_PACKAGE_SIZE as usize];
+
+        let user_account_clone = user_account.clone();
+        let message_id_clone = message_id.clone();
+        // let file_id = file_id;
+        //let timestamp = timestamp;
+        //let path_name_clone = path_name.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = Self::send_file_chunks(
+                user_account_clone,
+                group,
+                message_id_clone,
+                file_id,
+                timestamp,
+                path_name,
+                size,
+            )
+            .await
+            {
+                log::error!("File send failed: {}", e);
+            }
+        });
+
+        Ok(true)
+    }
+
+    async fn send_file_chunks(
+        user_account: UserAccount,
+        group: Group,
+        message_id: Vec<u8>,
+        file_id: u64,
+        timestamp: u64,
+        path_name: String,
+        size: u32,
+    ) -> Result<(), String> {
+        use tokio::fs::File;
+        use tokio::io::AsyncReadExt;
+
+        let mut file = File::open(path_name).await.map_err(|e| e.to_string())?;
+
+        let mut buffer = vec![0u8; DEF_PACKAGE_SIZE as usize];
         let mut left_size = size;
-        let mut chunk_index: u32 = 0;
+        let mut chunk_index = 0;
 
         while left_size > 0 {
-            let mut read_size = left_size;
-            if left_size > DEF_PACKAGE_SIZE {
-                read_size = DEF_PACKAGE_SIZE;
-            };
-            left_size -= read_size;
-
-            if let Err(e) = file.read(&mut buffer) {
-                return Err(e.to_string());
+            let read_size = file.read(&mut buffer).await.map_err(|e| e.to_string())?;
+            if read_size == 0 {
+                break;
             }
 
-            // pack chat file container
+            left_size -= read_size as u32;
+
             let data = proto_net::ChatFileContainer {
                 message: Some(proto_net::chat_file_container::Message::FileData(
                     proto_net::ChatFileData {
@@ -681,9 +717,8 @@ impl ChatFile {
                 )),
             };
 
-            // send message to all group members
             Self::send_filecontainer_to_group(
-                user_account,
+                &user_account,
                 &group,
                 &message_id,
                 timestamp,
@@ -691,6 +726,8 @@ impl ChatFile {
             );
 
             chunk_index += 1;
+
+            tokio::task::yield_now().await;
         }
 
         // set file status to sent
@@ -700,7 +737,7 @@ impl ChatFile {
             super::rpc_proto::MessageStatus::Sent,
         );
 
-        Ok(true)
+        Ok(())
     }
 
     /// Save File Message in Chat Conversation

--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -566,7 +566,7 @@ impl ChatFile {
         // TODO: start in new async thread here
 
         // copy file
-        if let Err(e) = fs::copy(&path_name, file_path) {
+        if let Err(e) = fs::copy(&path_name, &file_path) {
             log::error!("copy file error {}", e);
         }
 
@@ -659,8 +659,6 @@ impl ChatFile {
         let message_id_clone = message_id.clone();
         let group_clone = group.clone();
         let mesage_count_clone = mesage_count;
-        let file_path_clone = file_path.clone();
-
         tokio::task::spawn_blocking(move || {
             if let Err(e) = Self::send_file_chunks_blocking(
                 user_account_clone,
@@ -669,7 +667,6 @@ impl ChatFile {
                 file_id,
                 timestamp,
                 path_name,
-                file_path_clone,
                 size,
                 mesage_count_clone,
             ) {
@@ -687,15 +684,9 @@ impl ChatFile {
         file_id: u64,
         timestamp: u64,
         path_name: String,
-        file_path: PathBuf,
         size: u32,
         message_count: u32,
     ) -> Result<(), String> {
-        // do the initial file copy async as well to avoid blocking the main thread
-        if let Err(e) = fs::copy(&path_name, file_path) {
-            log::error!("copy file error {}", e.to_string());
-        }
-
         let mut file = File::open(path_name).map_err(|e| e.to_string())?;
 
         let mut buffer: [u8; DEF_PACKAGE_SIZE as usize] = [0; DEF_PACKAGE_SIZE as usize];

--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -656,19 +656,17 @@ impl ChatFile {
         // read file contents and create and send FileData messages
 
         let user_account_clone = user_account.clone();
-        let message_id_clone = message_id.clone();
-        let group_clone = group.clone();
-        let mesage_count_clone = mesage_count;
+
         tokio::task::spawn_blocking(move || {
             if let Err(e) = Self::send_file_chunks_blocking(
                 user_account_clone,
-                group_clone,
-                message_id_clone,
+                group,
+                message_id,
                 file_id,
                 timestamp,
                 path_name,
                 size,
-                mesage_count_clone,
+                mesage_count,
             ) {
                 log::error!("File send failed: {}", e);
             }


### PR DESCRIPTION
## Description ##
Large file transfers were blocking the main thread during slicing and encryption, causing the application to become unresponsive until it completed.

The process of encrypting and sending file chunks has now been moved inside a tokio background worker, allowing the main thread to stay responsive while the file is sent asynchronously.

Github Issue: [#546](https://github.com/qaul/qaul.net/issues/546)

