### PR TITLE
Clean up after pr 822

### DIFF
--- a/qaul_ui/lib/main.dart
+++ b/qaul_ui/lib/main.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:collection/collection.dart';
-import 'package:fast_base58/fast_base58.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -17,34 +15,7 @@ import 'l10n/app_localizations.dart';
 import 'qaul_app.dart';
 import 'stores/stores.dart';
 
-final _inFlightUserFetchById = <String, Future<User?>>{};
-
-final _container = ProviderContainer(
-  overrides: [
-    fetchUserByIdForRpcProvider.overrideWith(
-      (ref) => (id) {
-        final idBase58 = Base58Encode(id);
-        final inStore = ref
-            .read(usersStoreProvider)
-            .firstWhereOrNull((u) => u.idBase58 == idBase58);
-        if (inStore != null) return Future.value(inStore);
-
-        final inFlight = _inFlightUserFetchById[idBase58];
-        if (inFlight != null) return inFlight;
-
-        final request = ref.read(qaulWorkerProvider).getUserById(id);
-        _inFlightUserFetchById[idBase58] = request;
-        return request.whenComplete(() {
-          _inFlightUserFetchById.remove(idBase58);
-        });
-      },
-    ),
-    onGroupMemberUserResolvedProvider.overrideWith(
-      (ref) => (u) =>
-          ref.read(usersStoreProvider.notifier).mergeResolvedRpcUser(u),
-    ),
-  ],
-);
+final _container = ProviderContainer();
 
 void main() async {
   runZonedGuarded<Future<void>>(() async {

--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -27,7 +27,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
         return _ChatData.fromJson(jsonDecode(e));
       }));
     }
-    ref.read(qaulWorkerProvider).getAllChatRooms();
+    await ref.read(groupStoreProvider.notifier).refreshChatRooms();
     _log.config(
         'Initialized:\n\t· User: ${localUser.name}\n\t· Cached chats: $_chats');
   }

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -35,9 +35,11 @@ class _ChatState extends _BaseTabState<_Chat> {
       ..sort();
 
     final refreshChatsAndInvites = useCallback(() async {
-      final worker = ref.read(qaulWorkerProvider);
-      worker.getAllChatRooms();
-      worker.getGroupInvitesReceived();
+      final groups = ref.read(groupStoreProvider.notifier);
+      await Future.wait([
+        groups.refreshChatRooms(),
+        groups.refreshGroupInvites(),
+      ]);
     }, []);
 
     final mobile =

--- a/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
@@ -55,8 +55,6 @@ class _CreateNewGroupDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final worker = ref.read(qaulWorkerProvider);
-
     final loading = useState(false);
     final nameCtrl = useTextEditingController();
 
@@ -103,7 +101,7 @@ class _CreateNewGroupDialog extends HookConsumerWidget {
                 loading.value = true;
 
                 var name = nameCtrl.text;
-                await createChatGroup(name, worker, ref);
+                await createChatGroup(name, ref);
                 if (!context.mounted) return;
 
                 final group = ref
@@ -139,14 +137,13 @@ class _CreateNewGroupDialog extends HookConsumerWidget {
     );
   }
 
-  Future<void> createChatGroup(
-      String name, LibqaulWorker worker, WidgetRef ref) async {
-    worker.createGroup(name);
+  Future<void> createChatGroup(String name, WidgetRef ref) async {
+    ref.read(qaulWorkerProvider).createGroup(name);
     for (var i = 0; i < 60; i++) {
       final groups = ref.read(chatRoomsProvider);
       if (groups.where((g) => g.name == name).isNotEmpty) break;
 
-      worker.getAllChatRooms();
+      await ref.read(groupStoreProvider.notifier).refreshChatRooms();
       await Future.delayed(const Duration(milliseconds: 1000));
     }
   }

--- a/qaul_ui/lib/stores/group_store.dart
+++ b/qaul_ui/lib/stores/group_store.dart
@@ -1,0 +1,92 @@
+part of 'stores.dart';
+
+final groupStoreProvider = NotifierProvider<GroupStore, void>(GroupStore.new);
+
+class GroupStore extends Notifier<void> {
+  @override
+  void build() {}
+
+  Future<List<ChatRoom>> refreshChatRooms() async {
+    final worker = ref.read(qaulWorkerProvider);
+    final rooms = await worker.getAllChatRooms();
+    if (!ref.mounted) return [];
+    await _resolveMissingUsersForRooms(rooms);
+    if (!ref.mounted) return [];
+    return ref.read(chatRoomsProvider);
+  }
+
+  Future<List<GroupInvite>> refreshGroupInvites() async {
+    final worker = ref.read(qaulWorkerProvider);
+    final invites = await worker.getGroupInvitesReceived();
+    if (!ref.mounted) return [];
+    final rooms = invites.map((i) => i.groupDetails).toList();
+    await _resolveMissingUsersForRooms(rooms);
+    if (!ref.mounted) return [];
+
+    final usersById = {
+      for (final u in ref.read(usersStoreProvider)) u.idBase58: u,
+    };
+    final inviteState = ref.read(groupInvitesProvider.notifier);
+    for (final invite in ref.read(groupInvitesProvider)) {
+      final hydratedRoom = _hydrateRoomMembers(invite.groupDetails, usersById);
+      if (hydratedRoom == invite.groupDetails) continue;
+      inviteState.update(
+        GroupInvite(
+          senderId: invite.senderId,
+          receivedAt: invite.receivedAt,
+          groupDetails: hydratedRoom,
+        ),
+      );
+    }
+    return ref.read(groupInvitesProvider);
+  }
+
+  Future<void> _resolveMissingUsersForRooms(List<ChatRoom> rooms) async {
+    final knownIds = ref.read(usersStoreProvider).map((u) => u.idBase58).toSet();
+    final missingIds = <String>{};
+
+    for (final room in rooms) {
+      for (final member in room.members) {
+        if (!knownIds.contains(member.idBase58)) {
+          missingIds.add(member.idBase58);
+        }
+      }
+    }
+
+    if (missingIds.isNotEmpty) {
+      final usersStore = ref.read(usersStoreProvider.notifier);
+      await Future.wait(missingIds.map(usersStore.getByUserID));
+    }
+    if (!ref.mounted) return;
+
+    final usersById = {
+      for (final u in ref.read(usersStoreProvider)) u.idBase58: u,
+    };
+    final roomsState = ref.read(chatRoomsProvider.notifier);
+    for (final room in ref.read(chatRoomsProvider)) {
+      final hydrated = _hydrateRoomMembers(room, usersById);
+      if (hydrated == room) continue;
+      roomsState.update(hydrated);
+    }
+  }
+
+  ChatRoom _hydrateRoomMembers(ChatRoom room, Map<String, User> usersById) {
+    var changed = false;
+    final members = room.members.map((member) {
+      final user = usersById[member.idBase58];
+      if (user == null) return member;
+      if (member.name == user.name) return member;
+      changed = true;
+      return ChatRoomUser(
+        user,
+        joinedAt: member.joinedAt,
+        roomId: member.roomId,
+        role: member.role,
+        invitationState: member.invitationState,
+      );
+    }).toList();
+
+    if (!changed) return room;
+    return room.copyWith(members: members);
+  }
+}

--- a/qaul_ui/lib/stores/stores.dart
+++ b/qaul_ui/lib/stores/stores.dart
@@ -14,3 +14,4 @@ import 'package:utils/utils.dart';
 
 part 'users_store.dart';
 part 'feed_message_store.dart';
+part 'group_store.dart';

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -7,6 +7,7 @@ final usersStoreProvider = NotifierProvider<UsersStore, List<User>>(
 class UsersStore extends Notifier<List<User>> {
   PaginationState? _pagination;
   PaginationState? get pagination => _pagination;
+  final _inFlightByUserId = <String, Future<User?>>{};
 
   Timer? _pollingTimer;
   static const _pollingInterval = Duration(seconds: 3);
@@ -61,17 +62,25 @@ class UsersStore extends Notifier<List<User>> {
     final match = state.where((u) => u.idBase58 == idBase58);
     if (match.isNotEmpty) return match.first;
     try {
+      final inFlight = _inFlightByUserId[idBase58];
+      if (inFlight != null) return inFlight;
+
       final worker = ref.read(qaulWorkerProvider);
       final userId = Uint8List.fromList(Base58Decode(idBase58));
-      return worker.getUserById(userId);
+      final request = worker.getUserById(userId);
+      _inFlightByUserId[idBase58] = request;
+
+      final user = await request;
+      if (user != null) {
+        _updateMany([user]);
+        _syncLookup();
+      }
+      return user;
     } catch (_) {
       return null;
+    } finally {
+      _inFlightByUserId.remove(idBase58);
     }
-  }
-
-  void mergeResolvedRpcUser(User u) {
-    _updateMany([u]);
-    _syncLookup();
   }
 
   /// Always hits the RPC, bypassing the local-first check in [getByUserID].

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -58,19 +58,32 @@ class UsersStore extends Notifier<List<User>> {
     return findMemberInRoom(otherMember.id, room);
   }
 
-  Future<User?> getByUserID(String idBase58) async {
+  Future<User?> getByUserID(String idBase58) {
     final match = state.where((u) => u.idBase58 == idBase58);
-    if (match.isNotEmpty) return match.first;
+    if (match.isNotEmpty) return Future.value(match.first);
+
+    final inFlight = _inFlightByUserId[idBase58];
+    if (inFlight != null) return inFlight;
+
+    final Uint8List userId;
     try {
-      final inFlight = _inFlightByUserId[idBase58];
-      if (inFlight != null) return inFlight;
+      userId = Uint8List.fromList(Base58Decode(idBase58));
+    } catch (_) {
+      return Future.value(null);
+    }
 
-      final worker = ref.read(qaulWorkerProvider);
-      final userId = Uint8List.fromList(Base58Decode(idBase58));
-      final request = worker.getUserById(userId);
-      _inFlightByUserId[idBase58] = request;
+    final request = _fetchAndMergeUser(idBase58, userId);
+    _inFlightByUserId[idBase58] = request;
+    return request;
+  }
 
-      final user = await request;
+  /// Owning fetch path for [getByUserID]. The `try/finally` here is safe
+  /// because this is the only invocation that ever drives the in-flight
+  /// future to completion — concurrent callers receive the future via
+  /// [getByUserID]'s in-flight check, never re-enter this method.
+  Future<User?> _fetchAndMergeUser(String idBase58, Uint8List userId) async {
+    try {
+      final user = await ref.read(qaulWorkerProvider).getUserById(userId);
       if (user != null) {
         _updateMany([user]);
         _syncLookup();

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -75,13 +75,13 @@ class ChatRoom with EquatableMixin implements Comparable {
   }
 
   factory ChatRoom.fromRpcGroupInfo(GroupInfo g, List<User> users) {
-    final members = <ChatRoomUser>[];
-
-    for (final user in users) {
-      final m = g.members.firstWhereOrNull((m) => m.userId.equals(user.id));
-      if (m == null) continue;
-      members.add(ChatRoomUser.fromUser(user, m));
-    }
+    final usersById = <String, User>{for (final u in users) u.idBase58: u};
+    final members = g.members.map((m) {
+      final memberId = Uint8List.fromList(m.userId);
+      final user = usersById[Base58Encode(memberId)] ??
+          User(name: 'Name Undefined', id: memberId);
+      return ChatRoomUser.fromUser(user, m);
+    }).toList();
 
     return ChatRoom(
       conversationId: Uint8List.fromList(g.groupId),

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart';
 import 'package:fast_base58/fast_base58.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:hooks_riverpod/legacy.dart';
 
 final defaultUserProvider = StateProvider<User?>((ref) => null);
@@ -13,16 +12,6 @@ final defaultUserProvider = StateProvider<User?>((ref) => null);
 /// (which live in the `qaul_rpc` package and cannot import app-layer stores)
 /// can look up users during message decoding.
 final userLookupProvider = StateProvider<List<User>>((ref) => []);
-
-/// Resolves a user by raw id bytes when they are missing from [userLookupProvider].
-///
-/// The app must override this (typically to call [LibqaulWorker.getUserById]) so group
-/// and chat decoding can load members that are not in the paginated user list.
-final fetchUserByIdForRpcProvider =
-    Provider<Future<User?> Function(Uint8List userId)?>((ref) => null);
-
-/// When a user is fetched during group decoding, the app may merge them into [UsersStore].
-final onGroupMemberUserResolvedProvider = Provider<void Function(User)?>((ref) => null);
 
 class PaginationState {
   const PaginationState({

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
@@ -1,52 +1,5 @@
 part of 'abstract_rpc_module_translator.dart';
 
-Future<List<User>> _resolveUsersForGroupInfo(
-  GroupInfo g,
-  Map<String, User> knownUsersById,
-  Map<String, User?> resolvedCache,
-  Ref ref,
-) async {
-  final fetch = ref.read(fetchUserByIdForRpcProvider);
-  final onResolved = ref.read(onGroupMemberUserResolvedProvider);
-  final result = <User>[];
-  final missingIds = <String>[];
-  final missingIdBytes = <Uint8List>[];
-
-  for (final m in g.members) {
-    final idBytes = Uint8List.fromList(m.userId);
-    final idBase58 = Base58Encode(idBytes);
-    final known = knownUsersById[idBase58];
-    if (known != null) {
-      result.add(known);
-      continue;
-    }
-    if (resolvedCache.containsKey(idBase58)) {
-      final cached = resolvedCache[idBase58];
-      if (cached != null) {
-        result.add(cached);
-      }
-      continue;
-    }
-    missingIds.add(idBase58);
-    missingIdBytes.add(idBytes);
-  }
-
-  if (fetch == null || missingIdBytes.isEmpty) return result;
-
-  final fetched = await Future.wait(missingIdBytes.map(fetch));
-  for (var i = 0; i < missingIdBytes.length; i++) {
-    final idBase58 = missingIds[i];
-    final u = fetched[i];
-    resolvedCache[idBase58] = u;
-    if (u != null) {
-      result.add(u);
-      knownUsersById[idBase58] = u;
-      onResolved?.call(u);
-    }
-  }
-  return result;
-}
-
 class GroupTranslator extends RpcModuleTranslator {
   @override
   Modules get type => Modules.GROUP;
@@ -54,20 +7,14 @@ class GroupTranslator extends RpcModuleTranslator {
   @override
   Future<RpcTranslatorResponse?> decodeMessageBytes(List<int> data, Ref ref) async {
     final knownUsers = ref.read(userLookupProvider);
-    final knownUsersById = <String, User>{
-      for (final u in knownUsers) u.idBase58: u,
-    };
-    final resolvedCache = <String, User?>{};
     final message = Group.fromBuffer(data);
 
     switch (message.whichMessage()) {
       case Group_Message.groupInfoResponse:
         final info = message.ensureGroupInfoResponse();
-        final users =
-            await _resolveUsersForGroupInfo(info, knownUsersById, resolvedCache, ref);
         return RpcTranslatorResponse(
           type,
-          ChatRoom.fromRpcGroupInfo(info, users),
+          ChatRoom.fromRpcGroupInfo(info, knownUsers),
         );
       case Group_Message.groupCreateResponse:
         final createResult = message.ensureGroupCreateResponse().result;
@@ -86,25 +33,15 @@ class GroupTranslator extends RpcModuleTranslator {
         return _receiveGroupResultResponse(replyResult);
       case Group_Message.groupListResponse:
         final groupsPb = message.ensureGroupListResponse().groups;
-        final rooms = <ChatRoom>[];
-        for (final g in groupsPb) {
-          final users =
-              await _resolveUsersForGroupInfo(g, knownUsersById, resolvedCache, ref);
-          rooms.add(ChatRoom.fromRpcGroupInfo(g, users));
-        }
+        final rooms = groupsPb
+            .map((g) => ChatRoom.fromRpcGroupInfo(g, knownUsers))
+            .toList();
         return RpcTranslatorResponse(type, rooms);
       case Group_Message.groupInvitedResponse:
         final invited = message.ensureGroupInvitedResponse().invited;
-        final invites = <GroupInvite>[];
-        for (final e in invited) {
-          final users = await _resolveUsersForGroupInfo(
-            e.group,
-            knownUsersById,
-            resolvedCache,
-            ref,
-          );
-          invites.add(GroupInvite.fromRpcGroupInvited(e, users));
-        }
+        final invites = invited
+            .map((e) => GroupInvite.fromRpcGroupInvited(e, knownUsers))
+            .toList();
         return RpcTranslatorResponse(type, invites);
       default:
         return super.decodeMessageBytes(data, ref);

--- a/qaul_ui/test/users_store_test.dart
+++ b/qaul_ui/test/users_store_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:fast_base58/fast_base58.dart';
@@ -14,6 +15,20 @@ class _MockWorkerForGetByUserID extends StubLibqaulWorker {
   @override
   Future<User?> getUserById(Uint8List userId) =>
       Future.value(getUserByIdResult);
+}
+
+/// Mock worker whose `getUserById` future is held open by an external
+/// `Completer`, so tests can fire concurrent callers before the RPC resolves.
+class _DeferredMockWorkerForGetByUserID extends StubLibqaulWorker {
+  _DeferredMockWorkerForGetByUserID(super.ref);
+  final completer = Completer<User?>();
+  int callCount = 0;
+
+  @override
+  Future<User?> getUserById(Uint8List userId) {
+    callCount++;
+    return completer.future;
+  }
 }
 
 class _MockWorkerForGetMoreUsers extends StubLibqaulWorker {
@@ -136,6 +151,124 @@ void main() {
     final result = await store.getByUserID(unknownIdBase58);
 
     expect(result, isNull);
+  });
+
+  group('getByUserID dedup', () {
+    test('concurrent callers share a single RPC and one state merge',
+        () async {
+      final user = User(
+        name: 'Shared',
+        id: Uint8List.fromList('shared_user_id'.codeUnits),
+      );
+
+      late _DeferredMockWorkerForGetByUserID mockWorker;
+      final container = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          qaulWorkerProvider.overrideWith((ref) {
+            mockWorker = _DeferredMockWorkerForGetByUserID(ref);
+            return mockWorker;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final store = container.read(usersStoreProvider.notifier);
+
+      // Fire three concurrent callers BEFORE the RPC resolves.
+      final f1 = store.getByUserID(user.idBase58);
+      final f2 = store.getByUserID(user.idBase58);
+      final f3 = store.getByUserID(user.idBase58);
+
+      // Only one underlying RPC should have been dispatched.
+      expect(mockWorker.callCount, 1);
+
+      mockWorker.completer.complete(user);
+      final results = await Future.wait([f1, f2, f3]);
+
+      expect(results.every((r) => r?.idBase58 == user.idBase58), isTrue);
+      expect(mockWorker.callCount, 1);
+
+      // The user is merged into state exactly once.
+      final state = container.read(usersStoreProvider);
+      expect(state.where((u) => u.idBase58 == user.idBase58).length, 1);
+    });
+
+    test('in-flight cache is released after the RPC completes', () async {
+      final user = User(
+        name: 'Released',
+        id: Uint8List.fromList('released_user_id'.codeUnits),
+      );
+
+      late _DeferredMockWorkerForGetByUserID mockWorker;
+      final container = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          qaulWorkerProvider.overrideWith((ref) {
+            mockWorker = _DeferredMockWorkerForGetByUserID(ref);
+            return mockWorker;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final store = container.read(usersStoreProvider.notifier);
+
+      final first = store.getByUserID(user.idBase58);
+      mockWorker.completer.complete(user);
+      await first;
+
+      // Second call hits the local-first check and does not dispatch a new RPC.
+      final cached = await store.getByUserID(user.idBase58);
+      expect(cached?.idBase58, user.idBase58);
+      expect(mockWorker.callCount, 1);
+    });
+
+    test('error path dedups, returns null, and clears the in-flight entry',
+        () async {
+      final unknownIdBase58 = User(
+        name: 'X',
+        id: Uint8List.fromList('error_user_id'.codeUnits),
+      ).idBase58;
+
+      late _DeferredMockWorkerForGetByUserID mockWorker;
+      final container = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          qaulWorkerProvider.overrideWith((ref) {
+            mockWorker = _DeferredMockWorkerForGetByUserID(ref);
+            return mockWorker;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final store = container.read(usersStoreProvider.notifier);
+
+      final f1 = store.getByUserID(unknownIdBase58);
+      final f2 = store.getByUserID(unknownIdBase58);
+      expect(mockWorker.callCount, 1);
+
+      mockWorker.completer.completeError(StateError('boom'));
+      final results = await Future.wait([f1, f2]);
+
+      expect(results, [null, null]);
+      expect(mockWorker.callCount, 1);
+      expect(
+        container
+            .read(usersStoreProvider)
+            .any((u) => u.idBase58 == unknownIdBase58),
+        isFalse,
+      );
+
+      // A follow-up call must dispatch a fresh RPC, proving the `finally`
+      // in `_fetchAndMergeUser` cleared the in-flight entry on the error path.
+      final follow = store.getByUserID(unknownIdBase58);
+      expect(mockWorker.callCount, 2);
+      // The mock's completer has already errored; the new fetch awaits the
+      // same already-errored future and is caught by the inner `try/catch`.
+      expect(await follow, isNull);
+    });
   });
 
   test('store state includes all users including blocked', () async {


### PR DESCRIPTION
## Description
This PR cleans up the architecture around group/chat user resolution after the PR #822 crash fixes.

- GroupTranslator decodes protobuf only: it no longer fetches users or reads app-specific providers. It builds ChatRoom from userLookupProvider plus protobuf member data; unknown members get a placeholder user so decoding stays synchronous.

- GroupStore (app layer) loads chat rooms and invites via the worker, collects all missing member IDs across rooms in one pass, deduplicates them, and resolves them through UsersStore.getByUserID, then hydrates room members in state when full user data arrives.

- UsersStore.getByUserID now deduplicates concurrent fetches and merges fetched users into state (replacing the old mergeResolvedRpcUser + main.dart overrides).

- Removed fetchUserByIdForRpcProvider, onGroupMemberUserResolvedProvider, _inFlightUserFetchById, and ProviderContainer overrides from main.dart.

- ChatNotificationController.initialize() awaits refreshChatRooms() so the container isn’t disposed while async work runs; GroupStore guards with ref.mounted after awaits.