### PR TITLE
Implement QaulChatBubble

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,4 +1,5 @@
 export 'styles/qaul_color_sheet.dart';
+export 'widgets/qaul_chat_bubble.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_loading_indicator.dart';
 export 'widgets/qaul_navbar.dart';

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -1,0 +1,437 @@
+import 'package:flutter/material.dart';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+enum TailEdge { topStart, topEnd, bottomStart, bottomEnd }
+
+enum MessageStatus { notSent, sent, read }
+
+enum MessageType { primary, secondary }
+
+// ---------------------------------------------------------------------------
+// Public constants & style
+// ---------------------------------------------------------------------------
+
+const double kChatBubbleWidthBreakpoint = 500.0;
+
+class ChatBubbleStyle {
+  static const maxBubbleWidthMobile = 272.0;
+  static const maxBubbleWidthExtended = 392.0;
+  static const minBubbleWidth = 32.0;
+
+  static const horizontalPadding = 10.0;
+  static const verticalPadding = 6.0;
+
+  static const gapBetweenTextAndDate = 4.0;
+
+  static const gapBetweenTimeAndStatusIcon = 3.0;
+
+  static const radius = Radius.circular(10);
+
+  static const primaryColor = Color(0xFF0288D1);
+  static const secondaryColor = Color(0xFF424242);
+
+  static const textStyle = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w300,
+    height: 1.2,
+    letterSpacing: 0.1,
+    color: Colors.white,
+  );
+
+  static const timeStyle = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w400,
+    height: 1.2,
+    letterSpacing: 0,
+    color: Colors.white70,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// QaulChatBubbleMessage
+// ---------------------------------------------------------------------------
+
+class QaulChatBubbleMessage {
+  const QaulChatBubbleMessage({
+    required this.content,
+    required this.sentAt,
+    required this.receivedAt,
+    required this.status,
+    required this.messageType,
+    required this.edges,
+  });
+
+  final String content;
+  final DateTime sentAt;
+  final DateTime receivedAt;
+  final MessageStatus status;
+  final MessageType messageType;
+  final List<TailEdge> edges;
+
+  QaulChatBubbleMessage copyWith({
+    String? content,
+    DateTime? sentAt,
+    DateTime? receivedAt,
+    MessageStatus? status,
+    MessageType? messageType,
+    List<TailEdge>? edges,
+  }) {
+    return QaulChatBubbleMessage(
+      content: content ?? this.content,
+      sentAt: sentAt ?? this.sentAt,
+      receivedAt: receivedAt ?? this.receivedAt,
+      status: status ?? this.status,
+      messageType: messageType ?? this.messageType,
+      edges: edges ?? this.edges,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Time label (pure: depends only on message + clock)
+// ---------------------------------------------------------------------------
+
+int _daysBetween(DateTime from, DateTime to) {
+  final fromDate = DateTime(from.year, from.month, from.day);
+  final toDate = DateTime(to.year, to.month, to.day);
+  return toDate.difference(fromDate).inDays;
+}
+
+/// Formats the timestamp line for a bubble. Same [message] and [clock]
+/// always produce the same string (no hidden [DateTime.now]).
+String formatQaulChatBubbleTime(QaulChatBubbleMessage message, DateTime clock) {
+  final isPrimary = message.messageType == MessageType.primary;
+  final baseTime = isPrimary ? message.sentAt : message.receivedAt;
+  final diffFromClock = clock.difference(baseTime);
+
+  String timeLabel;
+  if (diffFromClock.inMinutes < 1) {
+    timeLabel = 'Now';
+  } else if (diffFromClock.inMinutes < 60) {
+    timeLabel = '${diffFromClock.inMinutes} min';
+  } else {
+    final h = baseTime.hour.toString().padLeft(2, '0');
+    final m = baseTime.minute.toString().padLeft(2, '0');
+    timeLabel = '$h:$m';
+  }
+
+  if (message.status != MessageStatus.read) return timeLabel;
+
+  final days = _daysBetween(message.sentAt, message.receivedAt);
+  if (days < 1) return timeLabel;
+
+  if (isPrimary) {
+    final dayText = days == 1 ? '1 day' : '$days days';
+    return '$timeLabel + $dayText';
+  } else {
+    final dayText = days == 1 ? '1 day ago' : '$days days ago';
+    return '$timeLabel $dayText';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// QaulChatBubble widget
+// ---------------------------------------------------------------------------
+
+class QaulChatBubble extends StatelessWidget {
+  const QaulChatBubble({
+    super.key,
+    required this.message,
+    required this.clock,
+    this.showTimestamp = true,
+  });
+
+  final QaulChatBubbleMessage message;
+
+  /// Reference instant for relative labels ("Now", "N min"). Pass a fixed
+  /// value in tests; in the app, typically [DateTime.now] at the call site.
+  final DateTime clock;
+
+  final bool showTimestamp;
+
+  Widget? _buildStatusIcon(Color textColor) {
+    switch (message.status) {
+      case MessageStatus.notSent:
+        return null;
+
+      case MessageStatus.sent:
+        return Icon(
+          Icons.check,
+          size: 14,
+          color: textColor.withValues(alpha: 0.8),
+        );
+
+      case MessageStatus.read:
+        return Icon(
+          Icons.done_all,
+          size: 14,
+          color: textColor.withValues(alpha: 0.9),
+        );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isPrimary = message.messageType == MessageType.primary;
+
+    final width = MediaQuery.sizeOf(context).width;
+    final isMobile = width < kChatBubbleWidthBreakpoint;
+    final maxBubbleWidth = isMobile
+        ? ChatBubbleStyle.maxBubbleWidthMobile
+        : ChatBubbleStyle.maxBubbleWidthExtended;
+    final maxTextWidth =
+        maxBubbleWidth - ChatBubbleStyle.horizontalPadding * 2;
+
+    final backgroundColor = isPrimary
+        ? ChatBubbleStyle.primaryColor
+        : ChatBubbleStyle.secondaryColor;
+
+    const textColor = Colors.white;
+
+    final edges = message.edges.toSet();
+
+    final borderRadius = BorderRadiusDirectional.only(
+      topStart: edges.contains(TailEdge.topStart)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+      topEnd: edges.contains(TailEdge.topEnd)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+      bottomStart: edges.contains(TailEdge.bottomStart)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+      bottomEnd: edges.contains(TailEdge.bottomEnd)
+          ? Radius.zero
+          : ChatBubbleStyle.radius,
+    );
+
+    final timeLabel = formatQaulChatBubbleTime(message, clock);
+    final statusIcon = _buildStatusIcon(textColor);
+
+    return Align(
+      alignment: isPrimary ? Alignment.centerRight : Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          minWidth: ChatBubbleStyle.minBubbleWidth,
+          maxWidth: maxBubbleWidth,
+        ),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: borderRadius,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: ChatBubbleStyle.horizontalPadding,
+              vertical: ChatBubbleStyle.verticalPadding,
+            ),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: maxTextWidth),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final content = message.content.trim();
+                  final messageSpan = TextSpan(
+                    style: ChatBubbleStyle.textStyle,
+                    text: content,
+                  );
+                  final gap = ChatBubbleStyle.gapBetweenTextAndDate;
+                  final timeLabelPainter = TextPainter(
+                    text: TextSpan(
+                      text: timeLabel,
+                      style: ChatBubbleStyle.timeStyle,
+                    ),
+                    textDirection: TextDirection.ltr,
+                  );
+                  timeLabelPainter.layout();
+                  var timeBlockWidth = timeLabelPainter.width +
+                      ChatBubbleStyle.gapBetweenTimeAndStatusIcon;
+                  if (isPrimary && statusIcon != null) {
+                    timeBlockWidth += 14.0;
+                  }
+                  final maxMessageWidth =
+                      (constraints.maxWidth - gap - timeBlockWidth)
+                          .clamp(0.0, double.infinity);
+
+                  final painter = TextPainter(
+                    text: messageSpan,
+                    textDirection: TextDirection.ltr,
+                  );
+                  painter.layout(maxWidth: maxMessageWidth);
+                  final lineHeight = ChatBubbleStyle.textStyle.fontSize! *
+                      (ChatBubbleStyle.textStyle.height ?? 1.2);
+                  final fitsOnOneLine = painter.height <= lineHeight * 1.1;
+
+                  final timeRow = Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(timeLabel, style: ChatBubbleStyle.timeStyle),
+                      const SizedBox(
+                          width:
+                              ChatBubbleStyle.gapBetweenTimeAndStatusIcon),
+                      if (isPrimary && statusIcon != null) statusIcon,
+                    ],
+                  );
+
+                  if (!showTimestamp) {
+                    return RichText(
+                      textAlign: TextAlign.left,
+                      textWidthBasis: TextWidthBasis.longestLine,
+                      text: messageSpan,
+                    );
+                  }
+
+                  if (fitsOnOneLine) {
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Flexible(
+                          child: RichText(
+                            textAlign: TextAlign.left,
+                            textWidthBasis: TextWidthBasis.longestLine,
+                            text: messageSpan,
+                          ),
+                        ),
+                        SizedBox(width: gap),
+                        timeRow,
+                      ],
+                    );
+                  }
+
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: isPrimary
+                        ? CrossAxisAlignment.end
+                        : CrossAxisAlignment.start,
+                    children: [
+                      RichText(
+                        textAlign: TextAlign.left,
+                        textWidthBasis: TextWidthBasis.longestLine,
+                        text: messageSpan,
+                      ),
+                      Padding(
+                        padding: EdgeInsets.only(top: gap),
+                        child: timeRow,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Display item & layout constants
+// ---------------------------------------------------------------------------
+
+const double kChatBubbleLinkedGap = 4.0;
+const double kChatBubbleSeparatedGap = 12.0;
+
+class QaulChatBubbleDisplayItem {
+  const QaulChatBubbleDisplayItem({
+    required this.message,
+    required this.showTimestamp,
+    required this.marginTop,
+  });
+
+  final QaulChatBubbleMessage message;
+  final bool showTimestamp;
+  final double marginTop;
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
+  if (a.messageType != b.messageType) return false;
+
+  final ta = a.sentAt;
+  final tb = b.sentAt;
+
+  return ta.year == tb.year &&
+      ta.month == tb.month &&
+      ta.day == tb.day &&
+      ta.hour == tb.hour &&
+      ta.minute == tb.minute;
+}
+
+List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
+  List<QaulChatBubbleMessage> messages,
+) {
+  if (messages.isEmpty) return [];
+
+  final result = <QaulChatBubbleDisplayItem>[];
+
+  for (var i = 0; i < messages.length; i++) {
+    final prev = i > 0 ? messages[i - 1] : null;
+    final curr = messages[i];
+    final next = i < messages.length - 1 ? messages[i + 1] : null;
+
+    final prevLinked = prev != null && isChatBubbleLinked(prev, curr);
+    final nextLinked = next != null && isChatBubbleLinked(curr, next);
+
+    final isPrimary = curr.messageType == MessageType.primary;
+
+    final edges = isPrimary
+        ? _edgesForPrimary(prevLinked, nextLinked)
+        : _edgesForSecondary(prevLinked, nextLinked);
+
+    final showTimestamp = !nextLinked;
+
+    final marginTop = i == 0
+        ? 0.0
+        : (prevLinked ? kChatBubbleLinkedGap : kChatBubbleSeparatedGap);
+
+    result.add(
+      QaulChatBubbleDisplayItem(
+        message: curr.copyWith(edges: edges),
+        showTimestamp: showTimestamp,
+        marginTop: marginTop,
+      ),
+    );
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+List<TailEdge> _edgesForPrimary(bool hasPreviousLinked, bool hasNextLinked) {
+  if (!hasPreviousLinked && !hasNextLinked) return const [TailEdge.bottomEnd];
+
+  if (hasPreviousLinked && hasNextLinked) {
+    return const [TailEdge.topEnd, TailEdge.bottomEnd];
+  }
+
+  if (!hasPreviousLinked && hasNextLinked) return const [TailEdge.bottomEnd];
+
+  return const [TailEdge.topEnd];
+}
+
+List<TailEdge> _edgesForSecondary(bool hasPreviousLinked, bool hasNextLinked) {
+  if (!hasPreviousLinked && !hasNextLinked) {
+    return const [TailEdge.bottomStart];
+  }
+
+  if (hasPreviousLinked && hasNextLinked) {
+    return const [TailEdge.topStart, TailEdge.bottomStart];
+  }
+
+  if (!hasPreviousLinked && hasNextLinked) {
+    return const [TailEdge.bottomStart];
+  }
+
+  return const [TailEdge.topStart];
+}

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+Finder _findTimestampText(WidgetTester tester) {
+  return find.byWidgetPredicate(
+    (w) =>
+        w is Text &&
+        (w.data == null ||
+            w.data!.contains('min') ||
+            w.data!.contains(':') ||
+            w.data!.contains('Now') ||
+            w.data!.contains('day')),
+  );
+}
+
+void main() {
+  group('computeChatBubbleDisplayItems', () {
+    test('links messages from same sender and same minute', () {
+      final base = DateTime(2026, 4, 19, 19, 23);
+
+      final messages = [
+        QaulChatBubbleMessage(
+          content: 'first',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'middle',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'last',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+      ];
+
+      final items = computeChatBubbleDisplayItems(messages);
+      expect(items, hasLength(3));
+
+      expect(items[0].message.edges, const [TailEdge.bottomEnd]);
+      expect(items[1].message.edges,
+          const [TailEdge.topEnd, TailEdge.bottomEnd]);
+      expect(items[2].message.edges, const [TailEdge.topEnd]);
+
+      expect(items[0].showTimestamp, isFalse);
+      expect(items[1].showTimestamp, isFalse);
+      expect(items[2].showTimestamp, isTrue);
+
+      expect(items[0].marginTop, 0.0);
+      expect(items[1].marginTop, kChatBubbleLinkedGap);
+      expect(items[2].marginTop, kChatBubbleLinkedGap);
+    });
+
+    test('does not link messages from different sender or minute', () {
+      final base = DateTime(2026, 4, 19, 19, 23);
+
+      final messages = [
+        QaulChatBubbleMessage(
+          content: 'primary',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'primary later',
+          sentAt: base.add(const Duration(minutes: 1)),
+          receivedAt: base.add(const Duration(minutes: 1)),
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'secondary same minute as second',
+          sentAt: base.add(const Duration(minutes: 1)),
+          receivedAt: base.add(const Duration(minutes: 1)),
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
+        ),
+      ];
+
+      final items = computeChatBubbleDisplayItems(messages);
+      expect(items, hasLength(3));
+
+      expect(items[0].message.edges, const [TailEdge.bottomEnd]);
+      expect(items[1].message.edges, const [TailEdge.bottomEnd]);
+      expect(items[2].message.edges, const [TailEdge.bottomStart]);
+
+      expect(items[0].showTimestamp, isTrue);
+      expect(items[1].showTimestamp, isTrue);
+      expect(items[2].showTimestamp, isTrue);
+
+      expect(items[0].marginTop, 0.0);
+      expect(items[1].marginTop, kChatBubbleSeparatedGap);
+      expect(items[2].marginTop, kChatBubbleSeparatedGap);
+    });
+  });
+
+  group('formatQaulChatBubbleTime', () {
+    test('relative minutes uses clock, not wall time', () {
+      final clock = DateTime(2026, 6, 1, 12, 0);
+      final sent = clock.subtract(const Duration(minutes: 5));
+      final m = QaulChatBubbleMessage(
+        content: 'x',
+        sentAt: sent,
+        receivedAt: sent,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+      expect(formatQaulChatBubbleTime(m, clock), '5 min');
+    });
+  });
+
+  group('QaulChatBubble timestamp formatting', () {
+    testWidgets('shows minutes when sent less than an hour before clock',
+        (tester) async {
+      final clock = DateTime(2026, 6, 1, 12, 0);
+      final fiveMinutesAgo = clock.subtract(const Duration(minutes: 5));
+
+      final message = QaulChatBubbleMessage(
+        content: 'recent message',
+        sentAt: fiveMinutesAgo,
+        receivedAt: fiveMinutesAgo,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('5 min'), findsOneWidget);
+    });
+
+    testWidgets('shows absolute time when sent more than an hour before clock',
+        (tester) async {
+      final clock = DateTime(2026, 6, 1, 12, 0);
+      final ninetyMinutesAgo = clock.subtract(const Duration(minutes: 90));
+
+      final message = QaulChatBubbleMessage(
+        content: 'older message',
+        sentAt: ninetyMinutesAgo,
+        receivedAt: ninetyMinutesAgo,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText =
+          tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('min'), isFalse);
+      expect(label.contains(':'), isTrue);
+    });
+
+    testWidgets(
+        'sender (primary) read message shows sent time + days when received later',
+        (tester) async {
+      final clock = DateTime(2026, 4, 21, 16, 0);
+      final sentAt = DateTime(2026, 4, 19, 14, 50);
+      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sentAt,
+        receivedAt: receivedAt,
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText =
+          tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('+ 1 day'), isTrue);
+    });
+
+    testWidgets(
+        'receiver (secondary) read message shows received time + days ago',
+        (tester) async {
+      final clock = DateTime(2026, 4, 21, 16, 0);
+      final sentAt = DateTime(2026, 4, 19, 14, 50);
+      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sentAt,
+        receivedAt: receivedAt,
+        status: MessageStatus.read,
+        messageType: MessageType.secondary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText =
+          tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('1 day ago'), isTrue);
+    });
+
+    testWidgets('read message same day has no days suffix', (tester) async {
+      final clock = DateTime(2026, 4, 19, 18, 0);
+      final sameDay = DateTime(2026, 4, 19, 14, 50);
+      final receivedSameDay = DateTime(2026, 4, 19, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sameDay,
+        receivedAt: receivedSameDay,
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText =
+          tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('+ '), isFalse);
+      expect(label.contains(' ago'), isFalse);
+    });
+
+    testWidgets('sent (not read) message has no days suffix', (tester) async {
+      final clock = DateTime(2026, 4, 21, 16, 0);
+      final sentAt = DateTime(2026, 4, 19, 14, 50);
+      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+
+      final message = QaulChatBubbleMessage(
+        content: 'hello',
+        sentAt: sentAt,
+        receivedAt: receivedAt,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: true,
+            ),
+          ),
+        ),
+      );
+
+      final timestampText =
+          tester.widget<Text>(_findTimestampText(tester).first);
+      final label = timestampText.data ?? '';
+      expect(label.contains('+ 1 day'), isFalse);
+      expect(label.contains(' ago'), isFalse);
+    });
+  });
+
+  group('QaulChatBubble content', () {
+    testWidgets('preserves internal newlines (trim only)', (tester) async {
+      final clock = DateTime(2026, 1, 1, 12, 0);
+      final message = QaulChatBubbleMessage(
+        content: '  line one\nline two  ',
+        sentAt: clock,
+        receivedAt: clock,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: QaulChatBubble(
+              message: message,
+              clock: clock,
+              showTimestamp: false,
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText).first);
+      final text = rich.text.toPlainText();
+      expect(text, 'line one\nline two');
+    });
+  });
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -12,6 +12,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:qaul_components_widgetbook/use_cases/qaul_color_sheet.dart'
     as _qaul_components_widgetbook_use_cases_qaul_color_sheet;
+import 'package:qaul_components_widgetbook/use_cases/qaul_chat_bubble.dart'
+    as _qaul_components_widgetbook_use_cases_qaul_chat_bubble;
 import 'package:qaul_components_widgetbook/use_cases/qaul_fab.dart'
     as _qaul_components_widgetbook_use_cases_qaul_fab;
 import 'package:qaul_components_widgetbook/use_cases/qaul_navbar.dart'
@@ -37,6 +39,16 @@ final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
     name: 'widgets',
     children: [
+      _widgetbook.WidgetbookComponent(
+        name: 'QaulChatBubble',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Conversation preview',
+            builder: _qaul_components_widgetbook_use_cases_qaul_chat_bubble
+                .buildChatBubbleConversationUseCase,
+          ),
+        ],
+      ),
       _widgetbook.WidgetbookComponent(
         name: 'QaulFAB',
         useCases: [

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+final _previewClock = DateTime(2026, 4, 12, 14, 30);
+
+@widgetbook.UseCase(name: 'Conversation preview', type: QaulChatBubble)
+Widget buildChatBubbleConversationUseCase(BuildContext context) {
+  const dateLabels = ['Friday, April 11, 2026 ', 'Saturday, April 12, 2026 '];
+
+  final clock = _previewClock;
+  final today = DateTime(clock.year, clock.month, clock.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+
+  final rawMessages = [
+    QaulChatBubbleMessage(
+      content: 'Hello in 16px 300 font',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content:
+          'This is a longer message with no own timestamp followed by another message with timestamp',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.sent,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'This one is it',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Chatpartner is answering',
+      sentAt: yesterday.copyWith(hour: 18, minute: 9),
+      receivedAt: yesterday.copyWith(hour: 18, minute: 9),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Another answer',
+      sentAt: yesterday.copyWith(hour: 18, minute: 29),
+      receivedAt: yesterday.copyWith(hour: 18, minute: 29),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Message',
+      sentAt: yesterday.copyWith(hour: 19, minute: 23),
+      receivedAt: yesterday.copyWith(hour: 19, minute: 23),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Longer message from the chatpartner',
+      sentAt: yesterday.copyWith(hour: 21, minute: 19),
+      receivedAt: yesterday.copyWith(hour: 21, minute: 19),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'followed by one with time',
+      sentAt: yesterday.copyWith(hour: 21, minute: 19),
+      receivedAt: yesterday.copyWith(hour: 21, minute: 19),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Message with delay',
+      sentAt: today
+          .subtract(const Duration(days: 4))
+          .copyWith(hour: 12, minute: 14),
+      receivedAt: today.copyWith(hour: 12, minute: 30),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Out and delivered',
+      sentAt: clock.subtract(const Duration(minutes: 12)),
+      receivedAt: clock.subtract(const Duration(minutes: 12)),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'Out but not delivered yet',
+      sentAt: clock.subtract(const Duration(minutes: 1)),
+      receivedAt: clock.subtract(const Duration(minutes: 1)),
+      status: MessageStatus.sent,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+    QaulChatBubbleMessage(
+      content: 'New Message not out',
+      sentAt: clock,
+      receivedAt: clock,
+      status: MessageStatus.notSent,
+      messageType: MessageType.primary,
+      edges: const [],
+    ),
+  ];
+
+  final items = computeChatBubbleDisplayItems(rawMessages);
+
+  var dateLabelIndex = 0;
+  final children = <Widget>[
+    const SizedBox(height: 16),
+  ];
+
+  for (final item in items) {
+    var addedSeparator = false;
+    if (dateLabelIndex == 0) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 16.5),
+          child: Center(
+            child: Text(
+              dateLabels[dateLabelIndex++],
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.2,
+                color: Colors.white.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ),
+      );
+      addedSeparator = true;
+    } else if (item.message.content == 'Out and delivered' &&
+        dateLabelIndex == 1) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 16.5),
+          child: Center(
+            child: Text(
+              dateLabels[dateLabelIndex++],
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.2,
+                color: Colors.white.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ),
+      );
+      addedSeparator = true;
+    }
+
+    children.add(
+      Padding(
+        padding: EdgeInsets.only(top: addedSeparator ? 0 : item.marginTop),
+        child: QaulChatBubble(
+          message: item.message,
+          clock: clock,
+          showTimestamp: item.showTimestamp,
+        ),
+      ),
+    );
+  }
+
+  return Container(
+    color: Colors.black,
+    padding: const EdgeInsets.all(16),
+    child: Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 500),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: children,
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Description
This PR brings the chat bubble redesign onto the current main branch and wires it into the chat screen. After the navbar redesign and related main changes (file history, stores, PaginatedData providers), the bubble UI and its layout logic were re-integrated so that text messages use the new bubbles, timestamps, and linking behaviour.

## Evidence 
<img width="1190" height="838" alt="Screenshot 2026-03-15 at 21 27 04" src="https://github.com/user-attachments/assets/3bed6ed0-455e-4222-9722-c9242345acd0" />

<img width="1277" height="678" alt="Screenshot 2026-03-15 at 21 27 44" src="https://github.com/user-attachments/assets/7addb92b-335d-4c8c-a8e9-f30c7254994f" />
