### PR TITLE
UI Redesign Chat Room

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -4,3 +4,4 @@ export 'widgets/qaul_chat_bubble.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_loading_indicator.dart';
 export 'widgets/qaul_navbar.dart';
+export 'widgets/room_meta_message.dart';

--- a/qaul_ui/packages/qaul_components/lib/widgets/chat_message.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/chat_message.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/widgets.dart';
+
+/// Union supertype for all messages that can be rendered in [ChatRoom].
+abstract class ChatMessage extends StatelessWidget {
+  const ChatMessage({super.key});
+}

--- a/qaul_ui/packages/qaul_components/lib/widgets/chat_room.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/chat_room.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import 'chat_message.dart';
+import 'qaul_chat_bubble.dart';
+
+class ChatRoom extends StatelessWidget {
+  const ChatRoom({
+    super.key,
+    required this.messages,
+    this.clock,
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  final List<ChatMessage> messages;
+  final DateTime? clock;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final children = <Widget>[];
+    var first = true;
+    var pendingBubbleRun = <QaulChatBubbleMessage>[];
+
+    void flushBubbleRun() {
+      if (pendingBubbleRun.isEmpty) return;
+
+      final displayItems = computeChatBubbleDisplayItems(pendingBubbleRun);
+      for (final item in displayItems) {
+        children.add(
+          Padding(
+            padding: EdgeInsets.only(top: first ? 0 : item.marginTop),
+            child: QaulChatBubble(
+              message: item.message,
+              clock: clock ?? DateTime.now(),
+              showTimestamp: item.showTimestamp,
+            ),
+          ),
+        );
+        first = false;
+      }
+
+      pendingBubbleRun = <QaulChatBubbleMessage>[];
+    }
+
+    for (final message in messages) {
+      if (message is QaulChatBubbleMessage) {
+        pendingBubbleRun.add(message);
+        continue;
+      }
+
+      flushBubbleRun();
+      children.add(
+        Padding(
+          padding: EdgeInsets.only(top: first ? 0 : kChatBubbleSeparatedGap),
+          child: message,
+        ),
+      );
+      first = false;
+    }
+
+    flushBubbleRun();
+
+    return Padding(
+      padding: padding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:qaul_components/widgets/chat_message.dart';
+
+import 'chat_message.dart';
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -257,7 +258,7 @@ class QaulChatBubble extends StatelessWidget {
                     style: ChatBubbleStyle.textStyle,
                     text: content,
                   );
-                  final gap = ChatBubbleStyle.gapBetweenTextAndDate;
+                  const gap = ChatBubbleStyle.gapBetweenTextAndDate;
                   final timeLabelPainter = TextPainter(
                     text: TextSpan(
                       text: timeLabel,
@@ -320,7 +321,7 @@ class QaulChatBubble extends StatelessWidget {
                             text: messageSpan,
                           ),
                         ),
-                        SizedBox(width: gap),
+                        const SizedBox(width: gap),
                         timeRow,
                       ],
                     );
@@ -338,7 +339,7 @@ class QaulChatBubble extends StatelessWidget {
                         text: messageSpan,
                       ),
                       Padding(
-                        padding: EdgeInsets.only(top: gap),
+                        padding: const EdgeInsets.only(top: gap),
                         child: timeRow,
                       ),
                     ],

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:qaul_components/widgets/chat_message.dart';
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -54,14 +55,17 @@ class ChatBubbleStyle {
 // QaulChatBubbleMessage
 // ---------------------------------------------------------------------------
 
-class QaulChatBubbleMessage {
+class QaulChatBubbleMessage extends ChatMessage {
   const QaulChatBubbleMessage({
+    super.key,
     required this.content,
     required this.sentAt,
     required this.receivedAt,
     required this.status,
     required this.messageType,
     required this.edges,
+    this.clock,
+    this.showTimestamp = true,
   });
 
   final String content;
@@ -70,22 +74,39 @@ class QaulChatBubbleMessage {
   final MessageStatus status;
   final MessageType messageType;
   final List<TailEdge> edges;
+  final DateTime? clock;
+  final bool showTimestamp;
 
   QaulChatBubbleMessage copyWith({
+    Key? key,
     String? content,
     DateTime? sentAt,
     DateTime? receivedAt,
     MessageStatus? status,
     MessageType? messageType,
     List<TailEdge>? edges,
+    DateTime? clock,
+    bool? showTimestamp,
   }) {
     return QaulChatBubbleMessage(
+      key: key ?? this.key,
       content: content ?? this.content,
       sentAt: sentAt ?? this.sentAt,
       receivedAt: receivedAt ?? this.receivedAt,
       status: status ?? this.status,
       messageType: messageType ?? this.messageType,
       edges: edges ?? this.edges,
+      clock: clock ?? this.clock,
+      showTimestamp: showTimestamp ?? this.showTimestamp,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return QaulChatBubble(
+      message: this,
+      clock: clock ?? DateTime.now(),
+      showTimestamp: showTimestamp,
     );
   }
 }
@@ -182,8 +203,7 @@ class QaulChatBubble extends StatelessWidget {
     final maxBubbleWidth = isMobile
         ? ChatBubbleStyle.maxBubbleWidthMobile
         : ChatBubbleStyle.maxBubbleWidthExtended;
-    final maxTextWidth =
-        maxBubbleWidth - ChatBubbleStyle.horizontalPadding * 2;
+    final maxTextWidth = maxBubbleWidth - ChatBubbleStyle.horizontalPadding * 2;
 
     final backgroundColor = isPrimary
         ? ChatBubbleStyle.primaryColor
@@ -246,21 +266,25 @@ class QaulChatBubble extends StatelessWidget {
                     textDirection: TextDirection.ltr,
                   );
                   timeLabelPainter.layout();
-                  var timeBlockWidth = timeLabelPainter.width +
+                  var timeBlockWidth =
+                      timeLabelPainter.width +
                       ChatBubbleStyle.gapBetweenTimeAndStatusIcon;
                   if (isPrimary && statusIcon != null) {
                     timeBlockWidth += 14.0;
                   }
                   final maxMessageWidth =
-                      (constraints.maxWidth - gap - timeBlockWidth)
-                          .clamp(0.0, double.infinity);
+                      (constraints.maxWidth - gap - timeBlockWidth).clamp(
+                        0.0,
+                        double.infinity,
+                      );
 
                   final painter = TextPainter(
                     text: messageSpan,
                     textDirection: TextDirection.ltr,
                   );
                   painter.layout(maxWidth: maxMessageWidth);
-                  final lineHeight = ChatBubbleStyle.textStyle.fontSize! *
+                  final lineHeight =
+                      ChatBubbleStyle.textStyle.fontSize! *
                       (ChatBubbleStyle.textStyle.height ?? 1.2);
                   final fitsOnOneLine = painter.height <= lineHeight * 1.1;
 
@@ -270,8 +294,8 @@ class QaulChatBubble extends StatelessWidget {
                     children: [
                       Text(timeLabel, style: ChatBubbleStyle.timeStyle),
                       const SizedBox(
-                          width:
-                              ChatBubbleStyle.gapBetweenTimeAndStatusIcon),
+                        width: ChatBubbleStyle.gapBetweenTimeAndStatusIcon,
+                      ),
                       if (isPrimary && statusIcon != null) statusIcon,
                     ],
                   );

--- a/qaul_ui/packages/qaul_components/lib/widgets/room_meta_message.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/room_meta_message.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import 'chat_message.dart';
+
+class RoomMetaMessage extends ChatMessage {
+  const RoomMetaMessage._({super.key, required this.label});
+
+  final String label;
+
+  factory RoomMetaMessage.date({Key? key, required DateTime date}) {
+    return RoomMetaMessage._(key: key, label: _formatDateLabel(date));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        label,
+        style: const TextStyle(fontSize: 12, height: 1.2, color: Colors.grey),
+      ),
+    );
+  }
+}
+
+const _weekdays = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+const _months = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+String _formatDateLabel(DateTime date) {
+  final weekday = _weekdays[date.weekday - 1];
+  final month = _months[date.month - 1];
+  return '$weekday, $month ${date.day}, ${date.year}';
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -69,14 +69,9 @@ final directories = <_widgetbook.WidgetbookNode>[
         name: 'ChatRoom',
         useCases: [
           _widgetbook.WidgetbookUseCase(
-            name: 'Landscape',
+            name: 'Preview',
             builder: _qaul_components_widgetbook_use_cases_chat_room
-                .buildChatRoomLandscapeUseCase,
-          ),
-          _widgetbook.WidgetbookUseCase(
-            name: 'Portrait',
-            builder: _qaul_components_widgetbook_use_cases_chat_room
-                .buildChatRoomPortraitUseCase,
+                .buildChatRoomPreviewUseCase,
           ),
         ],
       ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -12,14 +12,18 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:qaul_components_widgetbook/use_cases/chat_header.dart'
     as _qaul_components_widgetbook_use_cases_chat_header;
-import 'package:qaul_components_widgetbook/use_cases/qaul_color_sheet.dart'
-    as _qaul_components_widgetbook_use_cases_qaul_color_sheet;
+import 'package:qaul_components_widgetbook/use_cases/chat_room.dart'
+    as _qaul_components_widgetbook_use_cases_chat_room;
 import 'package:qaul_components_widgetbook/use_cases/qaul_chat_bubble.dart'
     as _qaul_components_widgetbook_use_cases_qaul_chat_bubble;
+import 'package:qaul_components_widgetbook/use_cases/qaul_color_sheet.dart'
+    as _qaul_components_widgetbook_use_cases_qaul_color_sheet;
 import 'package:qaul_components_widgetbook/use_cases/qaul_fab.dart'
     as _qaul_components_widgetbook_use_cases_qaul_fab;
 import 'package:qaul_components_widgetbook/use_cases/qaul_navbar.dart'
     as _qaul_components_widgetbook_use_cases_qaul_navbar;
+import 'package:qaul_components_widgetbook/use_cases/room_meta_message.dart'
+    as _qaul_components_widgetbook_use_cases_room_meta_message;
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
 
 final directories = <_widgetbook.WidgetbookNode>[
@@ -62,6 +66,21 @@ final directories = <_widgetbook.WidgetbookNode>[
         ],
       ),
       _widgetbook.WidgetbookComponent(
+        name: 'ChatRoom',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Landscape',
+            builder: _qaul_components_widgetbook_use_cases_chat_room
+                .buildChatRoomLandscapeUseCase,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Portrait',
+            builder: _qaul_components_widgetbook_use_cases_chat_room
+                .buildChatRoomPortraitUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
         name: 'QaulChatBubble',
         useCases: [
           _widgetbook.WidgetbookUseCase(
@@ -98,6 +117,16 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Vertical (tablet/desktop)',
             builder: _qaul_components_widgetbook_use_cases_qaul_navbar
                 .buildNavBarVerticalUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'RoomMetaMessage',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Date',
+            builder: _qaul_components_widgetbook_use_cases_room_meta_message
+                .buildRoomMetaMessageDateUseCase,
           ),
         ],
       ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/chat_room.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/chat_room.dart
@@ -9,7 +9,7 @@ final _previewClock = DateTime(2026, 4, 12, 14, 30);
 /// Date headers in Widgetbook only: vertical space above/below so they clear
 /// nearby bubble timestamps (app spacing unchanged).
 class _WidgetbookPaddedDateMeta extends ChatMessage {
-  const _WidgetbookPaddedDateMeta({super.key, required this.date});
+  const _WidgetbookPaddedDateMeta({required this.date});
 
   final DateTime date;
 
@@ -124,27 +124,13 @@ List<ChatMessage> _buildPreviewMessages() {
   ];
 }
 
-Widget _buildScaffoldedRoom({required double maxWidth}) {
+@widgetbook.UseCase(name: 'Preview', type: ChatRoom)
+Widget buildChatRoomPreviewUseCase(BuildContext context) {
   return Container(
     color: Colors.black,
-    child: Center(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: maxWidth),
-        child: ChatRoom(
-          messages: _buildPreviewMessages(),
-          clock: _previewClock,
-        ),
-      ),
+    child: ChatRoom(
+      messages: _buildPreviewMessages(),
+      clock: _previewClock,
     ),
   );
-}
-
-@widgetbook.UseCase(name: 'Portrait', type: ChatRoom)
-Widget buildChatRoomPortraitUseCase(BuildContext context) {
-  return _buildScaffoldedRoom(maxWidth: 402);
-}
-
-@widgetbook.UseCase(name: 'Landscape', type: ChatRoom)
-Widget buildChatRoomLandscapeUseCase(BuildContext context) {
-  return _buildScaffoldedRoom(maxWidth: 900);
 }

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/chat_room.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/chat_room.dart
@@ -1,18 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:qaul_components/qaul_components.dart';
+import 'package:qaul_components/widgets/chat_message.dart';
+import 'package:qaul_components/widgets/chat_room.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 final _previewClock = DateTime(2026, 4, 12, 14, 30);
 
-@widgetbook.UseCase(name: 'Conversation preview', type: QaulChatBubble)
-Widget buildChatBubbleConversationUseCase(BuildContext context) {
-  const dateLabels = ['Friday, April 11, 2026 ', 'Saturday, April 12, 2026 '];
+/// Date headers in Widgetbook only: vertical space above/below so they clear
+/// nearby bubble timestamps (app spacing unchanged).
+class _WidgetbookPaddedDateMeta extends ChatMessage {
+  const _WidgetbookPaddedDateMeta({super.key, required this.date});
 
+  final DateTime date;
+
+  static const _padding = EdgeInsets.symmetric(vertical: 16);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: _padding,
+      child: RoomMetaMessage.date(date: date),
+    );
+  }
+}
+
+List<ChatMessage> _buildPreviewMessages() {
   final clock = _previewClock;
   final today = DateTime(clock.year, clock.month, clock.day);
   final yesterday = today.subtract(const Duration(days: 1));
 
-  final rawMessages = [
+  return [
+    _WidgetbookPaddedDateMeta(date: yesterday),
     QaulChatBubbleMessage(
       content: 'Hello in 16px 300 font',
       sentAt: yesterday.copyWith(hour: 16, minute: 13),
@@ -78,16 +96,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       messageType: MessageType.secondary,
       edges: const [],
     ),
-    QaulChatBubbleMessage(
-      content: 'Message with delay',
-      sentAt: today
-          .subtract(const Duration(days: 4))
-          .copyWith(hour: 12, minute: 14),
-      receivedAt: today.copyWith(hour: 12, minute: 30),
-      status: MessageStatus.read,
-      messageType: MessageType.primary,
-      edges: const [],
-    ),
+    _WidgetbookPaddedDateMeta(date: today),
     QaulChatBubbleMessage(
       content: 'Out and delivered',
       sentAt: clock.subtract(const Duration(minutes: 12)),
@@ -113,76 +122,29 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       edges: const [],
     ),
   ];
+}
 
-  final items = computeChatBubbleDisplayItems(rawMessages);
-
-  var dateLabelIndex = 0;
-  final children = <Widget>[
-    const SizedBox(height: 16),
-  ];
-
-  for (final item in items) {
-    var addedSeparator = false;
-    if (dateLabelIndex == 0) {
-      children.add(
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Center(
-            child: Text(
-              dateLabels[dateLabelIndex++],
-              style: TextStyle(
-                fontSize: 12,
-                height: 1.2,
-                color: Colors.white.withValues(alpha: 0.7),
-              ),
-            ),
-          ),
-        ),
-      );
-      addedSeparator = true;
-    } else if (item.message.content == 'Out and delivered' &&
-        dateLabelIndex == 1) {
-      children.add(
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Center(
-            child: Text(
-              dateLabels[dateLabelIndex++],
-              style: TextStyle(
-                fontSize: 12,
-                height: 1.2,
-                color: Colors.white.withValues(alpha: 0.7),
-              ),
-            ),
-          ),
-        ),
-      );
-      addedSeparator = true;
-    }
-
-    children.add(
-      Padding(
-        padding: EdgeInsets.only(top: addedSeparator ? 0 : item.marginTop),
-        child: QaulChatBubble(
-          message: item.message,
-          clock: clock,
-          showTimestamp: item.showTimestamp,
-        ),
-      ),
-    );
-  }
-
+Widget _buildScaffoldedRoom({required double maxWidth}) {
   return Container(
     color: Colors.black,
-    padding: const EdgeInsets.all(16),
     child: Center(
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 500),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: children,
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: ChatRoom(
+          messages: _buildPreviewMessages(),
+          clock: _previewClock,
         ),
       ),
     ),
   );
+}
+
+@widgetbook.UseCase(name: 'Portrait', type: ChatRoom)
+Widget buildChatRoomPortraitUseCase(BuildContext context) {
+  return _buildScaffoldedRoom(maxWidth: 402);
+}
+
+@widgetbook.UseCase(name: 'Landscape', type: ChatRoom)
+Widget buildChatRoomLandscapeUseCase(BuildContext context) {
+  return _buildScaffoldedRoom(maxWidth: 900);
 }

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/room_meta_message.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/room_meta_message.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(name: 'Date', type: RoomMetaMessage)
+Widget buildRoomMetaMessageDateUseCase(BuildContext context) {
+  return Container(
+    color: Colors.black,
+    alignment: Alignment.center,
+    child: Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: RoomMetaMessage.date(date: DateTime(2026, 4, 12)),
+    ),
+  );
+}


### PR DESCRIPTION
## Description

Introduced ChatMessage as the shared supertype in qaul_components, with QaulChatBubbleMessage and RoomMetaMessage (date factory for day headers). ChatRoom takes a messages list, flushes consecutive bubbles through computeChatBubbleDisplayItems for same-minute grouping and timestamp rules, and inserts meta rows between runs. Widgetbook covers RoomMetaMessage (date) and ChatRoom in portrait and landscape; the chat preview uses a small padded wrapper around date headers for clarity in Widgetbook only.

## Note

Compared to the original PR sketch: the supertype is an abstract class instead of sealed (avoids forcing every subtype into one library), the factory is RoomMetaMessage.date per Dart style.

The dedicated Landscape ChatRoom preview was removed from Widgetbook. In practice, it did not provide a reliable orientation simulation across viewport presets and created misleading scaling/constraint behavior.