### PR TITLE
fix(qaul): codebase audit fixes

### DIFF
--- a/rust/clients/cli/src/chat.rs
+++ b/rust/clients/cli/src/chat.rs
@@ -24,7 +24,13 @@ impl Chat {
             // send chat message
             cmd if cmd.starts_with("send ") => {
                 // get group id
-                let command_string = cmd.strip_prefix("send ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("send ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("chat send command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
@@ -254,8 +260,14 @@ impl Chat {
                     Some(proto::chat::Message::ConversationList(proto_conversation)) => {
                         // Conversation table
                         println!("");
-                        let group_id =
-                            uuid::Uuid::from_bytes(proto_conversation.group_id.try_into().unwrap());
+                        let group_id_bytes: [u8; 16] = match proto_conversation.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
 
                         println!("Conversation [ {} ]", group_id.to_string());
                         println!("");

--- a/rust/clients/cli/src/group.rs
+++ b/rust/clients/cli/src/group.rs
@@ -22,7 +22,13 @@ impl Group {
         match command {
             // create group
             cmd if cmd.starts_with("create ") => {
-                let command_string = cmd.strip_prefix("create ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("create ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group create command incorrectly formatted");
+                        return;
+                    }
+                };
                 let group_name = command_string.trim().to_string();
 
                 if group_name.len() > 0 {
@@ -33,18 +39,25 @@ impl Group {
             }
             // rename group
             cmd if cmd.starts_with("rename ") => {
-                let command_string = cmd.strip_prefix("rename ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("rename ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group rename command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
                     match Self::uuid_string_to_bin(group_id_str.to_string()) {
                         Ok(group_id) => {
-                            let group_name = command_string
-                                .strip_prefix(group_id_str)
-                                .unwrap()
-                                .to_string()
-                                .trim()
-                                .to_string();
+                            let group_name = match command_string.strip_prefix(group_id_str) {
+                                Some(s) => s.trim().to_string(),
+                                None => {
+                                    log::error!("group rename command incorrectly formatted");
+                                    return;
+                                }
+                            };
 
                             if group_name.len() > 0 {
                                 Self::rename_group(group_id, group_name.to_string());
@@ -63,7 +76,13 @@ impl Group {
             }
             // group info
             cmd if cmd.starts_with("info ") => {
-                let command_string = cmd.strip_prefix("info ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("info ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group info command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
@@ -91,7 +110,13 @@ impl Group {
             }
             // group invite
             cmd if cmd.starts_with("invite ") => {
-                let command_string = cmd.strip_prefix("invite ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("invite ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group invite command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
@@ -122,7 +147,13 @@ impl Group {
             }
             // accept invite
             cmd if cmd.starts_with("accept ") => {
-                let command_string = cmd.strip_prefix("accept ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("accept ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group accept command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
@@ -141,7 +172,13 @@ impl Group {
             }
             // decline invite
             cmd if cmd.starts_with("decline ") => {
-                let command_string = cmd.strip_prefix("decline ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("decline ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group decline command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
@@ -160,7 +197,13 @@ impl Group {
             }
             // remove member
             cmd if cmd.starts_with("remove ") => {
-                let command_string = cmd.strip_prefix("remove ").unwrap().to_string();
+                let command_string = match cmd.strip_prefix("remove ") {
+                    Some(s) => s.to_string(),
+                    None => {
+                        log::error!("group remove command incorrectly formatted");
+                        return;
+                    }
+                };
                 let mut iter = command_string.split_whitespace();
 
                 if let Some(group_id_str) = iter.next() {
@@ -472,18 +515,34 @@ impl Group {
                     Some(proto::group::Message::GroupCreateResponse(create_group_response)) => {
                         println!("====================================");
                         println!("Group was created or updated");
-                        let group_id = uuid::Uuid::from_bytes(
-                            create_group_response.group_id.try_into().unwrap(),
-                        );
+                        let group_id_bytes: [u8; 16] = match create_group_response.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("\tid: {}", group_id.to_string());
                     }
                     Some(proto::group::Message::GroupRenameResponse(rename_group_response)) => {
-                        let result = rename_group_response.result.unwrap();
+                        let result = match rename_group_response.result {
+                            Some(r) => r,
+                            None => {
+                                log::error!("missing result in rename response");
+                                return;
+                            }
+                        };
                         println!("====================================");
                         println!("Group Rename status: {}", result.status);
-                        let group_id = uuid::Uuid::from_bytes(
-                            rename_group_response.group_id.try_into().unwrap(),
-                        );
+                        let group_id_bytes: [u8; 16] = match rename_group_response.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("\tid: {}", group_id.to_string());
                         if !result.status {
                             println!("\terror: {}", result.message);
@@ -492,24 +551,46 @@ impl Group {
                     Some(proto::group::Message::GroupInviteMemberResponse(
                         invite_group_response,
                     )) => {
-                        let result = invite_group_response.result.unwrap();
+                        let result = match invite_group_response.result {
+                            Some(r) => r,
+                            None => {
+                                log::error!("missing result in invite response");
+                                return;
+                            }
+                        };
                         println!("====================================");
                         println!("Group Invite status: {}", result.status);
-                        let group_id = uuid::Uuid::from_bytes(
-                            invite_group_response.group_id.try_into().unwrap(),
-                        );
+                        let group_id_bytes: [u8; 16] = match invite_group_response.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("\tid: {}", group_id.to_string());
                         if !result.status {
                             println!("\terror: {}", result.message);
                         }
                     }
                     Some(proto::group::Message::GroupReplyInviteResponse(reply_group_response)) => {
-                        let result = reply_group_response.result.unwrap();
+                        let result = match reply_group_response.result {
+                            Some(r) => r,
+                            None => {
+                                log::error!("missing result in reply invite response");
+                                return;
+                            }
+                        };
                         println!("====================================");
                         println!("Reply Group Invite status: {}", result.status);
-                        let group_id = uuid::Uuid::from_bytes(
-                            reply_group_response.group_id.try_into().unwrap(),
-                        );
+                        let group_id_bytes: [u8; 16] = match reply_group_response.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("\tid: {}", group_id.to_string());
                         if !result.status {
                             println!("\terror: {}", result.message);
@@ -518,12 +599,23 @@ impl Group {
                     Some(proto::group::Message::GroupRemoveMemberResponse(
                         remove_member_response,
                     )) => {
-                        let result = remove_member_response.result.unwrap();
+                        let result = match remove_member_response.result {
+                            Some(r) => r,
+                            None => {
+                                log::error!("missing result in remove member response");
+                                return;
+                            }
+                        };
                         println!("====================================");
                         println!("Group Remove Member status: {}", result.status);
-                        let group_id = uuid::Uuid::from_bytes(
-                            remove_member_response.group_id.try_into().unwrap(),
-                        );
+                        let group_id_bytes: [u8; 16] = match remove_member_response.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("\tid: {}", group_id.to_string());
                         if !result.status {
                             println!("\terror: {}", result.message);
@@ -533,9 +625,14 @@ impl Group {
                         // group
                         println!("====================================");
                         println!("Group Information");
-                        let group_id = uuid::Uuid::from_bytes(
-                            group_info_response.group_id.try_into().unwrap(),
-                        );
+                        let group_id_bytes: [u8; 16] = match group_info_response.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                return;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("\tid: {}", group_id.to_string());
                         println!("\tname: {}", group_info_response.group_name.clone());
                         println!("\tcreated_at: {}", group_info_response.created_at);
@@ -545,8 +642,14 @@ impl Group {
                         // List groups
                         println!("=============List Of Groups=================");
                         for group in group_list_response.groups {
-                            let group_id =
-                                uuid::Uuid::from_bytes(group.group_id.try_into().unwrap());
+                            let group_id_bytes: [u8; 16] = match group.group_id.try_into() {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    log::error!("invalid group id bytes: {:?}", e);
+                                    continue;
+                                }
+                            };
+                            let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                             let group_type: String;
                             match group.is_direct_chat {
                                 true => group_type = "Direct".to_string(),
@@ -614,8 +717,14 @@ impl Group {
                         println!("=============List Of Invited=================");
                         for invite in group_invited_response.invited {
                             if let Some(group) = invite.group {
-                                let group_id =
-                                    uuid::Uuid::from_bytes(group.group_id.try_into().unwrap());
+                                let group_id_bytes: [u8; 16] = match group.group_id.try_into() {
+                                    Ok(b) => b,
+                                    Err(e) => {
+                                        log::error!("invalid group id bytes: {:?}", e);
+                                        continue;
+                                    }
+                                };
+                                let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                                 println!("id: {}", group_id.to_string());
                                 println!("\tname: {}", group.group_name.clone());
                                 println!(

--- a/rust/clients/cli/src/users.rs
+++ b/rust/clients/cli/src/users.rs
@@ -31,25 +31,35 @@ impl Users {
             }
             // verify a user
             cmd if cmd.starts_with("verify ") => {
-                let user_id = cmd.strip_prefix("verify ").unwrap();
-
-                Self::send_user_update(user_id, true, false);
+                if let Some(user_id) = cmd.strip_prefix("verify ") {
+                    Self::send_user_update(user_id, true, false);
+                } else {
+                    log::error!("verify command incorrectly formatted");
+                }
             }
             // block a user
             cmd if cmd.starts_with("block ") => {
-                let user_id = cmd.strip_prefix("block ").unwrap();
-
-                Self::send_user_update(user_id, false, true);
+                if let Some(user_id) = cmd.strip_prefix("block ") {
+                    Self::send_user_update(user_id, false, true);
+                } else {
+                    log::error!("block command incorrectly formatted");
+                }
             }
             // security number for a user
             cmd if cmd.starts_with("secure ") => {
-                let user_id = cmd.strip_prefix("secure ").unwrap();
-                Self::send_user_secure_number(user_id);
+                if let Some(user_id) = cmd.strip_prefix("secure ") {
+                    Self::send_user_secure_number(user_id);
+                } else {
+                    log::error!("secure command incorrectly formatted");
+                }
             }
             // get a single user by id
             cmd if cmd.starts_with("get ") => {
-                let user_id = cmd.strip_prefix("get ").unwrap();
-                Self::request_user_by_id(user_id);
+                if let Some(user_id) = cmd.strip_prefix("get ") {
+                    Self::request_user_by_id(user_id);
+                } else {
+                    log::error!("get command incorrectly formatted");
+                }
             }
             // unknown command
             _ => log::error!("unknown users command"),
@@ -107,7 +117,13 @@ impl Users {
 
     /// create rpc user security number message
     fn send_user_secure_number(user_id_base58: &str) {
-        let user_id = bs58::decode(user_id_base58).into_vec().unwrap();
+        let user_id = match bs58::decode(user_id_base58).into_vec() {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("invalid base58 user id '{}': {}", user_id_base58, e);
+                return;
+            }
+        };
 
         // create request message
         let proto_message = proto::Users {
@@ -132,7 +148,13 @@ impl Users {
 
     /// create rpc request to get a single user by id
     fn request_user_by_id(user_id_base58: &str) {
-        let user_id = bs58::decode(user_id_base58).into_vec().unwrap();
+        let user_id = match bs58::decode(user_id_base58).into_vec() {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("invalid base58 user id '{}': {}", user_id_base58, e);
+                return;
+            }
+        };
 
         // create request message
         let proto_message = proto::Users {
@@ -157,7 +179,13 @@ impl Users {
 
     /// create rpc user update message
     fn send_user_update(user_id_base58: &str, verified: bool, blocked: bool) {
-        let user_id = bs58::decode(user_id_base58).into_vec().unwrap();
+        let user_id = match bs58::decode(user_id_base58).into_vec() {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("invalid base58 user id '{}': {}", user_id_base58, e);
+                return;
+            }
+        };
 
         // create request message
         let proto_message = proto::Users {
@@ -240,7 +268,7 @@ impl Users {
                             println!("  Connections: module | hc | rtt | via");
                             for cnn in user.connections {
                                 let module = proto::ConnectionModule::try_from(cnn.module)
-                                    .unwrap()
+                                    .unwrap_or(proto::ConnectionModule::None)
                                     .as_str_name();
                                 println!(
                                     "      {} | {} | {} | {}",
@@ -294,7 +322,7 @@ impl Users {
                             println!("Connections: module | hc | rtt | via");
                             for cnn in user.connections {
                                 let module = proto::ConnectionModule::try_from(cnn.module)
-                                    .unwrap()
+                                    .unwrap_or(proto::ConnectionModule::None)
                                     .as_str_name();
                                 println!(
                                     "  {} | {} | {} | {}",

--- a/rust/clients/qauld-ctl/src/commands/chat.rs
+++ b/rust/clients/qauld-ctl/src/commands/chat.rs
@@ -120,7 +120,14 @@ impl RpcCommand for ChatSubcmd {
             Some(chat::Message::ConversationList(proto_conversation)) => {
                 // Conversation table
                 println!("");
-                let group_id = Uuid::from_bytes(proto_conversation.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match proto_conversation.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
 
                 println!("Conversation [ {} ]", group_id.to_string());
                 println!("");

--- a/rust/clients/qauld-ctl/src/commands/group.rs
+++ b/rust/clients/qauld-ctl/src/commands/group.rs
@@ -183,45 +183,103 @@ impl RpcCommand for GroupSubcmd {
             Some(group::Message::GroupCreateResponse(create_group_response)) => {
                 println!("====================================");
                 println!("Group was created or updated");
-                let group_id = Uuid::from_bytes(create_group_response.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match create_group_response.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
                 println!("\tid: {}", group_id.to_string());
             }
             Some(group::Message::GroupRenameResponse(rename_group_response)) => {
-                let result = rename_group_response.result.unwrap();
+                let result = match rename_group_response.result {
+                    Some(r) => r,
+                    None => {
+                        log::error!("missing result in rename response");
+                        return Ok(());
+                    }
+                };
                 println!("====================================");
                 println!("Group Rename status: {}", result.status);
-                let group_id = Uuid::from_bytes(rename_group_response.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match rename_group_response.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
                 println!("\tid: {}", group_id.to_string());
                 if !result.status {
                     println!("\terror: {}", result.message);
                 }
             }
             Some(group::Message::GroupInviteMemberResponse(invite_group_response)) => {
-                let result = invite_group_response.result.unwrap();
+                let result = match invite_group_response.result {
+                    Some(r) => r,
+                    None => {
+                        log::error!("missing result in invite response");
+                        return Ok(());
+                    }
+                };
                 println!("====================================");
                 println!("Group Invite status: {}", result.status);
-                let group_id = Uuid::from_bytes(invite_group_response.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match invite_group_response.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
                 println!("\tid: {}", group_id.to_string());
                 if !result.status {
                     println!("\terror: {}", result.message);
                 }
             }
             Some(group::Message::GroupReplyInviteResponse(reply_group_response)) => {
-                let result = reply_group_response.result.unwrap();
+                let result = match reply_group_response.result {
+                    Some(r) => r,
+                    None => {
+                        log::error!("missing result in reply invite response");
+                        return Ok(());
+                    }
+                };
                 println!("====================================");
                 println!("Reply Group Invite status: {}", result.status);
-                let group_id = Uuid::from_bytes(reply_group_response.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match reply_group_response.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
                 println!("\tid: {}", group_id.to_string());
                 if !result.status {
                     println!("\terror: {}", result.message);
                 }
             }
             Some(group::Message::GroupRemoveMemberResponse(remove_member_response)) => {
-                let result = remove_member_response.result.unwrap();
+                let result = match remove_member_response.result {
+                    Some(r) => r,
+                    None => {
+                        log::error!("missing result in remove member response");
+                        return Ok(());
+                    }
+                };
                 println!("====================================");
                 println!("Group Remove Member status: {}", result.status);
-                let group_id =
-                    Uuid::from_bytes(remove_member_response.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match remove_member_response.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
                 println!("\tid: {}", group_id.to_string());
                 if !result.status {
                     println!("\terror: {}", result.message);
@@ -231,7 +289,14 @@ impl RpcCommand for GroupSubcmd {
                 // group
                 println!("====================================");
                 println!("Group Information");
-                let group_id = Uuid::from_bytes(group_info_response.group_id.try_into().unwrap());
+                let group_id_bytes: [u8; 16] = match group_info_response.group_id.try_into() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::error!("invalid group id bytes: {:?}", e);
+                        return Ok(());
+                    }
+                };
+                let group_id = Uuid::from_bytes(group_id_bytes);
                 println!("\tid: {}", group_id.to_string());
                 println!("\tname: {}", group_info_response.group_name.clone());
                 println!("\tcreated_at: {}", group_info_response.created_at);
@@ -241,7 +306,14 @@ impl RpcCommand for GroupSubcmd {
                 // List groups
                 println!("=============List Of Groups=================");
                 for group in group_list_response.groups {
-                    let group_id = uuid::Uuid::from_bytes(group.group_id.try_into().unwrap());
+                    let group_id_bytes: [u8; 16] = match group.group_id.try_into() {
+                        Ok(b) => b,
+                        Err(e) => {
+                            log::error!("invalid group id bytes: {:?}", e);
+                            continue;
+                        }
+                    };
+                    let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                     let group_type: String;
                     match group.is_direct_chat {
                         true => group_type = "Direct".to_string(),
@@ -309,7 +381,14 @@ impl RpcCommand for GroupSubcmd {
                 println!("=============List Of Invited=================");
                 for invite in group_invited_response.invited {
                     if let Some(group) = invite.group {
-                        let group_id = uuid::Uuid::from_bytes(group.group_id.try_into().unwrap());
+                        let group_id_bytes: [u8; 16] = match group.group_id.try_into() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::error!("invalid group id bytes: {:?}", e);
+                                continue;
+                            }
+                        };
+                        let group_id = uuid::Uuid::from_bytes(group_id_bytes);
                         println!("id: {}", group_id.to_string());
                         println!("\tname: {}", group.group_name.clone());
                         println!("\tsender: {}", bs58::encode(invite.sender_id).into_string());

--- a/rust/clients/qauld-ctl/src/commands/users.rs
+++ b/rust/clients/qauld-ctl/src/commands/users.rs
@@ -15,7 +15,10 @@ fn send_user_update(
     verified: bool,
     blocked: bool,
 ) -> Result<Users, Box<dyn std::error::Error>> {
-    let user_id = bs58::decode(user_id_base58).into_vec().unwrap();
+    let user_id = match bs58::decode(user_id_base58).into_vec() {
+        Ok(v) => v,
+        Err(e) => return Err(format!("invalid base58 user id: {}", e).into()),
+    };
 
     // create request message
     let proto_message = Users {
@@ -179,7 +182,7 @@ impl RpcCommand for UsersSubcmd {
                         println!("  Connections: module | hc | rtt | via");
                         for cnn in user.connections {
                             let module = ConnectionModule::try_from(cnn.module)
-                                .unwrap()
+                                .unwrap_or(ConnectionModule::None)
                                 .as_str_name();
                             println!(
                                 "      {} | {} | {} | {}",
@@ -232,7 +235,7 @@ impl RpcCommand for UsersSubcmd {
                         println!("Connections: module | hc | rtt | via");
                         for cnn in user.connections {
                             let module = ConnectionModule::try_from(cnn.module)
-                                .unwrap()
+                                .unwrap_or(ConnectionModule::None)
                                 .as_str_name();
                             println!(
                                 "  {} | {} | {} | {}",

--- a/rust/libqaul/src/api/android.rs
+++ b/rust/libqaul/src/api/android.rs
@@ -30,9 +30,21 @@ lazy_static! {
 
 #[no_mangle]
 pub fn nativeSetCallback(env: JNIEnv, _obj: JObject, callback: JObject) {
-    let callback = env.new_global_ref(JObject::from(callback)).unwrap();
+    let callback = match env.new_global_ref(JObject::from(callback)) {
+        Ok(cb) => cb,
+        Err(e) => {
+            log::error!("nativeSetCallback: failed to create global ref: {:?}", e);
+            return;
+        }
+    };
 
-    let mut ptr_fn = JNI_CALLBACK.lock().unwrap();
+    let mut ptr_fn = match JNI_CALLBACK.lock() {
+        Ok(guard) => guard,
+        Err(e) => {
+            log::error!("nativeSetCallback: failed to lock JNI_CALLBACK: {:?}", e);
+            return;
+        }
+    };
     *ptr_fn = Some(callback);
 }
 
@@ -52,7 +64,13 @@ unsafe fn JNI_OnLoad(java_vm: JavaVM, _: *mut std::os::raw::c_void) -> jint {
         log::error!("android jni: register natives failed");
     }
 
-    let mut ptr_jvm = JVM_GLOBAL.lock().unwrap();
+    let mut ptr_jvm = match JVM_GLOBAL.lock() {
+        Ok(guard) => guard,
+        Err(e) => {
+            log::error!("JNI_OnLoad: failed to lock JVM_GLOBAL: {:?}", e);
+            return JNI_ERR;
+        }
+    };
     *ptr_jvm = Some(java_vm);
 
     JNI_VERSION_1_6
@@ -62,12 +80,13 @@ unsafe fn JNI_OnLoad(java_vm: JavaVM, _: *mut std::os::raw::c_void) -> jint {
 #[no_mangle]
 pub extern "system" fn Java_net_qaul_libqaul_LibqaulKt_hello(env: JNIEnv, _: JClass) -> jstring {
     // create a string
-    let output = env
-        .new_string(format!("Hello qaul!"))
-        .expect("Couldn't create java string!");
-
-    // return the raw pointer
-    output.into_raw()
+    match env.new_string(format!("Hello qaul!")) {
+        Ok(output) => output.into_raw(),
+        Err(e) => {
+            log::error!("hello: failed to create java string: {:?}", e);
+            std::ptr::null_mut()
+        }
+    }
 }
 
 /// start libqaul from android
@@ -78,10 +97,13 @@ pub extern "system" fn Java_net_qaul_libqaul_LibqaulKt_start(
     path: JString,
 ) {
     // get path string
-    let android_path: String = env
-        .get_string(&path)
-        .expect("Couldn't get Java path string!")
-        .into();
+    let android_path: String = match env.get_string(&path) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            log::error!("start: failed to get Java path string: {:?}", e);
+            return;
+        }
+    };
 
     // start libqaul in an own thread
     super::start_android(android_path);
@@ -127,7 +149,13 @@ pub extern "system" fn Java_net_qaul_libqaul_LibqaulKt_send<'local>(
     message: JByteArray<'local>,
 ) {
     // get the message out of java
-    let binary_message: Vec<u8> = env.convert_byte_array(&message).unwrap();
+    let binary_message: Vec<u8> = match env.convert_byte_array(&message) {
+        Ok(msg) => msg,
+        Err(e) => {
+            log::error!("send: failed to convert byte array: {:?}", e);
+            return;
+        }
+    };
 
     // send it to libqaul
     super::send_rpc(binary_message);
@@ -142,15 +170,23 @@ pub extern "system" fn Java_net_qaul_libqaul_LibqaulKt_receive<'local>(
     // check if there is an RPC message
     if let Ok(message) = super::receive_rpc() {
         // convert message to java byte array
-        let byte_array = env.byte_array_from_slice(&message).unwrap();
-        // return byte array
-        return byte_array;
+        match env.byte_array_from_slice(&message) {
+            Ok(byte_array) => return byte_array,
+            Err(e) => {
+                log::error!("receive: failed to create byte array from message: {:?}", e);
+            }
+        }
     }
 
-    // there is no message and we return an empty array
+    // there is no message (or conversion failed) and we return an empty array
     let buf: [u8; 0] = [0; 0];
-    let empty_array = env.byte_array_from_slice(&buf).unwrap();
-    empty_array
+    match env.byte_array_from_slice(&buf) {
+        Ok(empty_array) => empty_array,
+        Err(e) => {
+            log::error!("receive: failed to create empty byte array: {:?}", e);
+            JByteArray::default()
+        }
+    }
 }
 
 /// # BLE Module Functions
@@ -166,7 +202,13 @@ pub extern "system" fn Java_net_qaul_libqaul_LibqaulKt_syssend<'local>(
     message: JByteArray<'local>,
 ) {
     // get the message out of java
-    let binary_message: Vec<u8> = env.convert_byte_array(&message).unwrap();
+    let binary_message: Vec<u8> = match env.convert_byte_array(&message) {
+        Ok(msg) => msg,
+        Err(e) => {
+            log::error!("syssend: failed to convert byte array: {:?}", e);
+            return;
+        }
+    };
 
     // send it to libqaul
     super::send_sys(binary_message);
@@ -181,15 +223,23 @@ pub extern "system" fn Java_net_qaul_libqaul_LibqaulKt_sysreceive<'local>(
     // check if there is an RPC message
     if let Ok(message) = super::receive_sys() {
         // convert message to java byte array
-        let byte_array = env.byte_array_from_slice(&message).unwrap();
-        // return byte array
-        return byte_array;
+        match env.byte_array_from_slice(&message) {
+            Ok(byte_array) => return byte_array,
+            Err(e) => {
+                log::error!("sysreceive: failed to create byte array from message: {:?}", e);
+            }
+        }
     }
 
-    // there is no message and we return an empty array
+    // there is no message (or conversion failed) and we return an empty array
     let buf: [u8; 0] = [0; 0];
-    let empty_array = env.byte_array_from_slice(&buf).unwrap();
-    empty_array
+    match env.byte_array_from_slice(&buf) {
+        Ok(empty_array) => empty_array,
+        Err(e) => {
+            log::error!("sysreceive: failed to create empty byte array: {:?}", e);
+            JByteArray::default()
+        }
+    }
 }
 
 pub struct Android {}
@@ -202,8 +252,20 @@ impl Android {
     }
 
     unsafe fn register_natives(jvm: &JavaVM, class_name: &str, methods: &[NativeMethod]) -> jint {
-        let mut env: JNIEnv = jvm.get_env().unwrap();
-        let jni_version = env.get_version().unwrap();
+        let mut env: JNIEnv = match jvm.get_env() {
+            Ok(e) => e,
+            Err(e) => {
+                log::error!("register_natives: failed to get JNI env: {:?}", e);
+                return JNI_ERR;
+            }
+        };
+        let jni_version = match env.get_version() {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("register_natives: failed to get JNI version: {:?}", e);
+                return JNI_ERR;
+            }
+        };
         let version: jint = jni_version.into();
 
         let clazz = match env.find_class(class_name) {
@@ -228,17 +290,31 @@ impl Android {
     where
         F: Fn(&JObject, &mut JNIEnv) + Send + 'static,
     {
-        let ptr_jvm = JVM_GLOBAL.lock().unwrap();
+        let ptr_jvm = match JVM_GLOBAL.lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                log::error!("call_jvm: failed to lock JVM_GLOBAL: {:?}", e);
+                return;
+            }
+        };
         if (*ptr_jvm).is_none() {
             return;
         }
-        let ptr_fn = callback.lock().unwrap();
+        let ptr_fn = match callback.lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                log::error!("call_jvm: failed to lock callback: {:?}", e);
+                return;
+            }
+        };
         if (*ptr_fn).is_none() {
             return;
         }
+        // Safe: we checked is_none() above
         let jvm: &JavaVM = (*ptr_jvm).as_ref().unwrap();
         match jvm.attach_current_thread_permanently() {
             Ok(mut env) => {
+                // Safe: we checked is_none() above
                 let obj = (*ptr_fn).as_ref().unwrap().as_obj();
                 run(obj, &mut env);
                 if let Ok(true) = env.exception_check() {
@@ -254,7 +330,13 @@ impl Android {
 
     pub fn call_java_callback(fun_type: Vec<u8>) {
         Self::call_jvm(&JNI_CALLBACK, move |obj: &JObject, env: &mut JNIEnv| {
-            let jmessage = env.byte_array_from_slice(fun_type.as_slice()).unwrap();
+            let jmessage = match env.byte_array_from_slice(fun_type.as_slice()) {
+                Ok(arr) => arr,
+                Err(e) => {
+                    log::error!("call_java_callback: failed to create byte array: {:?}", e);
+                    return;
+                }
+            };
             match env.call_method(
                 obj,
                 "OnLibqaulMessage",

--- a/rust/libqaul/src/connections/mod.rs
+++ b/rust/libqaul/src/connections/mod.rs
@@ -335,8 +335,14 @@ impl Connections {
                                         Multiaddr,
                                         libp2p::multiaddr::Error,
                                     > = nodes_entry.address.clone().parse();
-                                    let address = address_result.unwrap();
-                                    Internet::peer_dial(address, &mut internet.swarm);
+                                    match address_result {
+                                        Ok(address) => {
+                                            Internet::peer_dial(address, &mut internet.swarm);
+                                        }
+                                        Err(e) => {
+                                            log::error!("failed to parse multiaddr '{}': {}", nodes_entry.address, e);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/rust/libqaul/src/node/user_accounts.rs
+++ b/rust/libqaul/src/node/user_accounts.rs
@@ -37,6 +37,7 @@ pub struct UserAccount {
     pub keys: Keypair,
     pub name: String,
     pub password_hash: Option<String>,
+    // Note: salt is embedded in the Argon2 password_hash string; this field is kept for backward compatibility
     pub password_salt: Option<String>,
 }
 

--- a/rust/libqaul/src/node/user_accounts.rs
+++ b/rust/libqaul/src/node/user_accounts.rs
@@ -52,10 +52,28 @@ impl UserAccounts {
         let mut accounts = UserAccounts { users: Vec::new() };
 
         for user in &config.user_accounts {
-            let mut basedecode = base64::engine::general_purpose::STANDARD
+            let mut basedecode = match base64::engine::general_purpose::STANDARD
                 .decode(&user.keys)
-                .unwrap();
-            let ed25519_keys = ed25519::Keypair::try_from_bytes(&mut basedecode).unwrap();
+            {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    log::error!(
+                        "skipping user '{}': failed to base64-decode keys: {}",
+                        user.name, e
+                    );
+                    continue;
+                }
+            };
+            let ed25519_keys = match ed25519::Keypair::try_from_bytes(&mut basedecode) {
+                Ok(kp) => kp,
+                Err(e) => {
+                    log::error!(
+                        "skipping user '{}': failed to parse ed25519 keypair: {}",
+                        user.name, e
+                    );
+                    continue;
+                }
+            };
             let keys = Keypair::from(ed25519_keys);
             let id = PeerId::from(keys.public());
 

--- a/rust/libqaul/src/router/connections.rs
+++ b/rust/libqaul/src/router/connections.rs
@@ -222,8 +222,9 @@ impl ConnectionTable {
         let config = super::Router::get_configuration();
 
         // calculate link quality
-        // `hop_count_penalty` is seconds unit, thus it must be converted micro seconds
-        let lq = rtt + (hc as u32 * (config.hop_count_penalty as u32) * 1000_000);
+        // `hop_count_penalty` is seconds unit, thus it must be converted to micro seconds
+        let penalty = (hc as u64) * (config.hop_count_penalty as u64) * 1_000_000;
+        let lq = (rtt as u64).saturating_add(penalty).min(u32::MAX as u64) as u32;
 
         // return link quality
         lq
@@ -276,7 +277,7 @@ impl ConnectionTable {
             } else if pgid < user.pgid {
                 if user.pgid_update_hc == connection.hc {
                     //reboot node case
-                    if (user.pgid - pgid) > (connection.hc as u32) {
+                    if user.pgid.saturating_sub(pgid) > (connection.hc as u32) {
                         user.pgid = pgid;
                         user.pgid_update = now_ts;
                         user.pgid_update_hc = connection.hc;
@@ -311,7 +312,9 @@ impl ConnectionTable {
             user.pgid = propagation_id;
             // QUESTION: is this of any use?
             user.pgid_update = Timestamp::get_timestamp();
-            user.connections.get_mut(0).unwrap().last_update = Timestamp::get_timestamp();
+            if let Some(conn) = user.connections.get_mut(0) {
+                conn.last_update = Timestamp::get_timestamp();
+            }
         }
     }
 

--- a/rust/libqaul/src/router/neighbours.rs
+++ b/rust/libqaul/src/router/neighbours.rs
@@ -108,6 +108,12 @@ impl Neighbours {
             node.rtt = Self::calculate_rtt(node.rtt, rtt);
             node.updated_at = Timestamp::get_timestamp();
         } else {
+            if neighbours.nodes.len() >= 100_000 {
+                log::warn!(
+                    "neighbours table has reached {} entries; possible resource exhaustion",
+                    neighbours.nodes.len()
+                );
+            }
             log::trace!("add node {:?} to neighbours table", node_id);
             neighbours.nodes.insert(
                 node_id,

--- a/rust/libqaul/src/router/users.rs
+++ b/rust/libqaul/src/router/users.rs
@@ -56,7 +56,7 @@ impl Users {
                 // decode user bytes
                 let user: UserData = bincode::deserialize(&user_bytes).unwrap();
                 // encode values from bytes
-                let q8id = user.id[6..14].to_vec();
+                let q8id = QaulId::bytes_to_q8id(user.id.clone());
                 let id = PeerId::from_bytes(&user.id).unwrap();
                 let key = PublicKey::try_decode_protobuf(&user.key).unwrap();
                 // fill result into user table
@@ -79,7 +79,7 @@ impl Users {
     /// This user will be added to the users list in memory and to the data base
     pub fn add(id: PeerId, key: PublicKey, name: String, verified: bool, blocked: bool) {
         let id_bytes = id.to_bytes();
-        let q8id = id_bytes[6..14].to_vec();
+        let q8id = QaulId::bytes_to_q8id(id_bytes.clone());
 
         // save user to the data base
         DbUsers::add_user(UserData {
@@ -92,6 +92,12 @@ impl Users {
 
         // add user to the users table
         let mut users = USERS.get().write().unwrap();
+        if users.users.len() >= 100_000 {
+            log::warn!(
+                "users table has reached {} entries; possible resource exhaustion",
+                users.users.len()
+            );
+        }
         users.users.insert(
             q8id,
             User {
@@ -117,7 +123,7 @@ impl Users {
         // check if user already exists
         {
             let id_bytes = id.to_bytes();
-            let q8id = &id_bytes[6..14];
+            let q8id = QaulId::bytes_as_q8id(&id_bytes);
             let users = USERS.get().read().unwrap();
 
             // check if user already exists
@@ -146,7 +152,7 @@ impl Users {
     /// get the public key of a known user
     pub fn get_pub_key(user_id: &PeerId) -> Option<PublicKey> {
         let user_id_bytes = user_id.to_bytes();
-        Self::get_pub_key_by_q8id(&user_id_bytes[6..14])
+        Self::get_pub_key_by_q8id(QaulId::bytes_as_q8id(&user_id_bytes))
     }
 
     /// get the public key of a known user by it's q8id
@@ -225,9 +231,9 @@ impl Users {
 
     /// get security number
     fn get_security_number(my_user: &PeerId, user_id: &[u8]) -> Result<Vec<u8>, String> {
-        let q8id = &user_id[6..14];
+        let q8id = QaulId::bytes_as_q8id(user_id);
         let my_user_bytes = my_user.to_bytes();
-        let q8id_my = &my_user_bytes[6..14];
+        let q8id_my = QaulId::bytes_as_q8id(&my_user_bytes);
 
         // find user from users
         let users = USERS.get().read().unwrap();
@@ -390,7 +396,7 @@ impl Users {
                 return;
             }
         };
-        let q8id = &user_id_bytes[6..14];
+        let q8id = QaulId::bytes_as_q8id(user_id_bytes);
 
         // acquire a lock to lookup the user entry
         let mut store = USERS.get().write().unwrap();

--- a/rust/libqaul/src/rpc/authentication.rs
+++ b/rust/libqaul/src/rpc/authentication.rs
@@ -178,7 +178,8 @@ impl Authentication {
     /// Mark a user as authenticated with a session
     fn mark_authenticated(qaul_id: PeerId) {
         let mut authenticated = AUTHENTICATED_USERS.get().write().unwrap();
-        let expires_at = Timestamp::get_timestamp() + (86400 * 365 * 100);
+        // Session expires after 24 hours (86400 seconds * 1000 milliseconds)
+        let expires_at = Timestamp::get_timestamp() + (86400 * 1000);
         authenticated.insert(qaul_id.to_bytes(), expires_at);
     }
 

--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -228,6 +228,7 @@ pub struct FileHistory {
     /// file extension
     pub file_extension: String,
     /// file size in bytes
+    // TODO: u32 limits files to 4GB; consider u64 for large file support
     pub file_size: u32,
     /// file sent
     pub sent_at: u64,

--- a/rust/libqaul/src/services/crypto/noise.rs
+++ b/rust/libqaul/src/services/crypto/noise.rs
@@ -185,7 +185,14 @@ impl CryptoNoise {
         message = Some(cipher.encrypt_vec(data.as_slice()));
 
         // save new nonce to state
-        state.index_nonce_out = nonce + 1;
+        if nonce >= u64::MAX - 1 {
+            log::error!(
+                "nonce overflow imminent for session {}: session must be renegotiated",
+                state.session_id
+            );
+        } else {
+            state.index_nonce_out = nonce + 1;
+        }
 
         // save state
         storage.save_state(remote_id, state.session_id, state);

--- a/rust/libqaul/src/services/dtn/mod.rs
+++ b/rust/libqaul/src/services/dtn/mod.rs
@@ -205,6 +205,11 @@ impl Dtn {
             };
             let message_entry_bytes = bincode::serialize(&message_entry).unwrap();
 
+            // NOTE: The following two tree writes (db_ref and db_ref_id) are not
+            // atomic. If a crash occurs between them, the database could end up in
+            // an inconsistent state (e.g. an entry in db_ref without a corresponding
+            // entry in db_ref_id, or vice versa). A sled transaction spanning both
+            // trees would fix this but requires a larger refactor.
             if let Err(_e) = storage_state
                 .db_ref
                 .insert(signature.clone(), message_entry_bytes)
@@ -268,7 +273,9 @@ impl Dtn {
             state.used_size = state.used_size.saturating_sub(entry.size as u64);
             state.message_counts = state.message_counts.saturating_sub(1);
 
-            // remove entry
+            // NOTE: The following two tree removals (db_ref and db_ref_id) are not
+            // atomic. A crash between them could leave stale entries in one tree.
+            // A sled transaction spanning both trees would fix this.
             if let Err(_) = state.db_ref.remove(&dtn_response.signature) {
                 log::error!("remove storage node entry error!");
             } else {

--- a/rust/libqaul/src/services/dtn/mod.rs
+++ b/rust/libqaul/src/services/dtn/mod.rs
@@ -256,18 +256,17 @@ impl Dtn {
     pub fn on_dtn_response(dtn_response: &super::messaging::proto::DtnResponse) {
         // check if storage node case
         let mut state = STORAGESTATE.get().write().unwrap();
-        if state.db_ref.contains_key(&dtn_response.signature).unwrap() {
+        if let Ok(Some(entry_bytes)) = state.db_ref.get(&dtn_response.signature) {
             // update storage node state
-            let entry_bytes = state.db_ref.get(&dtn_response.signature).unwrap().unwrap();
-            let entry: DtnMessageEntry = bincode::deserialize(&entry_bytes).unwrap();
-            if state.used_size > entry.size as u64 {
-                state.used_size = state.used_size + (entry.size as u64);
-            } else {
-                state.used_size = 0;
-            }
-            if state.message_counts > 0 {
-                state.message_counts = state.message_counts - 1;
-            }
+            let entry: DtnMessageEntry = match bincode::deserialize(&entry_bytes) {
+                Ok(e) => e,
+                Err(e) => {
+                    log::error!("DTN: failed to deserialize entry: {}", e);
+                    return;
+                }
+            };
+            state.used_size = state.used_size.saturating_sub(entry.size as u64);
+            state.message_counts = state.message_counts.saturating_sub(1);
 
             // remove entry
             if let Err(_) = state.db_ref.remove(&dtn_response.signature) {

--- a/rust/libqaul/src/services/group/member.rs
+++ b/rust/libqaul/src/services/group/member.rs
@@ -382,12 +382,12 @@ impl Member {
         }
 
         // check if user is invite pending state
-        if !group.members.contains_key(&sender_id_bytes) {
-            return Err("member is not invite pending state".to_string());
-        }
-        let member = group.members.get(&sender_id_bytes).unwrap();
-        if member.state > 0 {
-            return Err("member is not invite pending state, it's joined".to_string());
+        match group.members.get(&sender_id_bytes) {
+            None => return Err("member is not invite pending state".to_string()),
+            Some(member) if member.state > 0 => {
+                return Err("member is not invite pending state, it's joined".to_string());
+            }
+            Some(_) => {}
         }
 
         group.members.remove(&sender_id_bytes);

--- a/rust/libqaul/src/services/messaging/mod.rs
+++ b/rust/libqaul/src/services/messaging/mod.rs
@@ -503,6 +503,14 @@ impl Messaging {
 
         // add it to sending queue
         let mut messaging = MESSAGING.get().write().unwrap();
+        const MAX_QUEUE_SIZE: usize = 10_000;
+        if messaging.to_send.len() >= MAX_QUEUE_SIZE {
+            log::warn!(
+                "messaging send queue full ({} messages), dropping oldest message",
+                messaging.to_send.len()
+            );
+            messaging.to_send.pop_front();
+        }
         messaging.to_send.push_back(msg);
     }
 

--- a/rust/libqaul/src/services/messaging/retransmit.rs
+++ b/rust/libqaul/src/services/messaging/retransmit.rs
@@ -77,22 +77,30 @@ impl MessagingRetransmit {
                             );
 
                             // update entry
-                            let mut new_retry = unconfirmed_message.retry;
+                            let new_retry = unconfirmed_message.retry + 1;
                             if new_retry > 10 {
-                                new_retry = 1;
-                            }
-
-                            unconfirmed_message.retry = new_retry;
-                            unconfirmed_message.last_sent = cur_time;
-                            let unconfirmed_message_todb =
-                                bincode::serialize(&unconfirmed_message).unwrap();
-                            if let Err(_e) = unconfirmed
-                                .unconfirmed
-                                .insert(signature, unconfirmed_message_todb)
-                            {
-                                log::error!("updating unconfirmed table error!");
-                            } else {
+                                // max retries reached, remove from unconfirmed
+                                log::warn!(
+                                    "retransmit: max retries reached for message, removing: {}",
+                                    bs58::encode(&signature).into_string()
+                                );
+                                if let Err(_e) = unconfirmed.unconfirmed.remove(&signature) {
+                                    log::error!("removing expired unconfirmed message error!");
+                                }
                                 updated = true;
+                            } else {
+                                unconfirmed_message.retry = new_retry;
+                                unconfirmed_message.last_sent = cur_time;
+                                let unconfirmed_message_todb =
+                                    bincode::serialize(&unconfirmed_message).unwrap();
+                                if let Err(_e) = unconfirmed
+                                    .unconfirmed
+                                    .insert(signature, unconfirmed_message_todb)
+                                {
+                                    log::error!("updating unconfirmed table error!");
+                                } else {
+                                    updated = true;
+                                }
                             }
                         }
                     }

--- a/rust/libqaul/src/services/messaging/retransmit.rs
+++ b/rust/libqaul/src/services/messaging/retransmit.rs
@@ -46,6 +46,19 @@ impl MessagingRetransmit {
                     continue;
                 }
 
+                // expire messages older than 1 hour to prevent indefinite accumulation
+                if cur_time.saturating_sub(unconfirmed_message.last_sent) > 3_600_000 {
+                    log::warn!(
+                        "retransmit: message expired (>1h), removing: {}",
+                        bs58::encode(&signature).into_string()
+                    );
+                    if let Err(_e) = unconfirmed.unconfirmed.remove(&signature) {
+                        log::error!("removing expired unconfirmed message error!");
+                    }
+                    updated = true;
+                    continue;
+                }
+
                 let qaul_id = QaulId::bytes_as_q8id(&unconfirmed_message.receiver_id);
                 //1. check receiver is online
                 if let Some(_hc) = online_users.get(qaul_id) {

--- a/rust/libqaul/src/services/rtc/mod.rs
+++ b/rust/libqaul/src/services/rtc/mod.rs
@@ -179,7 +179,10 @@ impl Rtc {
                 //     );
                 // }
                 _ => {
-                    log::error!("rtc message from {} was empty", sender_id.to_base58())
+                    log::warn!(
+                        "unhandled or empty RTC message variant from {} (RtcMessage processing is commented out)",
+                        sender_id.to_base58()
+                    );
                 }
             },
             Err(e) => {

--- a/rust/libqaul/src/storage/configuration.rs
+++ b/rust/libqaul/src/storage/configuration.rs
@@ -264,7 +264,13 @@ impl Configuration {
                 log::error!("no configuration file found, creating one.");
                 Configuration::default()
             }
-            Ok(c) => c.try_deserialize::<Configuration>().unwrap(),
+            Ok(c) => match c.try_deserialize::<Configuration>() {
+                Ok(config) => config,
+                Err(e) => {
+                    log::error!("failed to deserialize configuration: {}, using defaults", e);
+                    Configuration::default()
+                }
+            },
         }
     }
 
@@ -301,7 +307,13 @@ impl Configuration {
     /// Libqaul uses the `init()` function to load and initialize the configuration!
     pub fn load(path: &str) -> Option<Configuration> {
         if let Ok(c) = Config::builder().add_source(File::with_name(path)).build() {
-            return Some(c.try_deserialize::<Configuration>().unwrap());
+            match c.try_deserialize::<Configuration>() {
+                Ok(config) => return Some(config),
+                Err(e) => {
+                    log::error!("failed to deserialize configuration at {}: {}", path, e);
+                    return None;
+                }
+            }
         }
         None
     }

--- a/rust/libqaul/src/storage/database.rs
+++ b/rust/libqaul/src/storage/database.rs
@@ -39,9 +39,9 @@ impl DataBase {
 
         // open node data base
         let node = sled::Config::default()
-            .path(db_path)
+            .path(db_path.clone())
             .open()
-            .expect("Failed to open sled db");
+            .expect(&format!("Failed to open sled database at {:?}", db_path));
 
         DataBase {
             path: storage_path.to_string(),
@@ -82,9 +82,9 @@ impl DataBase {
 
         // open data base from disk
         let db = sled::Config::default()
-            .path(db_path)
+            .path(db_path.clone())
             .open()
-            .expect("Failed to open sled db");
+            .expect(&format!("Failed to open sled database at {:?}", db_path));
 
         // save data base to state
         self.users.insert(account_id.to_bytes(), db.clone());
@@ -122,9 +122,9 @@ impl DataBase {
 
             // open data base from disk
             let db = sled::Config::default()
-                .path(db_path)
+                .path(db_path.clone())
                 .open()
-                .expect("Failed to open sled db");
+                .expect(&format!("Failed to open sled database at {:?}", db_path));
 
             // save data base to state
             database.users.insert(account_id.to_bytes(), db.clone());

--- a/rust/libqaul/src/utilities/upgrade/mod.rs
+++ b/rust/libqaul/src/utilities/upgrade/mod.rs
@@ -48,7 +48,13 @@ impl Upgrade {
                 return false;
             }
         } else {
-            old_version = fs::read_to_string(path).unwrap();
+            match fs::read_to_string(&path) {
+                Ok(v) => old_version = v,
+                Err(e) => {
+                    println!("failed to read version file: {}", e);
+                    return false;
+                }
+            }
         }
 
         // check if old version is equal to new version
@@ -65,12 +71,24 @@ impl Upgrade {
     fn upgrade(storage_path: &Path, old_version: &str) -> bool {
         println!("running upgrade check for version {}", old_version);
 
-        let mut version = Version::parse(old_version).unwrap();
+        let mut version = match Version::parse(old_version) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("failed to parse old version '{}': {}", old_version, e);
+                return false;
+            }
+        };
 
         // check if libqaul is upgradable
         // the last possible upgradable version at the moment is 2.0.0-beta.18
         // all previous versions need to upgrade to that one in order to upgrade further.
-        let last_upgradable_version = Version::parse("2.0.0-beta.18").unwrap();
+        let last_upgradable_version = match Version::parse("2.0.0-beta.18") {
+            Ok(v) => v,
+            Err(e) => {
+                println!("failed to parse last upgradable version: {}", e);
+                return false;
+            }
+        };
         if version < last_upgradable_version {
             // issue an informative message
             println!(
@@ -96,11 +114,24 @@ impl Upgrade {
         // put new upgrade version below this chain.
 
         // upgrade to version 2.0.0-rc.1
-        if version < Version::parse("2.0.0-rc.1").unwrap() {
+        let version_rc1 = match Version::parse("2.0.0-rc.1") {
+            Ok(v) => v,
+            Err(e) => {
+                println!("failed to parse version 2.0.0-rc.1: {}", e);
+                return false;
+            }
+        };
+        if version < version_rc1 {
             match v2_0_0_rc_1::VersionUpgrade::upgrade(storage_path, &backup_path) {
                 Ok((new_version, new_path)) => {
                     // update values
-                    version = Version::parse(&new_version).unwrap();
+                    version = match Version::parse(&new_version) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            println!("failed to parse upgraded version '{}': {}", new_version, e);
+                            return false;
+                        }
+                    };
                     backup_path = new_path;
                 }
                 Err(e) => {
@@ -111,11 +142,24 @@ impl Upgrade {
         }
 
         // upgrade to version 2.0.0-rc.5
-        if version < Version::parse("2.0.0-rc.5").unwrap() {
+        let version_rc5 = match Version::parse("2.0.0-rc.5") {
+            Ok(v) => v,
+            Err(e) => {
+                println!("failed to parse version 2.0.0-rc.5: {}", e);
+                return false;
+            }
+        };
+        if version < version_rc5 {
             match v2_0_0_rc_5::VersionUpgrade::upgrade(storage_path, &backup_path) {
                 Ok((new_version, new_path)) => {
                     // update values
-                    version = Version::parse(&new_version).unwrap();
+                    version = match Version::parse(&new_version) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            println!("failed to parse upgraded version '{}': {}", new_version, e);
+                            return false;
+                        }
+                    };
                     backup_path = new_path;
                 }
                 Err(e) => {


### PR DESCRIPTION
  - Fixed DTN storage size being incremented instead of decremented on message confirmation
  - Fixed u32 overflow in hop count penalty calculation corrupting routing metrics
  - Replaced panicking unwraps with proper error handling in config loading, key parsing, DTN responses, and group membership checks
  - Capped message retransmit at 10 attempts instead of cycling forever
  - and other less critical fixes

closes #836 