### PR TITLE
Implement Chat Group Names

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -55,6 +55,9 @@ part 'image_message_widget.dart';
 
 typedef OnSendPressed = void Function(String rawText);
 
+ChatRenderMode resolveChatRenderMode(ChatRoom room) =>
+    room.isGroupChatRoom ? ChatRenderMode.group : ChatRenderMode.direct;
+
 const _kChatRouteName = '/chat';
 
 Future<void> openChat(
@@ -176,7 +179,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   User? get otherUser => widget.otherUser;
 
   User? _directChatPeer(ChatRoom forRoom) {
-    if (forRoom.isGroupChatRoom) return null;
+    if (resolveChatRenderMode(forRoom) == ChatRenderMode.group) return null;
     if (otherUser != null) return otherUser;
     return ref
         .read(usersStoreProvider.notifier)
@@ -184,7 +187,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   final Map<String, String> _overflowMenuOptions = {};
-  Map<String, QaulChatBubbleDisplayItem> _bubbleDisplayItems = {};
+  Map<String, MessagePresentation> _messagePresentations = {};
+  ChatRenderMode _chatRenderMode = ChatRenderMode.direct;
 
   void _handleClick(String value) {
     switch (value) {
@@ -216,6 +220,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _chatRenderMode = resolveChatRenderMode(room);
     _updateMenuOptionsBasedOnRoomType();
   }
 
@@ -223,6 +228,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   void didUpdateWidget(covariant ChatScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.room == room) return;
+    _chatRenderMode = resolveChatRenderMode(room);
     _updateMenuOptionsBasedOnRoomType();
     _scheduleUpdateCurrentOpenChat();
   }
@@ -260,6 +266,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     final l10n = AppLocalizations.of(context)!;
     final directPeer = _directChatPeer(room);
+    _chatRenderMode = resolveChatRenderMode(room);
+
     return Scaffold(
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
@@ -267,7 +275,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         title: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            (room.isGroupChatRoom)
+            (_chatRenderMode == ChatRenderMode.group)
                 ? QaulAvatar.groupSmall()
                 : QaulAvatar.small(user: directPeer),
             const SizedBox(width: 12),
@@ -306,12 +314,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           bottom: false,
           child: Chat(
           showUserAvatars: false,
-          showUserNames: room.isGroupChatRoom,
+          showUserNames: false,
           user: user.toInternalUser(),
           useTopSafeAreaInset: false,
           dateHeaderThreshold: const Duration(days: 365).inMilliseconds,
           groupMessagesThreshold: const Duration(days: 365).inMilliseconds,
-          messages: messages(room, l10n: l10n) ?? [],
+          messages: messages(
+                room,
+                l10n: l10n,
+                renderMode: _chatRenderMode,
+              ) ??
+              [],
           onSendPressed: sendMessage,
           inputOptions: const InputOptions(
             sendButtonVisibilityMode: SendButtonVisibilityMode.always,
@@ -331,7 +344,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 ? null
                 : 'Please wait for the admin to confirm your acceptance to send messages',
             sendButtonVisibilityMode: SendButtonVisibilityMode.editing,
-            hintText: room.isGroupChatRoom
+            hintText: _chatRenderMode == ChatRenderMode.group
                 ? l10n.groupChatMessageHint
                 : l10n.securePrivateMessageHint,
             onSendPressed: sendMessage,
@@ -483,23 +496,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           },
           textMessageBuilder:
               (message, {required int messageWidth, required bool showName}) {
-                final msgIdx = room.messages!.indexWhere(
-                  (element) => element.messageIdBase58 == message.id,
-                );
-
-                var prevMsgWasFromSamePerson = false;
-                if (msgIdx > 0) {
-                  final prevMsg = room.messages![msgIdx - 1];
-                  prevMsgWasFromSamePerson =
-                      prevMsg.content is TextMessageContent &&
-                      prevMsg.senderIdBase58 == message.author.id;
-                }
-
                 return TextMessage(
                   message: message,
                   usePreviewData: true,
                   hideBackgroundOnEmojiMessages: true,
-                  showName: showName && !prevMsgWasFromSamePerson,
+                  showName: false,
                   emojiEnlargementBehavior: EmojiEnlargementBehavior.multi,
                   nameBuilder: (usr) {
                     var user = room.members.firstWhereOrNull(
@@ -587,6 +588,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   List<types.Message>? messages(
     ChatRoom room, {
     required AppLocalizations l10n,
+    required ChatRenderMode renderMode,
   }) {
     final domainMessages = room.messages?.sorted();
     if (domainMessages == null) return null;
@@ -639,6 +641,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   : MessageStatus.notSent),
           messageType: isMe ? MessageType.primary : MessageType.secondary,
           edges: const [],
+          senderIdBase58: m.senderIdBase58,
         ),
       );
       bubbleIds.add(m.messageIdBase58);
@@ -649,7 +652,44 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     for (var i = 0; i < bubbleIds.length; i++) {
       map[bubbleIds[i]] = displayItems[i];
     }
-    _bubbleDisplayItems = map;
+    final ordered = [...domainMessages]..sort((a, b) => a.sentAt.compareTo(b.sentAt));
+    final presentations = <String, MessagePresentation>{};
+    for (var i = 0; i < ordered.length; i++) {
+      final m = ordered[i];
+      final isPrimary = m.senderId.equals(user.id);
+      final isGroupIncoming = renderMode == ChatRenderMode.group && !isPrimary;
+      final authorForGroup = isGroupIncoming ? _author(m, l10n) : null;
+      final groupSender = authorForGroup == null
+          ? null
+          : QaulGroupMessageSender(
+              idBase58: authorForGroup.idBase58,
+              name: authorForGroup.name,
+              isConnected: authorForGroup.isConnected,
+            );
+      final prev = i > 0 ? ordered[i - 1] : null;
+      final next = i < ordered.length - 1 ? ordered[i + 1] : null;
+      final prevSameSender = prev != null && prev.senderIdBase58 == m.senderIdBase58;
+      final nextSameSender = next != null && next.senderIdBase58 == m.senderIdBase58;
+
+      final textDisplay = map[m.messageIdBase58];
+      final incomingFlags = isGroupIncoming
+          ? GroupIncomingBubbleFlags.fromSequentialMessages(
+              textDisplay: textDisplay,
+              prevSameSender: prevSameSender,
+              nextSameSender: nextSameSender,
+            )
+          : null;
+
+      presentations[m.messageIdBase58] = MessagePresentation(
+        messageId: m.messageIdBase58,
+        isPrimary: isPrimary,
+        sender: groupSender,
+        showSenderName: incomingFlags?.showSenderName ?? false,
+        showSenderAvatar: incomingFlags?.showSenderAvatar ?? false,
+        bubbleDisplay: textDisplay,
+      );
+    }
+    _messagePresentations = presentations;
 
     return internalMessages;
   }
@@ -672,39 +712,31 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       );
     }
 
+    final presentation = _messagePresentations[message.id];
+    if (presentation == null) return child;
+
     if (message is types.TextMessage) {
-      final currentRoom = ref.read(currentOpenChatRoom);
-      final roomMessages = currentRoom?.messages;
-      if (roomMessages == null) return child;
-
-      final domainMessage = roomMessages
-          .firstWhereOrNull((m) => m.messageIdBase58 == message.id);
-      if (domainMessage == null) return child;
-
-      final display = _bubbleDisplayItems[domainMessage.messageIdBase58];
-      if (display == null) return child;
-
-      final clock = DateTime.now();
-      final isPrimary = display.message.messageType == MessageType.primary;
-
-      // Symmetric inset from screen edges (Notion / PR review): leading 16 for
-      // received bubbles, trailing 16 for sent (primary). RTL-safe.
-      return Padding(
-        padding: EdgeInsetsDirectional.only(
-          top: display.marginTop,
-          start: isPrimary ? 0 : 16,
-          end: isPrimary ? 16 : 0,
-        ),
-        child: QaulChatBubble(
-          message: display.message,
-          clock: clock,
-          showTimestamp: display.showTimestamp,
-        ),
+      return ChatMessageRenderer.renderText(
+        presentation: presentation,
+        mode: _chatRenderMode,
+        clock: DateTime.now(),
       );
     }
 
-    const radius = 20.0;
+    final legacyBubble = _buildLegacyBubble(child, message, nextMessageInGroup);
+    return ChatMessageRenderer.wrapNonText(
+      child: legacyBubble,
+      presentation: presentation,
+      mode: _chatRenderMode,
+    );
+  }
 
+  Widget _buildLegacyBubble(
+    Widget child,
+    types.Message message,
+    bool nextMessageInGroup,
+  ) {
+    const radius = 20.0;
     return Builder(
       builder: (context) {
         return Bubble(
@@ -743,10 +775,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   void _updateMenuOptionsBasedOnRoomType() {
     var l10n = AppLocalizations.of(context)!;
-    if (room.isGroupChatRoom && _overflowMenuOptions.isEmpty) {
+    if (_chatRenderMode == ChatRenderMode.group &&
+        _overflowMenuOptions.isEmpty) {
       _overflowMenuOptions.addAll({'groupSettings': l10n.groupSettings});
     }
-    if (room.isDirectChat && _overflowMenuOptions.isNotEmpty) {
+    if (_chatRenderMode == ChatRenderMode.direct &&
+        _overflowMenuOptions.isNotEmpty) {
       _overflowMenuOptions.clear();
     }
   }

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -58,6 +58,9 @@ typedef OnSendPressed = void Function(String rawText);
 ChatRenderMode resolveChatRenderMode(ChatRoom room) =>
     room.isGroupChatRoom ? ChatRenderMode.group : ChatRenderMode.direct;
 
+bool _sameLocalCalendarDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
+
 const _kChatRouteName = '/chat';
 
 Future<void> openChat(
@@ -647,7 +650,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       bubbleIds.add(m.messageIdBase58);
     }
 
-    final displayItems = computeChatBubbleDisplayItems(bubbleMessages);
+    final displayItems = computeChatBubbleDisplayItems(
+      bubbleMessages,
+      layoutMode: renderMode,
+    );
     final map = <String, QaulChatBubbleDisplayItem>{};
     for (var i = 0; i < bubbleIds.length; i++) {
       map[bubbleIds[i]] = displayItems[i];
@@ -670,6 +676,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       final next = i < ordered.length - 1 ? ordered[i + 1] : null;
       final prevSameSender = prev != null && prev.senderIdBase58 == m.senderIdBase58;
       final nextSameSender = next != null && next.senderIdBase58 == m.senderIdBase58;
+      final hasNextFromSameSenderOnSameCalendarDay = next != null &&
+          nextSameSender &&
+          _sameLocalCalendarDay(m.sentAt, next.sentAt);
 
       final textDisplay = map[m.messageIdBase58];
       final incomingFlags = isGroupIncoming
@@ -677,6 +686,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               textDisplay: textDisplay,
               prevSameSender: prevSameSender,
               nextSameSender: nextSameSender,
+              hasNextFromSameSenderOnSameCalendarDay:
+                  hasNextFromSameSenderOnSameCalendarDay,
+              layoutMode: renderMode,
             )
           : null;
 

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -53,13 +53,12 @@ part 'group_settings.dart';
 
 part 'image_message_widget.dart';
 
+part 'chat_timeline_projection.dart';
+
 typedef OnSendPressed = void Function(String rawText);
 
 ChatRenderMode resolveChatRenderMode(ChatRoom room) =>
     room.isGroupChatRoom ? ChatRenderMode.group : ChatRenderMode.direct;
-
-bool _sameLocalCalendarDay(DateTime a, DateTime b) =>
-    a.year == b.year && a.month == b.month && a.day == b.day;
 
 const _kChatRouteName = '/chat';
 
@@ -593,117 +592,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     required AppLocalizations l10n,
     required ChatRenderMode renderMode,
   }) {
-    final domainMessages = room.messages?.sorted();
-    if (domainMessages == null) return null;
-
-    final internalMessages = <types.Message>[];
-    final textMessages = <Message>[];
-
-    for (final m in domainMessages) {
-      final author = _author(m, l10n);
-      final internal = m.toInternalMessage(
-        author,
-        ref,
-        l10n: l10n,
-        room: room,
-      );
-
-      if (m.content is TextMessageContent && internal is types.TextMessage) {
-        // Status + ticks live in [QaulChatBubble]; hide flutter_chat_ui's
-        // trailing status slot (avoids Row crossAxisAlignment.end shift).
-        internalMessages.add(
-          internal.copyWith(
-            status: null,
-            showStatus: false,
-          ),
-        );
-        textMessages.add(m);
-      } else {
-        internalMessages.add(internal);
-      }
-    }
-
-    final bubbleSources = [...textMessages]
-      ..sort((a, b) => a.sentAt.compareTo(b.sentAt));
-
-    final bubbleMessages = <QaulChatBubbleMessage>[];
-    final bubbleIds = <String>[];
-
-    for (final m in bubbleSources) {
-      final isMe = m.senderId.equals(user.id);
-      bubbleMessages.add(
-        QaulChatBubbleMessage(
-          content: (m.content as TextMessageContent).content,
-          sentAt: m.sentAt,
-          receivedAt: m.receivedAt,
-          status: m.status == MessageState.sent
-              ? MessageStatus.sent
-              : (m.status == MessageState.confirmed ||
-                      m.status == MessageState.confirmedByAll
-                  ? MessageStatus.read
-                  : MessageStatus.notSent),
-          messageType: isMe ? MessageType.primary : MessageType.secondary,
-          edges: const [],
-          senderIdBase58: m.senderIdBase58,
-        ),
-      );
-      bubbleIds.add(m.messageIdBase58);
-    }
-
-    final displayItems = computeChatBubbleDisplayItems(
-      bubbleMessages,
-      layoutMode: renderMode,
+    final projection = buildChatTimelineProjection(
+      room: room,
+      signedInUser: user,
+      l10n: l10n,
+      renderMode: renderMode,
+      ref: ref,
+      resolveAuthor: _author,
     );
-    final map = <String, QaulChatBubbleDisplayItem>{};
-    for (var i = 0; i < bubbleIds.length; i++) {
-      map[bubbleIds[i]] = displayItems[i];
-    }
-    final ordered = [...domainMessages]..sort((a, b) => a.sentAt.compareTo(b.sentAt));
-    final presentations = <String, MessagePresentation>{};
-    for (var i = 0; i < ordered.length; i++) {
-      final m = ordered[i];
-      final isPrimary = m.senderId.equals(user.id);
-      final isGroupIncoming = renderMode == ChatRenderMode.group && !isPrimary;
-      final authorForGroup = isGroupIncoming ? _author(m, l10n) : null;
-      final groupSender = authorForGroup == null
-          ? null
-          : QaulGroupMessageSender(
-              idBase58: authorForGroup.idBase58,
-              name: authorForGroup.name,
-              isConnected: authorForGroup.isConnected,
-            );
-      final prev = i > 0 ? ordered[i - 1] : null;
-      final next = i < ordered.length - 1 ? ordered[i + 1] : null;
-      final prevSameSender = prev != null && prev.senderIdBase58 == m.senderIdBase58;
-      final nextSameSender = next != null && next.senderIdBase58 == m.senderIdBase58;
-      final hasNextFromSameSenderOnSameCalendarDay = next != null &&
-          nextSameSender &&
-          _sameLocalCalendarDay(m.sentAt, next.sentAt);
-
-      final textDisplay = map[m.messageIdBase58];
-      final incomingFlags = isGroupIncoming
-          ? GroupIncomingBubbleFlags.fromSequentialMessages(
-              textDisplay: textDisplay,
-              prevSameSender: prevSameSender,
-              nextSameSender: nextSameSender,
-              hasNextFromSameSenderOnSameCalendarDay:
-                  hasNextFromSameSenderOnSameCalendarDay,
-              layoutMode: renderMode,
-            )
-          : null;
-
-      presentations[m.messageIdBase58] = MessagePresentation(
-        messageId: m.messageIdBase58,
-        isPrimary: isPrimary,
-        sender: groupSender,
-        showSenderName: incomingFlags?.showSenderName ?? false,
-        showSenderAvatar: incomingFlags?.showSenderAvatar ?? false,
-        bubbleDisplay: textDisplay,
-      );
-    }
-    _messagePresentations = presentations;
-
-    return internalMessages;
+    if (projection == null) return null;
+    _messagePresentations = projection.presentations;
+    return projection.internalMessages;
   }
 
   Widget _bubbleBuilder(
@@ -735,7 +634,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       );
     }
 
-    final legacyBubble = _buildLegacyBubble(child, message, nextMessageInGroup);
+    final legacyBubble = _buildLegacyBubble(
+      child,
+      message,
+      legacyClustersWithFollowing:
+          presentation.meta.legacyBubbleClustersWithNext,
+    );
     return ChatMessageRenderer.wrapNonText(
       child: legacyBubble,
       presentation: presentation,
@@ -745,9 +649,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   Widget _buildLegacyBubble(
     Widget child,
-    types.Message message,
-    bool nextMessageInGroup,
-  ) {
+    types.Message message, {
+    required bool legacyClustersWithFollowing,
+  }) {
     const radius = 20.0;
     return Builder(
       builder: (context) {
@@ -762,7 +666,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           color: user.toInternalUser().id != message.author.id
               ? Colors.grey.shade200
               : Colors.lightBlue.shade700,
-          nip: nextMessageInGroup
+          nip: legacyClustersWithFollowing
               ? BubbleNip.no
               : user.toInternalUser().id != message.author.id
                   ? BubbleNip.leftBottom

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -222,16 +222,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _chatRenderMode = resolveChatRenderMode(room);
-    _updateMenuOptionsBasedOnRoomType();
+    _updateMenuOptionsBasedOnRoomType(resolveChatRenderMode(room));
   }
 
   @override
   void didUpdateWidget(covariant ChatScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.room == room) return;
-    _chatRenderMode = resolveChatRenderMode(room);
-    _updateMenuOptionsBasedOnRoomType();
+    _updateMenuOptionsBasedOnRoomType(resolveChatRenderMode(room));
     _scheduleUpdateCurrentOpenChat();
   }
 
@@ -504,24 +502,6 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   hideBackgroundOnEmojiMessages: true,
                   showName: false,
                   emojiEnlargementBehavior: EmojiEnlargementBehavior.multi,
-                  nameBuilder: (usr) {
-                    var user = room.members.firstWhereOrNull(
-                      (u) => usr.id == u.idBase58,
-                    );
-                    if (user == null) return const SizedBox();
-                    final color = colorGenerationStrategy(user.idBase58);
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 4.0),
-                      child: Text(
-                        user.name,
-                        style: TextStyle(
-                          fontSize: 11,
-                          color: color,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    );
-                  },
                 );
               },
           fileMessageBuilder: (message, {required int messageWidth}) {
@@ -634,23 +614,22 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       );
     }
 
-    final legacyBubble = _buildLegacyBubble(
+    final nonTextBubble = _buildNonTextBubble(
       child,
       message,
-      legacyClustersWithFollowing:
-          presentation.meta.legacyBubbleClustersWithNext,
+      clustersWithNext: presentation.meta.nonTextClustersWithNext,
     );
     return ChatMessageRenderer.wrapNonText(
-      child: legacyBubble,
+      child: nonTextBubble,
       presentation: presentation,
       mode: _chatRenderMode,
     );
   }
 
-  Widget _buildLegacyBubble(
+  Widget _buildNonTextBubble(
     Widget child,
     types.Message message, {
-    required bool legacyClustersWithFollowing,
+    required bool clustersWithNext,
   }) {
     const radius = 20.0;
     return Builder(
@@ -666,7 +645,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           color: user.toInternalUser().id != message.author.id
               ? Colors.grey.shade200
               : Colors.lightBlue.shade700,
-          nip: legacyClustersWithFollowing
+          nip: clustersWithNext
               ? BubbleNip.no
               : user.toInternalUser().id != message.author.id
                   ? BubbleNip.leftBottom
@@ -689,14 +668,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     return isReceiving;
   }
 
-  void _updateMenuOptionsBasedOnRoomType() {
+  void _updateMenuOptionsBasedOnRoomType(ChatRenderMode mode) {
     var l10n = AppLocalizations.of(context)!;
-    if (_chatRenderMode == ChatRenderMode.group &&
-        _overflowMenuOptions.isEmpty) {
+    if (mode == ChatRenderMode.group && _overflowMenuOptions.isEmpty) {
       _overflowMenuOptions.addAll({'groupSettings': l10n.groupSettings});
     }
-    if (_chatRenderMode == ChatRenderMode.direct &&
-        _overflowMenuOptions.isNotEmpty) {
+    if (mode == ChatRenderMode.direct && _overflowMenuOptions.isNotEmpty) {
       _overflowMenuOptions.clear();
     }
   }

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
@@ -46,13 +46,10 @@ ChatTimelineProjection? buildChatTimelineProjection({
     }
   }
 
-  final bubbleSources = [...textMessages]
-    ..sort((a, b) => a.sentAt.compareTo(b.sentAt));
-
   final bubbleMessages = <QaulChatBubbleMessage>[];
   final bubbleIds = <String>[];
 
-  for (final m in bubbleSources) {
+  for (final m in textMessages) {
     final isMe = m.senderId.equals(signedInUser.id);
     bubbleMessages.add(
       QaulChatBubbleMessage(
@@ -78,9 +75,8 @@ ChatTimelineProjection? buildChatTimelineProjection({
     bubbleBaseById[bubbleIds[i]] = bubbleMessages[i];
   }
 
-  final ordered = [...domainMessages]..sort((a, b) => a.sentAt.compareTo(b.sentAt));
   final ascendingRows = <ChatTimelinePresentationRow>[
-    for (final m in ordered)
+    for (final m in domainMessages)
       ChatTimelinePresentationRow(
         messageIdBase58: m.messageIdBase58,
         senderIdBase58: m.senderIdBase58,
@@ -98,7 +94,7 @@ ChatTimelineProjection? buildChatTimelineProjection({
   );
 
   final presentations = <String, MessagePresentation>{};
-  for (final m in ordered) {
+  for (final m in domainMessages) {
     final slice = computed[m.messageIdBase58]!;
     final incomingGroup = renderMode == ChatRenderMode.group && !slice.isPrimary;
 

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
@@ -1,0 +1,126 @@
+part of 'chat.dart';
+
+class ChatTimelineProjection {
+  const ChatTimelineProjection({
+    required this.internalMessages,
+    required this.presentations,
+  });
+
+  final List<types.Message> internalMessages;
+  final Map<String, MessagePresentation> presentations;
+}
+
+ChatTimelineProjection? buildChatTimelineProjection({
+  required ChatRoom room,
+  required User signedInUser,
+  required AppLocalizations l10n,
+  required ChatRenderMode renderMode,
+  required WidgetRef ref,
+  required User Function(Message m, AppLocalizations l10n) resolveAuthor,
+}) {
+  final domainMessages = room.messages?.sorted();
+  if (domainMessages == null) return null;
+
+  final internalMessages = <types.Message>[];
+  final textMessages = <Message>[];
+
+  for (final m in domainMessages) {
+    final author = resolveAuthor(m, l10n);
+    final internal = m.toInternalMessage(
+      author,
+      ref,
+      l10n: l10n,
+      room: room,
+    );
+
+    if (m.content is TextMessageContent && internal is types.TextMessage) {
+      internalMessages.add(
+        internal.copyWith(
+          status: null,
+          showStatus: false,
+        ),
+      );
+      textMessages.add(m);
+    } else {
+      internalMessages.add(internal);
+    }
+  }
+
+  final bubbleSources = [...textMessages]
+    ..sort((a, b) => a.sentAt.compareTo(b.sentAt));
+
+  final bubbleMessages = <QaulChatBubbleMessage>[];
+  final bubbleIds = <String>[];
+
+  for (final m in bubbleSources) {
+    final isMe = m.senderId.equals(signedInUser.id);
+    bubbleMessages.add(
+      QaulChatBubbleMessage(
+        content: (m.content as TextMessageContent).content,
+        sentAt: m.sentAt,
+        receivedAt: m.receivedAt,
+        status: m.status == MessageState.sent
+            ? MessageStatus.sent
+            : (m.status == MessageState.confirmed ||
+                    m.status == MessageState.confirmedByAll
+                ? MessageStatus.read
+                : MessageStatus.notSent),
+        messageType: isMe ? MessageType.primary : MessageType.secondary,
+        edges: const [],
+        senderIdBase58: m.senderIdBase58,
+      ),
+    );
+    bubbleIds.add(m.messageIdBase58);
+  }
+
+  final bubbleBaseById = <String, QaulChatBubbleMessage>{};
+  for (var i = 0; i < bubbleIds.length; i++) {
+    bubbleBaseById[bubbleIds[i]] = bubbleMessages[i];
+  }
+
+  final ordered = [...domainMessages]..sort((a, b) => a.sentAt.compareTo(b.sentAt));
+  final ascendingRows = <ChatTimelinePresentationRow>[
+    for (final m in ordered)
+      ChatTimelinePresentationRow(
+        messageIdBase58: m.messageIdBase58,
+        senderIdBase58: m.senderIdBase58,
+        sentAt: m.sentAt,
+        isText: m.content is TextMessageContent,
+        isOutgoing: m.senderId.equals(signedInUser.id),
+        qaulBubbleBaseWithoutLayout:
+            bubbleBaseById[m.messageIdBase58]?.copyWith(edges: const []),
+      ),
+  ];
+
+  final computed = computeChatMessagePresentation(
+    ascendingTimeline: ascendingRows,
+    layoutMode: renderMode,
+  );
+
+  final presentations = <String, MessagePresentation>{};
+  for (final m in ordered) {
+    final slice = computed[m.messageIdBase58]!;
+    final incomingGroup = renderMode == ChatRenderMode.group && !slice.isPrimary;
+
+    QaulGroupMessageSender? groupSender;
+    if (incomingGroup) {
+      final author = resolveAuthor(m, l10n);
+      groupSender = QaulGroupMessageSender(
+        idBase58: author.idBase58,
+        name: author.name,
+        isConnected: author.isConnected,
+      );
+    }
+
+    presentations[m.messageIdBase58] = MessagePresentation.fromComputation(
+      messageId: m.messageIdBase58,
+      sender: groupSender,
+      computation: slice,
+    );
+  }
+
+  return ChatTimelineProjection(
+    internalMessages: internalMessages,
+    presentations: presentations,
+  );
+}

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,6 +1,8 @@
 export 'styles/qaul_color_sheet.dart';
 export 'widgets/chat_header.dart';
+export 'widgets/compute_message_presentation.dart';
 export 'widgets/group_chat_messages.dart';
+export 'widgets/message_presentation_meta.dart';
 export 'widgets/qaul_chat_bubble.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_loading_indicator.dart';

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,5 +1,6 @@
 export 'styles/qaul_color_sheet.dart';
 export 'widgets/chat_header.dart';
+export 'widgets/group_chat_messages.dart';
 export 'widgets/qaul_chat_bubble.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_loading_indicator.dart';

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,8 +1,21 @@
 export 'styles/qaul_color_sheet.dart';
 export 'widgets/chat_header.dart';
-export 'widgets/compute_message_presentation.dart';
-export 'widgets/group_chat_messages.dart';
-export 'widgets/message_presentation_meta.dart';
+export 'widgets/compute_message_presentation.dart'
+    show computeChatMessagePresentation, computeChatBubbleDisplayItems;
+export 'widgets/group_chat_messages.dart'
+    show
+        ChatMessageRenderer,
+        DirectTextMessageItem,
+        GroupMessageShell,
+        GroupSenderAvatar,
+        GroupTextMessageItem,
+        MessagePresentation,
+        QaulGroupMessageSender;
+export 'widgets/message_presentation_meta.dart'
+    show
+        ChatTimelinePresentationRow,
+        MessagePresentationComputation,
+        MessagePresentationMeta;
 export 'widgets/qaul_chat_bubble.dart';
 export 'widgets/qaul_fab.dart';
 export 'widgets/qaul_loading_indicator.dart';

--- a/qaul_ui/packages/qaul_components/lib/widgets/chat_room.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/chat_room.dart
@@ -9,11 +9,13 @@ class ChatRoom extends StatelessWidget {
     required this.messages,
     this.clock,
     this.padding = const EdgeInsets.all(16),
+    this.bubbleLayoutMode = ChatRenderMode.direct,
   });
 
   final List<ChatMessage> messages;
   final DateTime? clock;
   final EdgeInsetsGeometry padding;
+  final ChatRenderMode bubbleLayoutMode;
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +26,10 @@ class ChatRoom extends StatelessWidget {
     void flushBubbleRun() {
       if (pendingBubbleRun.isEmpty) return;
 
-      final displayItems = computeChatBubbleDisplayItems(pendingBubbleRun);
+      final displayItems = computeChatBubbleDisplayItems(
+        pendingBubbleRun,
+        layoutMode: bubbleLayoutMode,
+      );
       for (final item in displayItems) {
         children.add(
           Padding(

--- a/qaul_ui/packages/qaul_components/lib/widgets/chat_room.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/chat_room.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'chat_message.dart';
+import 'compute_message_presentation.dart';
 import 'qaul_chat_bubble.dart';
 
 class ChatRoom extends StatelessWidget {

--- a/qaul_ui/packages/qaul_components/lib/widgets/compute_message_presentation.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/compute_message_presentation.dart
@@ -1,0 +1,215 @@
+import 'message_presentation_meta.dart';
+import 'qaul_chat_bubble.dart';
+
+bool _sameParticipantStreakNeighbor(
+  ChatTimelinePresentationRow a,
+  ChatTimelinePresentationRow b,
+) {
+  if (a.isOutgoing != b.isOutgoing) return false;
+  if (a.isOutgoing) return true;
+  if (a.senderIdBase58.isEmpty || b.senderIdBase58.isEmpty) return false;
+  return a.senderIdBase58 == b.senderIdBase58;
+}
+
+Map<String, MessagePresentationComputation> computeChatMessagePresentation({
+  required List<ChatTimelinePresentationRow> ascendingTimeline,
+  required ChatRenderMode layoutMode,
+}) {
+  final textRows = ascendingTimeline
+      .where(
+        (r) => r.isText && r.qaulBubbleBaseWithoutLayout != null,
+      )
+      .toList();
+
+  MessagePresentationComputation buildTextComputation(
+    ChatTimelinePresentationRow row,
+    int textIndexInSequence,
+    int timelineIndex,
+  ) {
+    final bubble = row.qaulBubbleBaseWithoutLayout!;
+    final prevTimeline =
+        timelineIndex > 0 ? ascendingTimeline[timelineIndex - 1] : null;
+    final nextTimeline = timelineIndex < ascendingTimeline.length - 1
+        ? ascendingTimeline[timelineIndex + 1]
+        : null;
+
+    final prevMinute = textIndexInSequence > 0
+        ? textRows[textIndexInSequence - 1].qaulBubbleBaseWithoutLayout
+        : null;
+    final nextMinute = textIndexInSequence < textRows.length - 1
+        ? textRows[textIndexInSequence + 1].qaulBubbleBaseWithoutLayout
+        : null;
+
+    final linksToPrevious =
+        prevMinute != null && directChatBubblesShareMinute(prevMinute, bubble);
+    final linksToNext =
+        nextMinute != null && directChatBubblesShareMinute(bubble, nextMinute);
+
+    final isPrimary = row.isOutgoing;
+
+    final tailEdges = isPrimary
+        ? tailEdgesForPrimary(linksToPrevious, linksToNext)
+        : tailEdgesForSecondary(linksToPrevious, linksToNext);
+
+    final double topSpacing;
+    if (prevTimeline == null) {
+      topSpacing = 0;
+    } else if (layoutMode == ChatRenderMode.group) {
+      final compactParticipantStreakDay =
+          _sameParticipantStreakNeighbor(prevTimeline, row) &&
+          samePresentationLocalCalendarDay(prevTimeline.sentAt, row.sentAt);
+      topSpacing = compactParticipantStreakDay
+          ? kChatBubbleLinkedGap
+          : kChatBubbleSeparatedGap;
+    } else {
+      topSpacing = linksToPrevious
+          ? kChatBubbleLinkedGap
+          : kChatBubbleSeparatedGap;
+    }
+
+    final showTimestamp = !linksToNext;
+
+    var showSenderName = false;
+    var showAvatar = false;
+
+    if (layoutMode == ChatRenderMode.group && row.isGroupIncomingEligible) {
+      showSenderName = prevTimeline == null ||
+          !_sameParticipantStreakNeighbor(prevTimeline, row) ||
+          !samePresentationLocalCalendarDay(
+              prevTimeline.sentAt, row.sentAt);
+
+      final continuesAfter = nextTimeline != null &&
+          _sameParticipantStreakNeighbor(row, nextTimeline) &&
+          samePresentationLocalCalendarDay(row.sentAt, nextTimeline.sentAt);
+      showAvatar = !continuesAfter;
+    }
+
+    final legacyBubbleClustersWithNext = nextTimeline != null &&
+        _sameParticipantStreakNeighbor(row, nextTimeline);
+
+    final meta = MessagePresentationMeta(
+      linksToPrevious: linksToPrevious,
+      linksToNext: linksToNext,
+      showAvatar: showAvatar,
+      showSenderName: showSenderName,
+      showTimestamp: showTimestamp,
+      tailEdges: tailEdges,
+      topSpacing: topSpacing,
+      legacyBubbleClustersWithNext: legacyBubbleClustersWithNext,
+    );
+
+    final messageWithTail = bubble.copyWith(edges: tailEdges);
+
+    final item = QaulChatBubbleDisplayItem(
+      message: messageWithTail,
+      showTimestamp: showTimestamp,
+      marginTop: topSpacing,
+    );
+
+    return MessagePresentationComputation(
+      meta: meta,
+      textDisplay: item,
+      isPrimary: row.isOutgoing,
+    );
+  }
+
+  MessagePresentationComputation emptyNonText(
+    ChatTimelinePresentationRow row,
+    int timelineIndex,
+  ) {
+    final prevTimeline =
+        timelineIndex > 0 ? ascendingTimeline[timelineIndex - 1] : null;
+    final nextTimeline = timelineIndex < ascendingTimeline.length - 1
+        ? ascendingTimeline[timelineIndex + 1]
+        : null;
+
+    double topSpacing = 0;
+    var showAvatar = false;
+    var showSenderName = false;
+
+    if (layoutMode == ChatRenderMode.group && row.isGroupIncomingEligible) {
+      showSenderName = prevTimeline == null ||
+          !_sameParticipantStreakNeighbor(prevTimeline, row) ||
+          !samePresentationLocalCalendarDay(prevTimeline.sentAt, row.sentAt);
+
+      final continuesAfter = nextTimeline != null &&
+          _sameParticipantStreakNeighbor(row, nextTimeline) &&
+          samePresentationLocalCalendarDay(row.sentAt, nextTimeline.sentAt);
+      showAvatar = !continuesAfter;
+
+      if (prevTimeline != null) {
+        final compactParticipantStreakDay =
+            _sameParticipantStreakNeighbor(prevTimeline, row) &&
+                samePresentationLocalCalendarDay(prevTimeline.sentAt, row.sentAt);
+        topSpacing = compactParticipantStreakDay
+            ? kChatBubbleLinkedGap
+            : kChatBubbleSeparatedGap;
+      }
+    }
+
+    final legacyBubbleClustersWithNext = nextTimeline != null &&
+        _sameParticipantStreakNeighbor(row, nextTimeline);
+
+    final meta = MessagePresentationMeta(
+      linksToPrevious: false,
+      linksToNext: false,
+      showAvatar: showAvatar,
+      showSenderName: showSenderName,
+      showTimestamp: false,
+      tailEdges: const [],
+      topSpacing: topSpacing,
+      legacyBubbleClustersWithNext: legacyBubbleClustersWithNext,
+    );
+
+    return MessagePresentationComputation(
+      meta: meta,
+      textDisplay: null,
+      isPrimary: row.isOutgoing,
+    );
+  }
+
+  final map = <String, MessagePresentationComputation>{};
+  var textSeen = 0;
+
+  for (var i = 0; i < ascendingTimeline.length; i++) {
+    final row = ascendingTimeline[i];
+    if (row.isText && row.qaulBubbleBaseWithoutLayout != null) {
+      map[row.messageIdBase58] =
+          buildTextComputation(row, textSeen, i);
+      textSeen++;
+    } else {
+      map[row.messageIdBase58] = emptyNonText(row, i);
+    }
+  }
+
+  return map;
+}
+
+List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
+  List<QaulChatBubbleMessage> messages, {
+  ChatRenderMode layoutMode = ChatRenderMode.direct,
+}) {
+  if (messages.isEmpty) return [];
+
+  final rows = <ChatTimelinePresentationRow>[
+    for (var i = 0; i < messages.length; i++)
+      ChatTimelinePresentationRow(
+        messageIdBase58: 'text-only-$i',
+        senderIdBase58: messages[i].senderIdBase58 ?? '',
+        sentAt: messages[i].sentAt,
+        isText: true,
+        isOutgoing: messages[i].messageType == MessageType.primary,
+        qaulBubbleBaseWithoutLayout: messages[i].copyWith(edges: const []),
+      ),
+  ];
+
+  final computed = computeChatMessagePresentation(
+    ascendingTimeline: rows,
+    layoutMode: layoutMode,
+  );
+
+  return [
+    for (var i = 0; i < messages.length; i++)
+      computed['text-only-$i']!.textDisplay!,
+  ];
+}

--- a/qaul_ui/packages/qaul_components/lib/widgets/compute_message_presentation.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/compute_message_presentation.dart
@@ -1,6 +1,10 @@
 import 'message_presentation_meta.dart';
 import 'qaul_chat_bubble.dart';
 
+// Returns false for incoming neighbors when either senderIdBase58 is empty.
+// Callers without senderIds (e.g. the legacy `computeChatBubbleDisplayItems`
+// path used by widget tests) therefore never cluster incoming messages in
+// group mode — only the timeline-aware path supplies senderIds.
 bool _sameParticipantStreakNeighbor(
   ChatTimelinePresentationRow a,
   ChatTimelinePresentationRow b,
@@ -55,16 +59,18 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
     if (prevTimeline == null) {
       topSpacing = 0;
     } else if (layoutMode == ChatRenderMode.group) {
-      final compactParticipantStreakDay =
+      final isSameStreakSameDay =
           _sameParticipantStreakNeighbor(prevTimeline, row) &&
           samePresentationLocalCalendarDay(prevTimeline.sentAt, row.sentAt);
-      topSpacing = compactParticipantStreakDay
-          ? kChatBubbleLinkedGap
-          : kChatBubbleSeparatedGap;
+      if (isSameStreakSameDay) {
+        topSpacing = kChatBubbleLinkedGap;
+      } else {
+        topSpacing = kChatBubbleSeparatedGap;
+      }
+    } else if (linksToPrevious) {
+      topSpacing = kChatBubbleLinkedGap;
     } else {
-      topSpacing = linksToPrevious
-          ? kChatBubbleLinkedGap
-          : kChatBubbleSeparatedGap;
+      topSpacing = kChatBubbleSeparatedGap;
     }
 
     final showTimestamp = !linksToNext;
@@ -84,7 +90,7 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
       showAvatar = !continuesAfter;
     }
 
-    final legacyBubbleClustersWithNext = nextTimeline != null &&
+    final nonTextClustersWithNext = nextTimeline != null &&
         _sameParticipantStreakNeighbor(row, nextTimeline);
 
     final meta = MessagePresentationMeta(
@@ -95,7 +101,7 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
       showTimestamp: showTimestamp,
       tailEdges: tailEdges,
       topSpacing: topSpacing,
-      legacyBubbleClustersWithNext: legacyBubbleClustersWithNext,
+      nonTextClustersWithNext: nonTextClustersWithNext,
     );
 
     final messageWithTail = bubble.copyWith(edges: tailEdges);
@@ -138,16 +144,18 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
       showAvatar = !continuesAfter;
 
       if (prevTimeline != null) {
-        final compactParticipantStreakDay =
+        final isSameStreakSameDay =
             _sameParticipantStreakNeighbor(prevTimeline, row) &&
                 samePresentationLocalCalendarDay(prevTimeline.sentAt, row.sentAt);
-        topSpacing = compactParticipantStreakDay
-            ? kChatBubbleLinkedGap
-            : kChatBubbleSeparatedGap;
+        if (isSameStreakSameDay) {
+          topSpacing = kChatBubbleLinkedGap;
+        } else {
+          topSpacing = kChatBubbleSeparatedGap;
+        }
       }
     }
 
-    final legacyBubbleClustersWithNext = nextTimeline != null &&
+    final nonTextClustersWithNext = nextTimeline != null &&
         _sameParticipantStreakNeighbor(row, nextTimeline);
 
     final meta = MessagePresentationMeta(
@@ -158,7 +166,7 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
       showTimestamp: false,
       tailEdges: const [],
       topSpacing: topSpacing,
-      legacyBubbleClustersWithNext: legacyBubbleClustersWithNext,
+      nonTextClustersWithNext: nonTextClustersWithNext,
     );
 
     return MessagePresentationComputation(

--- a/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
@@ -3,6 +3,9 @@ import 'package:utils/utils.dart';
 
 import 'qaul_chat_bubble.dart';
 
+bool _sameLocalCalendarDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
+
 /// Lightweight sender snapshot for group chat UI (decouples from RPC `User`).
 @immutable
 class QaulGroupMessageSender {
@@ -19,8 +22,6 @@ class QaulGroupMessageSender {
   final bool isConnected;
 }
 
-enum ChatRenderMode { direct, group }
-
 /// Name + avatar visibility for an incoming group text bubble, given run context.
 @immutable
 class GroupIncomingBubbleFlags {
@@ -36,14 +37,23 @@ class GroupIncomingBubbleFlags {
     required QaulChatBubbleDisplayItem? textDisplay,
     required bool prevSameSender,
     required bool nextSameSender,
+    /// Next timeline message is the same sender and same **local calendar day**
+    /// (run continues; hide avatar). If the next message is the next day, this
+    /// is false so the avatar shows on the last bubble before a date boundary.
+    required bool hasNextFromSameSenderOnSameCalendarDay,
+    required ChatRenderMode layoutMode,
   }) {
     final showSenderName = textDisplay != null
         ? textDisplay.message.edges.contains(TailEdge.bottomStart) &&
             !textDisplay.message.edges.contains(TailEdge.topStart)
         : !prevSameSender;
-    final showSenderAvatar = textDisplay != null
-        ? textDisplay.showTimestamp
-        : !nextSameSender;
+    // Group: avatar on the last bubble of each per-day streak from a sender
+    // (new calendar day starts a new “group”). 1:1 keeps minute-cluster alignment.
+    final showSenderAvatar = layoutMode == ChatRenderMode.group
+        ? !hasNextFromSameSenderOnSameCalendarDay
+        : (textDisplay != null
+            ? textDisplay.showTimestamp
+            : !nextSameSender);
     return GroupIncomingBubbleFlags(
       showSenderName: showSenderName,
       showSenderAvatar: showSenderAvatar,
@@ -87,10 +97,15 @@ class MessagePresentation {
         prev.message.senderIdBase58 == item.message.senderIdBase58;
     final nextSame = next != null &&
         next.message.senderIdBase58 == item.message.senderIdBase58;
+    final hasNextSameSenderSameDay = next != null &&
+        nextSame &&
+        _sameLocalCalendarDay(item.message.sentAt, next.message.sentAt);
     final flags = GroupIncomingBubbleFlags.fromSequentialMessages(
       textDisplay: item,
       prevSameSender: prevSame,
       nextSameSender: nextSame,
+      hasNextFromSameSenderOnSameCalendarDay: hasNextSameSenderSameDay,
+      layoutMode: ChatRenderMode.group,
     );
     return MessagePresentation(
       messageId: 'seq-$index',

--- a/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:utils/utils.dart';
 
+import 'message_presentation_meta.dart';
 import 'qaul_chat_bubble.dart';
 
-bool _sameLocalCalendarDay(DateTime a, DateTime b) =>
-    a.year == b.year && a.month == b.month && a.day == b.day;
-
-/// Lightweight sender snapshot for group chat UI (decouples from RPC `User`).
 @immutable
 class QaulGroupMessageSender {
   const QaulGroupMessageSender({
@@ -18,47 +15,7 @@ class QaulGroupMessageSender {
   final String idBase58;
   final String name;
 
-  /// When true, [GroupSenderAvatar] shows the online indicator.
   final bool isConnected;
-}
-
-/// Name + avatar visibility for an incoming group text bubble, given run context.
-@immutable
-class GroupIncomingBubbleFlags {
-  const GroupIncomingBubbleFlags({
-    required this.showSenderName,
-    required this.showSenderAvatar,
-  });
-
-  final bool showSenderName;
-  final bool showSenderAvatar;
-
-  static GroupIncomingBubbleFlags fromSequentialMessages({
-    required QaulChatBubbleDisplayItem? textDisplay,
-    required bool prevSameSender,
-    required bool nextSameSender,
-    /// Next timeline message is the same sender and same **local calendar day**
-    /// (run continues; hide avatar). If the next message is the next day, this
-    /// is false so the avatar shows on the last bubble before a date boundary.
-    required bool hasNextFromSameSenderOnSameCalendarDay,
-    required ChatRenderMode layoutMode,
-  }) {
-    final showSenderName = textDisplay != null
-        ? textDisplay.message.edges.contains(TailEdge.bottomStart) &&
-            !textDisplay.message.edges.contains(TailEdge.topStart)
-        : !prevSameSender;
-    // Group: avatar on the last bubble of each per-day streak from a sender
-    // (new calendar day starts a new “group”). 1:1 keeps minute-cluster alignment.
-    final showSenderAvatar = layoutMode == ChatRenderMode.group
-        ? !hasNextFromSameSenderOnSameCalendarDay
-        : (textDisplay != null
-            ? textDisplay.showTimestamp
-            : !nextSameSender);
-    return GroupIncomingBubbleFlags(
-      showSenderName: showSenderName,
-      showSenderAvatar: showSenderAvatar,
-    );
-  }
 }
 
 @immutable
@@ -67,61 +24,28 @@ class MessagePresentation {
     required this.messageId,
     required this.isPrimary,
     required this.sender,
-    required this.showSenderName,
-    required this.showSenderAvatar,
+    required this.meta,
     required this.bubbleDisplay,
   });
 
-  /// Same grouping rules as the chat screen, for flat lists (e.g. Widgetbook
-  /// previews) so [ChatMessageRenderer.renderText] is the single render path.
-  factory MessagePresentation.forSequentialTextBubble({
-    required QaulChatBubbleDisplayItem item,
-    required int index,
-    required List<QaulChatBubbleDisplayItem> items,
-    required bool isPrimary,
+  factory MessagePresentation.fromComputation({
+    required String messageId,
     required QaulGroupMessageSender? sender,
+    required MessagePresentationComputation computation,
   }) {
-    if (isPrimary) {
-      return MessagePresentation(
-        messageId: 'seq-$index',
-        isPrimary: true,
-        sender: null,
-        showSenderName: false,
-        showSenderAvatar: false,
-        bubbleDisplay: item,
-      );
-    }
-    final prev = index > 0 ? items[index - 1] : null;
-    final next = index < items.length - 1 ? items[index + 1] : null;
-    final prevSame = prev != null &&
-        prev.message.senderIdBase58 == item.message.senderIdBase58;
-    final nextSame = next != null &&
-        next.message.senderIdBase58 == item.message.senderIdBase58;
-    final hasNextSameSenderSameDay = next != null &&
-        nextSame &&
-        _sameLocalCalendarDay(item.message.sentAt, next.message.sentAt);
-    final flags = GroupIncomingBubbleFlags.fromSequentialMessages(
-      textDisplay: item,
-      prevSameSender: prevSame,
-      nextSameSender: nextSame,
-      hasNextFromSameSenderOnSameCalendarDay: hasNextSameSenderSameDay,
-      layoutMode: ChatRenderMode.group,
-    );
     return MessagePresentation(
-      messageId: 'seq-$index',
-      isPrimary: false,
+      messageId: messageId,
+      isPrimary: computation.isPrimary,
       sender: sender,
-      showSenderName: flags.showSenderName,
-      showSenderAvatar: flags.showSenderAvatar,
-      bubbleDisplay: item,
+      meta: computation.meta,
+      bubbleDisplay: computation.textDisplay,
     );
   }
 
   final String messageId;
   final bool isPrimary;
   final QaulGroupMessageSender? sender;
-  final bool showSenderName;
-  final bool showSenderAvatar;
+  final MessagePresentationMeta meta;
   final QaulChatBubbleDisplayItem? bubbleDisplay;
 }
 
@@ -136,17 +60,15 @@ class ChatMessageRenderer {
 
     if (mode == ChatRenderMode.group && !presentation.isPrimary) {
       return GroupTextMessageItem(
-        display: display,
+        presentation: presentation,
         clock: clock,
-        sender: presentation.sender,
-        showSenderName: presentation.showSenderName,
-        showSenderAvatar: presentation.showSenderAvatar,
       );
     }
 
     return DirectTextMessageItem(
-      display: display,
+      presentation: presentation,
       clock: clock,
+      layoutMode: mode,
     );
   }
 
@@ -160,10 +82,10 @@ class ChatMessageRenderer {
     }
 
     return GroupMessageShell(
-      marginTop: presentation.bubbleDisplay?.marginTop ?? 0,
+      marginTop: presentation.meta.topSpacing,
       sender: presentation.sender,
-      showSenderName: false,
-      showSenderAvatar: presentation.showSenderAvatar,
+      showSenderName: presentation.meta.showSenderName,
+      showSenderAvatar: presentation.meta.showAvatar,
       child: child,
     );
   }
@@ -172,26 +94,30 @@ class ChatMessageRenderer {
 class DirectTextMessageItem extends StatelessWidget {
   const DirectTextMessageItem({
     super.key,
-    required this.display,
+    required this.presentation,
     required this.clock,
+    this.layoutMode = ChatRenderMode.direct,
   });
 
-  final QaulChatBubbleDisplayItem display;
+  final MessagePresentation presentation;
   final DateTime clock;
+  final ChatRenderMode layoutMode;
 
   @override
   Widget build(BuildContext context) {
-    final isPrimary = display.message.messageType == MessageType.primary;
+    final display = presentation.bubbleDisplay!;
+    final isPrimary = presentation.isPrimary;
+    final horizontalGutter = layoutMode == ChatRenderMode.direct;
     return Padding(
       padding: EdgeInsetsDirectional.only(
-        top: display.marginTop,
-        start: isPrimary ? 0 : 16,
-        end: isPrimary ? 16 : 0,
+        top: presentation.meta.topSpacing,
+        start: horizontalGutter && !isPrimary ? 16 : 0,
+        end: horizontalGutter && isPrimary ? 16 : 0,
       ),
       child: QaulChatBubble(
         message: display.message,
         clock: clock,
-        showTimestamp: display.showTimestamp,
+        showTimestamp: presentation.meta.showTimestamp,
       ),
     );
   }
@@ -200,39 +126,35 @@ class DirectTextMessageItem extends StatelessWidget {
 class GroupTextMessageItem extends StatelessWidget {
   const GroupTextMessageItem({
     super.key,
-    required this.display,
+    required this.presentation,
     required this.clock,
-    required this.sender,
-    required this.showSenderName,
-    required this.showSenderAvatar,
   });
 
-  final QaulChatBubbleDisplayItem display;
+  final MessagePresentation presentation;
   final DateTime clock;
-  final QaulGroupMessageSender? sender;
-  final bool showSenderName;
-  final bool showSenderAvatar;
 
   @override
   Widget build(BuildContext context) {
+    final display = presentation.bubbleDisplay!;
+    final sender = presentation.sender;
     final senderNameColor =
-        sender == null ? null : colorGenerationStrategy(sender!.idBase58);
-    final bubbleMessage = showSenderName && sender != null
+        sender == null ? null : colorGenerationStrategy(sender.idBase58);
+    final bubbleMessage = presentation.meta.showSenderName && sender != null
         ? display.message.copyWith(
-            senderDisplayName: sender!.name,
+            senderDisplayName: sender.name,
             senderDisplayNameColor: senderNameColor,
           )
         : display.message;
 
     return GroupMessageShell(
-      marginTop: display.marginTop,
+      marginTop: presentation.meta.topSpacing,
       sender: sender,
       showSenderName: false,
-      showSenderAvatar: showSenderAvatar,
+      showSenderAvatar: presentation.meta.showAvatar,
       child: QaulChatBubble(
         message: bubbleMessage,
         clock: clock,
-        showTimestamp: display.showTimestamp,
+        showTimestamp: presentation.meta.showTimestamp,
       ),
     );
   }
@@ -259,11 +181,7 @@ class GroupMessageShell extends StatelessWidget {
     final senderNameColor =
         sender == null ? null : colorGenerationStrategy(sender!.idBase58);
     return Padding(
-      padding: EdgeInsetsDirectional.only(
-        top: marginTop,
-        start: 16,
-        end: 0,
-      ),
+      padding: EdgeInsetsDirectional.only(top: marginTop),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [

--- a/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/material.dart';
+import 'package:utils/utils.dart';
+
+import 'qaul_chat_bubble.dart';
+
+/// Lightweight sender snapshot for group chat UI (decouples from RPC `User`).
+@immutable
+class QaulGroupMessageSender {
+  const QaulGroupMessageSender({
+    required this.idBase58,
+    required this.name,
+    this.isConnected = false,
+  });
+
+  final String idBase58;
+  final String name;
+
+  /// When true, [GroupSenderAvatar] shows the online indicator.
+  final bool isConnected;
+}
+
+enum ChatRenderMode { direct, group }
+
+/// Name + avatar visibility for an incoming group text bubble, given run context.
+@immutable
+class GroupIncomingBubbleFlags {
+  const GroupIncomingBubbleFlags({
+    required this.showSenderName,
+    required this.showSenderAvatar,
+  });
+
+  final bool showSenderName;
+  final bool showSenderAvatar;
+
+  static GroupIncomingBubbleFlags fromSequentialMessages({
+    required QaulChatBubbleDisplayItem? textDisplay,
+    required bool prevSameSender,
+    required bool nextSameSender,
+  }) {
+    final showSenderName = textDisplay != null
+        ? textDisplay.message.edges.contains(TailEdge.bottomStart) &&
+            !textDisplay.message.edges.contains(TailEdge.topStart)
+        : !prevSameSender;
+    final showSenderAvatar = textDisplay != null
+        ? textDisplay.showTimestamp
+        : !nextSameSender;
+    return GroupIncomingBubbleFlags(
+      showSenderName: showSenderName,
+      showSenderAvatar: showSenderAvatar,
+    );
+  }
+}
+
+@immutable
+class MessagePresentation {
+  const MessagePresentation({
+    required this.messageId,
+    required this.isPrimary,
+    required this.sender,
+    required this.showSenderName,
+    required this.showSenderAvatar,
+    required this.bubbleDisplay,
+  });
+
+  /// Same grouping rules as the chat screen, for flat lists (e.g. Widgetbook
+  /// previews) so [ChatMessageRenderer.renderText] is the single render path.
+  factory MessagePresentation.forSequentialTextBubble({
+    required QaulChatBubbleDisplayItem item,
+    required int index,
+    required List<QaulChatBubbleDisplayItem> items,
+    required bool isPrimary,
+    required QaulGroupMessageSender? sender,
+  }) {
+    if (isPrimary) {
+      return MessagePresentation(
+        messageId: 'seq-$index',
+        isPrimary: true,
+        sender: null,
+        showSenderName: false,
+        showSenderAvatar: false,
+        bubbleDisplay: item,
+      );
+    }
+    final prev = index > 0 ? items[index - 1] : null;
+    final next = index < items.length - 1 ? items[index + 1] : null;
+    final prevSame = prev != null &&
+        prev.message.senderIdBase58 == item.message.senderIdBase58;
+    final nextSame = next != null &&
+        next.message.senderIdBase58 == item.message.senderIdBase58;
+    final flags = GroupIncomingBubbleFlags.fromSequentialMessages(
+      textDisplay: item,
+      prevSameSender: prevSame,
+      nextSameSender: nextSame,
+    );
+    return MessagePresentation(
+      messageId: 'seq-$index',
+      isPrimary: false,
+      sender: sender,
+      showSenderName: flags.showSenderName,
+      showSenderAvatar: flags.showSenderAvatar,
+      bubbleDisplay: item,
+    );
+  }
+
+  final String messageId;
+  final bool isPrimary;
+  final QaulGroupMessageSender? sender;
+  final bool showSenderName;
+  final bool showSenderAvatar;
+  final QaulChatBubbleDisplayItem? bubbleDisplay;
+}
+
+class ChatMessageRenderer {
+  static Widget renderText({
+    required MessagePresentation presentation,
+    required ChatRenderMode mode,
+    required DateTime clock,
+  }) {
+    final display = presentation.bubbleDisplay;
+    if (display == null) return const SizedBox.shrink();
+
+    if (mode == ChatRenderMode.group && !presentation.isPrimary) {
+      return GroupTextMessageItem(
+        display: display,
+        clock: clock,
+        sender: presentation.sender,
+        showSenderName: presentation.showSenderName,
+        showSenderAvatar: presentation.showSenderAvatar,
+      );
+    }
+
+    return DirectTextMessageItem(
+      display: display,
+      clock: clock,
+    );
+  }
+
+  static Widget wrapNonText({
+    required Widget child,
+    required MessagePresentation presentation,
+    required ChatRenderMode mode,
+  }) {
+    if (mode != ChatRenderMode.group || presentation.isPrimary) {
+      return child;
+    }
+
+    return GroupMessageShell(
+      marginTop: presentation.bubbleDisplay?.marginTop ?? 0,
+      sender: presentation.sender,
+      showSenderName: false,
+      showSenderAvatar: presentation.showSenderAvatar,
+      child: child,
+    );
+  }
+}
+
+class DirectTextMessageItem extends StatelessWidget {
+  const DirectTextMessageItem({
+    super.key,
+    required this.display,
+    required this.clock,
+  });
+
+  final QaulChatBubbleDisplayItem display;
+  final DateTime clock;
+
+  @override
+  Widget build(BuildContext context) {
+    final isPrimary = display.message.messageType == MessageType.primary;
+    return Padding(
+      padding: EdgeInsetsDirectional.only(
+        top: display.marginTop,
+        start: isPrimary ? 0 : 16,
+        end: isPrimary ? 16 : 0,
+      ),
+      child: QaulChatBubble(
+        message: display.message,
+        clock: clock,
+        showTimestamp: display.showTimestamp,
+      ),
+    );
+  }
+}
+
+class GroupTextMessageItem extends StatelessWidget {
+  const GroupTextMessageItem({
+    super.key,
+    required this.display,
+    required this.clock,
+    required this.sender,
+    required this.showSenderName,
+    required this.showSenderAvatar,
+  });
+
+  final QaulChatBubbleDisplayItem display;
+  final DateTime clock;
+  final QaulGroupMessageSender? sender;
+  final bool showSenderName;
+  final bool showSenderAvatar;
+
+  @override
+  Widget build(BuildContext context) {
+    final senderNameColor =
+        sender == null ? null : colorGenerationStrategy(sender!.idBase58);
+    final bubbleMessage = showSenderName && sender != null
+        ? display.message.copyWith(
+            senderDisplayName: sender!.name,
+            senderDisplayNameColor: senderNameColor,
+          )
+        : display.message;
+
+    return GroupMessageShell(
+      marginTop: display.marginTop,
+      sender: sender,
+      showSenderName: false,
+      showSenderAvatar: showSenderAvatar,
+      child: QaulChatBubble(
+        message: bubbleMessage,
+        clock: clock,
+        showTimestamp: display.showTimestamp,
+      ),
+    );
+  }
+}
+
+class GroupMessageShell extends StatelessWidget {
+  const GroupMessageShell({
+    super.key,
+    required this.marginTop,
+    required this.sender,
+    required this.showSenderName,
+    required this.showSenderAvatar,
+    required this.child,
+  });
+
+  final double marginTop;
+  final QaulGroupMessageSender? sender;
+  final bool showSenderName;
+  final bool showSenderAvatar;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final senderNameColor =
+        sender == null ? null : colorGenerationStrategy(sender!.idBase58);
+    return Padding(
+      padding: EdgeInsetsDirectional.only(
+        top: marginTop,
+        start: 16,
+        end: 0,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          SizedBox(
+            width: 40,
+            child: showSenderAvatar && sender != null
+                ? Align(
+                    alignment: Alignment.bottomCenter,
+                    child: GroupSenderAvatar(sender: sender!),
+                  )
+                : const SizedBox.shrink(),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (showSenderName && sender != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text(
+                      sender!.name,
+                      style: TextStyle(
+                        fontFamily: 'Roboto',
+                        fontSize: 11,
+                        fontWeight: FontWeight.w400,
+                        height: 1.25,
+                        letterSpacing: 0.5,
+                        color: senderNameColor,
+                      ),
+                    ),
+                  ),
+                child,
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class GroupSenderAvatar extends StatelessWidget {
+  const GroupSenderAvatar({super.key, required this.sender});
+
+  final QaulGroupMessageSender sender;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = colorGenerationStrategy(sender.idBase58);
+
+    return SizedBox(
+      width: 28,
+      height: 28,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          CircleAvatar(
+            radius: 14,
+            backgroundColor: background,
+            child: Text(
+              initials(sender.name),
+              style: const TextStyle(
+                fontFamily: 'Roboto',
+                fontSize: 14,
+                color: Colors.white,
+                fontWeight: FontWeight.w300,
+                height: 1.2,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          if (sender.isConnected)
+            Positioned(
+              right: -1,
+              bottom: -1,
+              child: Container(
+                width: 9,
+                height: 9,
+                decoration: BoxDecoration(
+                  color: Colors.greenAccent.shade700,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 0.5),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/group_chat_messages.dart
@@ -68,7 +68,7 @@ class ChatMessageRenderer {
     return DirectTextMessageItem(
       presentation: presentation,
       clock: clock,
-      layoutMode: mode,
+      horizontalGutter: mode == ChatRenderMode.direct,
     );
   }
 
@@ -96,18 +96,21 @@ class DirectTextMessageItem extends StatelessWidget {
     super.key,
     required this.presentation,
     required this.clock,
-    this.layoutMode = ChatRenderMode.direct,
+    this.horizontalGutter = true,
   });
 
   final MessagePresentation presentation;
   final DateTime clock;
-  final ChatRenderMode layoutMode;
+
+  /// When true, applies a 16px gutter on the trailing edge for primary
+  /// (outgoing) bubbles and on the leading edge for secondary (incoming).
+  /// Set to false for group-mode outgoing bubbles, which render flush.
+  final bool horizontalGutter;
 
   @override
   Widget build(BuildContext context) {
     final display = presentation.bubbleDisplay!;
     final isPrimary = presentation.isPrimary;
-    final horizontalGutter = layoutMode == ChatRenderMode.direct;
     return Padding(
       padding: EdgeInsetsDirectional.only(
         top: presentation.meta.topSpacing,
@@ -205,12 +208,7 @@ class GroupMessageShell extends StatelessWidget {
                     padding: const EdgeInsets.only(bottom: 4),
                     child: Text(
                       sender!.name,
-                      style: TextStyle(
-                        fontFamily: 'Roboto',
-                        fontSize: 11,
-                        fontWeight: FontWeight.w400,
-                        height: 1.25,
-                        letterSpacing: 0.5,
+                      style: kGroupSenderNameTextStyle.copyWith(
                         color: senderNameColor,
                       ),
                     ),

--- a/qaul_ui/packages/qaul_components/lib/widgets/message_presentation_meta.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/message_presentation_meta.dart
@@ -40,7 +40,7 @@ class MessagePresentationMeta {
     required this.showTimestamp,
     required this.tailEdges,
     required this.topSpacing,
-    required this.legacyBubbleClustersWithNext,
+    required this.nonTextClustersWithNext,
   });
 
   final bool linksToPrevious;
@@ -57,7 +57,11 @@ class MessagePresentationMeta {
 
   final double topSpacing;
 
-  final bool legacyBubbleClustersWithNext;
+  /// True when the next timeline neighbor belongs to the same participant
+  /// streak. The non-text bubble path uses this to suppress its tail nip when
+  /// clustered. Distinct from flutter-chat-ui's old `nextMessageInGroup`
+  /// (which keyed on author + minute, not streak).
+  final bool nonTextClustersWithNext;
 }
 
 @immutable

--- a/qaul_ui/packages/qaul_components/lib/widgets/message_presentation_meta.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/message_presentation_meta.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+
+import 'qaul_chat_bubble.dart';
+
+bool samePresentationLocalCalendarDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
+
+@immutable
+class ChatTimelinePresentationRow {
+  const ChatTimelinePresentationRow({
+    required this.messageIdBase58,
+    required this.senderIdBase58,
+    required this.sentAt,
+    required this.isText,
+    required this.isOutgoing,
+    this.qaulBubbleBaseWithoutLayout,
+  });
+
+  final String messageIdBase58;
+  final String senderIdBase58;
+  final DateTime sentAt;
+  final bool isText;
+
+  final bool isOutgoing;
+
+  final QaulChatBubbleMessage? qaulBubbleBaseWithoutLayout;
+
+  bool get isGroupIncomingEligible =>
+      !isOutgoing &&
+      senderIdBase58.isNotEmpty;
+}
+
+@immutable
+class MessagePresentationMeta {
+  const MessagePresentationMeta({
+    required this.linksToPrevious,
+    required this.linksToNext,
+    required this.showAvatar,
+    required this.showSenderName,
+    required this.showTimestamp,
+    required this.tailEdges,
+    required this.topSpacing,
+    required this.legacyBubbleClustersWithNext,
+  });
+
+  final bool linksToPrevious;
+
+  final bool linksToNext;
+
+  final bool showAvatar;
+
+  final bool showSenderName;
+
+  final bool showTimestamp;
+
+  final List<TailEdge> tailEdges;
+
+  final double topSpacing;
+
+  final bool legacyBubbleClustersWithNext;
+}
+
+@immutable
+class MessagePresentationComputation {
+  const MessagePresentationComputation({
+    required this.meta,
+    required this.textDisplay,
+    required this.isPrimary,
+  });
+
+  final MessagePresentationMeta meta;
+  final QaulChatBubbleDisplayItem? textDisplay;
+  final bool isPrimary;
+}

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -67,6 +67,9 @@ class QaulChatBubbleMessage extends ChatMessage {
     required this.edges,
     this.clock,
     this.showTimestamp = true,
+    this.senderIdBase58,
+    this.senderDisplayName,
+    this.senderDisplayNameColor,
   });
 
   final String content;
@@ -77,6 +80,9 @@ class QaulChatBubbleMessage extends ChatMessage {
   final List<TailEdge> edges;
   final DateTime? clock;
   final bool showTimestamp;
+  final String? senderIdBase58;
+  final String? senderDisplayName;
+  final Color? senderDisplayNameColor;
 
   QaulChatBubbleMessage copyWith({
     Key? key,
@@ -88,6 +94,9 @@ class QaulChatBubbleMessage extends ChatMessage {
     List<TailEdge>? edges,
     DateTime? clock,
     bool? showTimestamp,
+    String? senderIdBase58,
+    String? senderDisplayName,
+    Color? senderDisplayNameColor,
   }) {
     return QaulChatBubbleMessage(
       key: key ?? this.key,
@@ -99,6 +108,10 @@ class QaulChatBubbleMessage extends ChatMessage {
       edges: edges ?? this.edges,
       clock: clock ?? this.clock,
       showTimestamp: showTimestamp ?? this.showTimestamp,
+      senderIdBase58: senderIdBase58 ?? this.senderIdBase58,
+      senderDisplayName: senderDisplayName ?? this.senderDisplayName,
+      senderDisplayNameColor:
+          senderDisplayNameColor ?? this.senderDisplayNameColor,
     );
   }
 
@@ -301,16 +314,15 @@ class QaulChatBubble extends StatelessWidget {
                     ],
                   );
 
+                  Widget messageContent;
                   if (!showTimestamp) {
-                    return RichText(
+                    messageContent = RichText(
                       textAlign: TextAlign.left,
                       textWidthBasis: TextWidthBasis.longestLine,
                       text: messageSpan,
                     );
-                  }
-
-                  if (fitsOnOneLine) {
-                    return Row(
+                  } else if (fitsOnOneLine) {
+                    messageContent = Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       mainAxisSize: MainAxisSize.min,
                       children: [
@@ -325,23 +337,51 @@ class QaulChatBubble extends StatelessWidget {
                         timeRow,
                       ],
                     );
+                  } else {
+                    messageContent = Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: isPrimary
+                          ? CrossAxisAlignment.end
+                          : CrossAxisAlignment.start,
+                      children: [
+                        RichText(
+                          textAlign: TextAlign.left,
+                          textWidthBasis: TextWidthBasis.longestLine,
+                          text: messageSpan,
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: gap),
+                          child: timeRow,
+                        ),
+                      ],
+                    );
+                  }
+
+                  if (message.senderDisplayName == null ||
+                      message.senderDisplayName!.isEmpty) {
+                    return messageContent;
                   }
 
                   return Column(
                     mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: isPrimary
-                        ? CrossAxisAlignment.end
-                        : CrossAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      RichText(
-                        textAlign: TextAlign.left,
-                        textWidthBasis: TextWidthBasis.longestLine,
-                        text: messageSpan,
-                      ),
                       Padding(
-                        padding: const EdgeInsets.only(top: gap),
-                        child: timeRow,
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Text(
+                          message.senderDisplayName!,
+                          style: TextStyle(
+                            fontFamily: 'Roboto',
+                            fontSize: 11,
+                            fontWeight: FontWeight.w400,
+                            height: 1.25,
+                            letterSpacing: 0.5,
+                            color: message.senderDisplayNameColor ??
+                                Colors.white.withValues(alpha: 0.85),
+                          ),
+                        ),
                       ),
+                      messageContent,
                     ],
                   );
                 },
@@ -379,6 +419,14 @@ class QaulChatBubbleDisplayItem {
 
 bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
   if (a.messageType != b.messageType) return false;
+
+  // When sender information is available, only link bubbles from the
+  // same sender; this is important for group chats.
+  if (a.senderIdBase58 != null &&
+      b.senderIdBase58 != null &&
+      a.senderIdBase58 != b.senderIdBase58) {
+    return false;
+  }
 
   final ta = a.sentAt;
   final tb = b.sentAt;

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -375,12 +375,7 @@ class QaulChatBubble extends StatelessWidget {
                         padding: const EdgeInsets.only(bottom: 4),
                         child: Text(
                           message.senderDisplayName!,
-                          style: TextStyle(
-                            fontFamily: 'Roboto',
-                            fontSize: 11,
-                            fontWeight: FontWeight.w400,
-                            height: 1.25,
-                            letterSpacing: 0.5,
+                          style: kGroupSenderNameTextStyle.copyWith(
                             color: message.senderDisplayNameColor ??
                                 Colors.white.withValues(alpha: 0.85),
                           ),
@@ -408,6 +403,14 @@ const double kChatBubbleLinkedGap = 4.0;
 const double kChatBubbleSeparatedGap = 12.0;
 
 const double kGroupChatBubbleSeparatedGap = 4.0;
+
+const TextStyle kGroupSenderNameTextStyle = TextStyle(
+  fontFamily: 'Roboto',
+  fontSize: 11,
+  fontWeight: FontWeight.w400,
+  height: 1.25,
+  letterSpacing: 0.5,
+);
 
 class QaulChatBubbleDisplayItem {
   const QaulChatBubbleDisplayItem({

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -403,13 +403,10 @@ class QaulChatBubble extends StatelessWidget {
 // Display item & layout constants
 // ---------------------------------------------------------------------------
 
-/// Vertical gap between bubbles in the same merged run (same minute, same side).
 const double kChatBubbleLinkedGap = 4.0;
 
-/// Vertical gap when the previous bubble is **not** linked (different time burst) — 1:1.
 const double kChatBubbleSeparatedGap = 12.0;
 
-/// Same as [kChatBubbleSeparatedGap] but for group rooms (tighter list rhythm).
 const double kGroupChatBubbleSeparatedGap = 4.0;
 
 class QaulChatBubbleDisplayItem {
@@ -428,10 +425,6 @@ class QaulChatBubbleDisplayItem {
 // Public helpers
 // ---------------------------------------------------------------------------
 
-/// Bubbles share a merged run (connected tails) when they are on the same side
-/// and fall in the same calendar **minute** (sender ids must match when both
-/// present). Same rule for 1:1 and group; spacing between **unlinked** rows is
-/// the only difference — see [computeChatBubbleDisplayItems].
 bool directChatBubblesShareMinute(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
   if (a.messageType != b.messageType) return false;
 
@@ -455,57 +448,11 @@ bool directChatBubblesShareMinute(QaulChatBubbleMessage a, QaulChatBubbleMessage
 bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) =>
     directChatBubblesShareMinute(a, b);
 
-List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
-  List<QaulChatBubbleMessage> messages, {
-  ChatRenderMode layoutMode = ChatRenderMode.direct,
-}) {
-  if (messages.isEmpty) return [];
-
-  final separatedGap = layoutMode == ChatRenderMode.group
-      ? kGroupChatBubbleSeparatedGap
-      : kChatBubbleSeparatedGap;
-
-  final result = <QaulChatBubbleDisplayItem>[];
-
-  for (var i = 0; i < messages.length; i++) {
-    final prev = i > 0 ? messages[i - 1] : null;
-    final curr = messages[i];
-    final next = i < messages.length - 1 ? messages[i + 1] : null;
-
-    final prevLinked =
-        prev != null && directChatBubblesShareMinute(prev, curr);
-    final nextLinked =
-        next != null && directChatBubblesShareMinute(curr, next);
-
-    final isPrimary = curr.messageType == MessageType.primary;
-
-    final edges = isPrimary
-        ? _edgesForPrimary(prevLinked, nextLinked)
-        : _edgesForSecondary(prevLinked, nextLinked);
-
-    final showTimestamp = !nextLinked;
-
-    final marginTop = i == 0
-        ? 0.0
-        : (prevLinked ? kChatBubbleLinkedGap : separatedGap);
-
-    result.add(
-      QaulChatBubbleDisplayItem(
-        message: curr.copyWith(edges: edges),
-        showTimestamp: showTimestamp,
-        marginTop: marginTop,
-      ),
-    );
-  }
-
-  return result;
-}
-
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
 
-List<TailEdge> _edgesForPrimary(bool hasPreviousLinked, bool hasNextLinked) {
+List<TailEdge> tailEdgesForPrimary(bool hasPreviousLinked, bool hasNextLinked) {
   if (!hasPreviousLinked && !hasNextLinked) return const [TailEdge.bottomEnd];
 
   if (hasPreviousLinked && hasNextLinked) {
@@ -517,7 +464,7 @@ List<TailEdge> _edgesForPrimary(bool hasPreviousLinked, bool hasNextLinked) {
   return const [TailEdge.topEnd];
 }
 
-List<TailEdge> _edgesForSecondary(bool hasPreviousLinked, bool hasNextLinked) {
+List<TailEdge> tailEdgesForSecondary(bool hasPreviousLinked, bool hasNextLinked) {
   if (!hasPreviousLinked && !hasNextLinked) {
     return const [TailEdge.bottomStart];
   }

--- a/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/widgets/qaul_chat_bubble.dart
@@ -12,6 +12,11 @@ enum MessageStatus { notSent, sent, read }
 
 enum MessageType { primary, secondary }
 
+/// Selects vertical spacing between **non-linked** bubbles only.
+/// Tail shapes, timestamps, and “linked minute” rules are identical for both
+/// modes — see [directChatBubblesShareMinute].
+enum ChatRenderMode { direct, group }
+
 // ---------------------------------------------------------------------------
 // Public constants & style
 // ---------------------------------------------------------------------------
@@ -398,8 +403,14 @@ class QaulChatBubble extends StatelessWidget {
 // Display item & layout constants
 // ---------------------------------------------------------------------------
 
+/// Vertical gap between bubbles in the same merged run (same minute, same side).
 const double kChatBubbleLinkedGap = 4.0;
+
+/// Vertical gap when the previous bubble is **not** linked (different time burst) — 1:1.
 const double kChatBubbleSeparatedGap = 12.0;
+
+/// Same as [kChatBubbleSeparatedGap] but for group rooms (tighter list rhythm).
+const double kGroupChatBubbleSeparatedGap = 4.0;
 
 class QaulChatBubbleDisplayItem {
   const QaulChatBubbleDisplayItem({
@@ -417,11 +428,13 @@ class QaulChatBubbleDisplayItem {
 // Public helpers
 // ---------------------------------------------------------------------------
 
-bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
+/// Bubbles share a merged run (connected tails) when they are on the same side
+/// and fall in the same calendar **minute** (sender ids must match when both
+/// present). Same rule for 1:1 and group; spacing between **unlinked** rows is
+/// the only difference — see [computeChatBubbleDisplayItems].
+bool directChatBubblesShareMinute(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
   if (a.messageType != b.messageType) return false;
 
-  // When sender information is available, only link bubbles from the
-  // same sender; this is important for group chats.
   if (a.senderIdBase58 != null &&
       b.senderIdBase58 != null &&
       a.senderIdBase58 != b.senderIdBase58) {
@@ -438,10 +451,19 @@ bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
       ta.minute == tb.minute;
 }
 
+/// Alias for [directChatBubblesShareMinute] (historical name).
+bool isChatBubbleLinked(QaulChatBubbleMessage a, QaulChatBubbleMessage b) =>
+    directChatBubblesShareMinute(a, b);
+
 List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
-  List<QaulChatBubbleMessage> messages,
-) {
+  List<QaulChatBubbleMessage> messages, {
+  ChatRenderMode layoutMode = ChatRenderMode.direct,
+}) {
   if (messages.isEmpty) return [];
+
+  final separatedGap = layoutMode == ChatRenderMode.group
+      ? kGroupChatBubbleSeparatedGap
+      : kChatBubbleSeparatedGap;
 
   final result = <QaulChatBubbleDisplayItem>[];
 
@@ -450,8 +472,10 @@ List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
     final curr = messages[i];
     final next = i < messages.length - 1 ? messages[i + 1] : null;
 
-    final prevLinked = prev != null && isChatBubbleLinked(prev, curr);
-    final nextLinked = next != null && isChatBubbleLinked(curr, next);
+    final prevLinked =
+        prev != null && directChatBubblesShareMinute(prev, curr);
+    final nextLinked =
+        next != null && directChatBubblesShareMinute(curr, next);
 
     final isPrimary = curr.messageType == MessageType.primary;
 
@@ -463,7 +487,7 @@ List<QaulChatBubbleDisplayItem> computeChatBubbleDisplayItems(
 
     final marginTop = i == 0
         ? 0.0
-        : (prevLinked ? kChatBubbleLinkedGap : kChatBubbleSeparatedGap);
+        : (prevLinked ? kChatBubbleLinkedGap : separatedGap);
 
     result.add(
       QaulChatBubbleDisplayItem(

--- a/qaul_ui/packages/qaul_components/pubspec.yaml
+++ b/qaul_ui/packages/qaul_components/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   badges: ^3.1.2
   flutter_svg: ^2.2.3
+  utils: { "path": "../utils" }
 
 dev_dependencies:
   flutter_test:

--- a/qaul_ui/packages/qaul_components/test/compute_message_presentation_test.dart
+++ b/qaul_ui/packages/qaul_components/test/compute_message_presentation_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+void main() {
+  group('computeChatMessagePresentation', () {
+    test('group texts: same sender same day stays 4px even when minutes differ',
+        () {
+      final t1 = DateTime(2026, 4, 19, 8, 9);
+      final t2 = DateTime(2026, 4, 19, 23, 39);
+      final m0 = QaulChatBubbleMessage(
+        content: 'a',
+        sentAt: t1,
+        receivedAt: t1,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'tm',
+      );
+      final m1 = QaulChatBubbleMessage(
+        content: 'b',
+        sentAt: t2,
+        receivedAt: t2,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'tm',
+      );
+      final timeline = <ChatTimelinePresentationRow>[
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-0',
+          senderIdBase58: 'tm',
+          sentAt: t1,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: m0,
+        ),
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-1',
+          senderIdBase58: 'tm',
+          sentAt: t2,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: m1,
+        ),
+      ];
+
+      final out = computeChatMessagePresentation(
+        ascendingTimeline: timeline,
+        layoutMode: ChatRenderMode.group,
+      );
+
+      expect(out['id-1']!.meta.linksToPrevious, isFalse,
+          reason: 'different calendar minutes → unlinked tails');
+      expect(out['id-1']!.meta.topSpacing, kChatBubbleLinkedGap,
+          reason: 'same streak (sender + calendar day) → compact gap');
+    });
+
+    test('group incoming: name at streak start, avatar at streak end same day', () {
+      final base = DateTime(2026, 4, 19, 21, 19);
+      final m0 = QaulChatBubbleMessage(
+        content: 'a',
+        sentAt: base,
+        receivedAt: base,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'tm',
+      );
+      final m1 = QaulChatBubbleMessage(
+        content: 'b',
+        sentAt: base,
+        receivedAt: base,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'tm',
+      );
+      final timeline = <ChatTimelinePresentationRow>[
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-0',
+          senderIdBase58: 'tm',
+          sentAt: base,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: m0,
+        ),
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-1',
+          senderIdBase58: 'tm',
+          sentAt: base,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: m1,
+        ),
+      ];
+
+      final out = computeChatMessagePresentation(
+        ascendingTimeline: timeline,
+        layoutMode: ChatRenderMode.group,
+      );
+
+      expect(out['id-0']!.meta.showSenderName, isTrue);
+      expect(out['id-0']!.meta.showAvatar, isFalse);
+      expect(out['id-1']!.meta.showSenderName, isFalse);
+      expect(out['id-1']!.meta.showAvatar, isTrue);
+    });
+
+    test('group incoming: new local calendar day restarts streak', () {
+      final d0 = DateTime(2026, 4, 19, 23, 0);
+      final d1 = DateTime(2026, 4, 20, 1, 0);
+      final m0 = QaulChatBubbleMessage(
+        content: 'a',
+        sentAt: d0,
+        receivedAt: d0,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'tm',
+      );
+      final m1 = QaulChatBubbleMessage(
+        content: 'b',
+        sentAt: d1,
+        receivedAt: d1,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'tm',
+      );
+      final timeline = <ChatTimelinePresentationRow>[
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-0',
+          senderIdBase58: 'tm',
+          sentAt: d0,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: m0,
+        ),
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-1',
+          senderIdBase58: 'tm',
+          sentAt: d1,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: m1,
+        ),
+      ];
+
+      final out = computeChatMessagePresentation(
+        ascendingTimeline: timeline,
+        layoutMode: ChatRenderMode.group,
+      );
+
+      expect(out['id-0']!.meta.showAvatar, isTrue);
+      expect(out['id-1']!.meta.showSenderName, isTrue);
+      expect(out['id-1']!.meta.showAvatar, isTrue);
+    });
+
+    test('non-text sandwiched between same sender does not break streak', () {
+      final t0 = DateTime(2026, 4, 19, 10, 0);
+      final tMid = DateTime(2026, 4, 19, 10, 1);
+      final t2 = DateTime(2026, 4, 19, 10, 2);
+      final text0 = QaulChatBubbleMessage(
+        content: 'a',
+        sentAt: t0,
+        receivedAt: t0,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'alice',
+      );
+      final text1 = QaulChatBubbleMessage(
+        content: 'b',
+        sentAt: t2,
+        receivedAt: t2,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [],
+        senderIdBase58: 'alice',
+      );
+      final timeline = <ChatTimelinePresentationRow>[
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-0',
+          senderIdBase58: 'alice',
+          sentAt: t0,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: text0,
+        ),
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-media',
+          senderIdBase58: 'alice',
+          sentAt: tMid,
+          isText: false,
+          isOutgoing: false,
+        ),
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-1',
+          senderIdBase58: 'alice',
+          sentAt: t2,
+          isText: true,
+          isOutgoing: false,
+          qaulBubbleBaseWithoutLayout: text1,
+        ),
+      ];
+
+      final out = computeChatMessagePresentation(
+        ascendingTimeline: timeline,
+        layoutMode: ChatRenderMode.group,
+      );
+
+      expect(out['id-0']!.meta.showSenderName, isTrue);
+      expect(out['id-0']!.meta.showAvatar, isFalse);
+      expect(out['id-1']!.meta.showSenderName, isFalse);
+      expect(out['id-1']!.meta.showAvatar, isTrue);
+    });
+  });
+}

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -116,8 +116,8 @@ void main() {
     });
 
     test(
-        'group layout: edges and timestamps match direct; only separated '
-        'vertical gap is tighter (4 vs 12)', () {
+        'group layout: edges/timestamps match direct; 4px vertical only for same '
+            'participant streak, 12px when switching me vs others', () {
       final base = DateTime(2026, 4, 19, 19, 23);
 
       final messages = [
@@ -163,8 +163,8 @@ void main() {
 
       expect(directItems[1].marginTop, kChatBubbleSeparatedGap);
       expect(directItems[2].marginTop, kChatBubbleSeparatedGap);
-      expect(groupItems[1].marginTop, kGroupChatBubbleSeparatedGap);
-      expect(groupItems[2].marginTop, kGroupChatBubbleSeparatedGap);
+      expect(groupItems[1].marginTop, kChatBubbleLinkedGap);
+      expect(groupItems[2].marginTop, kChatBubbleSeparatedGap);
     });
   });
 

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -46,7 +46,10 @@ void main() {
         ),
       ];
 
-      final items = computeChatBubbleDisplayItems(messages);
+      final items = computeChatBubbleDisplayItems(
+        messages,
+        layoutMode: ChatRenderMode.direct,
+      );
       expect(items, hasLength(3));
 
       expect(items[0].message.edges, const [TailEdge.bottomEnd]);
@@ -93,7 +96,10 @@ void main() {
         ),
       ];
 
-      final items = computeChatBubbleDisplayItems(messages);
+      final items = computeChatBubbleDisplayItems(
+        messages,
+        layoutMode: ChatRenderMode.direct,
+      );
       expect(items, hasLength(3));
 
       expect(items[0].message.edges, const [TailEdge.bottomEnd]);
@@ -107,6 +113,58 @@ void main() {
       expect(items[0].marginTop, 0.0);
       expect(items[1].marginTop, kChatBubbleSeparatedGap);
       expect(items[2].marginTop, kChatBubbleSeparatedGap);
+    });
+
+    test(
+        'group layout: edges and timestamps match direct; only separated '
+        'vertical gap is tighter (4 vs 12)', () {
+      final base = DateTime(2026, 4, 19, 19, 23);
+
+      final messages = [
+        QaulChatBubbleMessage(
+          content: 'primary',
+          sentAt: base,
+          receivedAt: base,
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'primary later',
+          sentAt: base.add(const Duration(minutes: 1)),
+          receivedAt: base.add(const Duration(minutes: 1)),
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        ),
+        QaulChatBubbleMessage(
+          content: 'secondary same minute as second',
+          sentAt: base.add(const Duration(minutes: 1)),
+          receivedAt: base.add(const Duration(minutes: 1)),
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
+        ),
+      ];
+
+      final directItems = computeChatBubbleDisplayItems(
+        messages,
+        layoutMode: ChatRenderMode.direct,
+      );
+      final groupItems = computeChatBubbleDisplayItems(
+        messages,
+        layoutMode: ChatRenderMode.group,
+      );
+
+      for (var i = 0; i < 3; i++) {
+        expect(groupItems[i].message.edges, directItems[i].message.edges);
+        expect(groupItems[i].showTimestamp, directItems[i].showTimestamp);
+      }
+
+      expect(directItems[1].marginTop, kChatBubbleSeparatedGap);
+      expect(directItems[2].marginTop, kChatBubbleSeparatedGap);
+      expect(groupItems[1].marginTop, kGroupChatBubbleSeparatedGap);
+      expect(groupItems[2].marginTop, kGroupChatBubbleSeparatedGap);
     });
   });
 

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -14,6 +14,8 @@ import 'package:qaul_components_widgetbook/use_cases/chat_header.dart'
     as _qaul_components_widgetbook_use_cases_chat_header;
 import 'package:qaul_components_widgetbook/use_cases/chat_room.dart'
     as _qaul_components_widgetbook_use_cases_chat_room;
+import 'package:qaul_components_widgetbook/use_cases/group_chat.dart'
+    as _qaul_components_widgetbook_use_cases_group_chat;
 import 'package:qaul_components_widgetbook/use_cases/qaul_chat_bubble.dart'
     as _qaul_components_widgetbook_use_cases_qaul_chat_bubble;
 import 'package:qaul_components_widgetbook/use_cases/qaul_color_sheet.dart'
@@ -82,6 +84,11 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Conversation preview',
             builder: _qaul_components_widgetbook_use_cases_qaul_chat_bubble
                 .buildChatBubbleConversationUseCase,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Group Chat',
+            builder: _qaul_components_widgetbook_use_cases_group_chat
+                .buildGroupChatUseCase,
           ),
         ],
       ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+import 'group_chat_preview.dart';
+
+final _groupPreviewClock = DateTime(2026, 4, 18, 22, 30);
+
+@widgetbook.UseCase(name: 'Group Chat', type: QaulChatBubble)
+Widget buildGroupChatUseCase(BuildContext context) {
+  return Container(
+    padding: const EdgeInsets.all(16),
+    child: Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 500),
+        child: GroupChatPreview(
+          clock: _groupPreviewClock,
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+        ),
+      ),
+    ),
+  );
+}
+

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat.dart
@@ -9,13 +9,16 @@ final _groupPreviewClock = DateTime(2026, 4, 18, 22, 30);
 @widgetbook.UseCase(name: 'Group Chat', type: QaulChatBubble)
 Widget buildGroupChatUseCase(BuildContext context) {
   return Container(
+    color: Colors.black,
     padding: const EdgeInsets.all(16),
     child: Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 500),
         child: GroupChatPreview(
           clock: _groupPreviewClock,
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+          surfaceColor: Colors.black,
+          dateLabelColor: Colors.white.withValues(alpha: 0.7),
+          padding: EdgeInsets.zero,
         ),
       ),
     ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat_preview.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat_preview.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+List<QaulChatBubbleMessage> buildGroupPreviewRawMessages(DateTime clock) {
+  final today = DateTime(clock.year, clock.month, clock.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+
+  return [
+    QaulChatBubbleMessage(
+      content: 'Hello in 16px 300 font',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+      senderIdBase58: 'me',
+    ),
+    QaulChatBubbleMessage(
+      content:
+          'This is a longer message with no own timestamp followed by another message with timestamp',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.sent,
+      messageType: MessageType.primary,
+      edges: const [],
+      senderIdBase58: 'me',
+    ),
+    QaulChatBubbleMessage(
+      content: 'This one is it',
+      sentAt: yesterday.copyWith(hour: 16, minute: 13),
+      receivedAt: yesterday.copyWith(hour: 16, minute: 13),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+      senderIdBase58: 'me',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Chatpartner is answering',
+      sentAt: yesterday.copyWith(hour: 18, minute: 9),
+      receivedAt: yesterday.copyWith(hour: 18, minute: 9),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-gm',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Another answer',
+      sentAt: yesterday.copyWith(hour: 18, minute: 29),
+      receivedAt: yesterday.copyWith(hour: 18, minute: 29),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-g2',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Message',
+      sentAt: yesterday.copyWith(hour: 19, minute: 23),
+      receivedAt: yesterday.copyWith(hour: 19, minute: 23),
+      status: MessageStatus.read,
+      messageType: MessageType.primary,
+      edges: const [],
+      senderIdBase58: 'me',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Longer message from the chatpartner',
+      sentAt: yesterday.copyWith(hour: 21, minute: 19),
+      receivedAt: yesterday.copyWith(hour: 21, minute: 19),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-tm',
+    ),
+    QaulChatBubbleMessage(
+      content: 'followed by one with time',
+      sentAt: yesterday.copyWith(hour: 21, minute: 19),
+      receivedAt: yesterday.copyWith(hour: 21, minute: 19),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-tm',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Message with delay',
+      sentAt: yesterday.copyWith(hour: 22, minute: 14),
+      receivedAt: today.copyWith(hour: 12, minute: 30),
+      status: MessageStatus.read,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-tm',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Written in the morning',
+      sentAt: today.copyWith(hour: 8, minute: 9),
+      receivedAt: today.copyWith(hour: 8, minute: 9),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-tm',
+    ),
+    QaulChatBubbleMessage(
+      content: 'Followed by one late night',
+      sentAt: today.copyWith(hour: 23, minute: 39),
+      receivedAt: today.copyWith(hour: 23, minute: 39),
+      status: MessageStatus.sent,
+      messageType: MessageType.secondary,
+      edges: const [],
+      senderIdBase58: 'user-tm',
+    ),
+  ];
+}
+
+const _previewSenders = <String, QaulGroupMessageSender>{
+  'user-gm': QaulGroupMessageSender(
+    idBase58: 'user-gm',
+    name: 'Group Member',
+    isConnected: true,
+  ),
+  'user-g2': QaulGroupMessageSender(
+    idBase58: 'user-g2',
+    name: 'Groupmember 2',
+    isConnected: true,
+  ),
+  'user-tm': QaulGroupMessageSender(
+    idBase58: 'user-tm',
+    name: 'Third Member',
+    isConnected: true,
+  ),
+};
+
+Widget _groupPreviewTextRow({
+  required List<QaulChatBubbleDisplayItem> items,
+  required int index,
+  required DateTime clock,
+}) {
+  final item = items[index];
+  final isPrimary = item.message.messageType == MessageType.primary;
+  final senderId = item.message.senderIdBase58;
+  final sender =
+      isPrimary ? null : (senderId == null ? null : _previewSenders[senderId]);
+
+  return ChatMessageRenderer.renderText(
+    presentation: MessagePresentation.forSequentialTextBubble(
+      item: item,
+      index: index,
+      items: items,
+      isPrimary: isPrimary,
+      sender: sender,
+    ),
+    mode: ChatRenderMode.group,
+    clock: clock,
+  );
+}
+
+class GroupChatPreview extends StatelessWidget {
+  const GroupChatPreview({
+    super.key,
+    required this.clock,
+    this.padding = const EdgeInsets.fromLTRB(16, 16, 16, 24),
+  });
+
+  final DateTime clock;
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final messages = buildGroupPreviewRawMessages(clock);
+    final items = computeChatBubbleDisplayItems(messages);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final background = isDark
+        ? Colors.black
+        : Theme.of(context).colorScheme.surfaceContainerHighest;
+    final dateColor = isDark ? Colors.white70 : Colors.black54;
+
+    return ColoredBox(
+      color: background,
+      child: Padding(
+        padding: padding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var i = 0; i < items.length; i++) ...[
+              if (items[i].message.content == 'Written in the morning')
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  child: Center(
+                    child: Text(
+                      'Saturday, April 18, 2026',
+                      style: TextStyle(
+                        fontSize: 12,
+                        height: 1.2,
+                        color: dateColor,
+                      ),
+                    ),
+                  ),
+                ),
+              _groupPreviewTextRow(
+                items: items,
+                index: i,
+                clock: clock,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat_preview.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat_preview.dart
@@ -164,7 +164,10 @@ class GroupChatPreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final messages = buildGroupPreviewRawMessages(clock);
-    final items = computeChatBubbleDisplayItems(messages);
+    final items = computeChatBubbleDisplayItems(
+      messages,
+      layoutMode: ChatRenderMode.group,
+    );
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final background = isDark
         ? Colors.black

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat_preview.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/group_chat_preview.dart
@@ -128,23 +128,23 @@ const _previewSenders = <String, QaulGroupMessageSender>{
 };
 
 Widget _groupPreviewTextRow({
-  required List<QaulChatBubbleDisplayItem> items,
+  required Map<String, MessagePresentationComputation> computed,
+  required List<QaulChatBubbleMessage> raw,
   required int index,
   required DateTime clock,
 }) {
-  final item = items[index];
-  final isPrimary = item.message.messageType == MessageType.primary;
-  final senderId = item.message.senderIdBase58;
+  final id = 'preview-$index';
+  final m = raw[index];
+  final isPrimary = m.messageType == MessageType.primary;
+  final senderId = m.senderIdBase58;
   final sender =
       isPrimary ? null : (senderId == null ? null : _previewSenders[senderId]);
 
   return ChatMessageRenderer.renderText(
-    presentation: MessagePresentation.forSequentialTextBubble(
-      item: item,
-      index: index,
-      items: items,
-      isPrimary: isPrimary,
+    presentation: MessagePresentation.fromComputation(
+      messageId: id,
       sender: sender,
+      computation: computed[id]!,
     ),
     mode: ChatRenderMode.group,
     clock: clock,
@@ -155,24 +155,45 @@ class GroupChatPreview extends StatelessWidget {
   const GroupChatPreview({
     super.key,
     required this.clock,
-    this.padding = const EdgeInsets.fromLTRB(16, 16, 16, 24),
+    this.padding = EdgeInsets.zero,
+    this.surfaceColor,
+    this.dateLabelColor,
   });
 
   final DateTime clock;
   final EdgeInsets padding;
 
+  /// When set (e.g. Widgetbook), replaces theme-based chat background.
+  final Color? surfaceColor;
+
+  /// When set, replaces theme-based date divider text color.
+  final Color? dateLabelColor;
+
   @override
   Widget build(BuildContext context) {
     final messages = buildGroupPreviewRawMessages(clock);
-    final items = computeChatBubbleDisplayItems(
-      messages,
+    final ascendingRows = <ChatTimelinePresentationRow>[
+      for (var i = 0; i < messages.length; i++)
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'preview-$i',
+          senderIdBase58: messages[i].senderIdBase58 ?? '',
+          sentAt: messages[i].sentAt,
+          isText: true,
+          isOutgoing: messages[i].messageType == MessageType.primary,
+          qaulBubbleBaseWithoutLayout: messages[i].copyWith(edges: const []),
+        ),
+    ];
+    final computed = computeChatMessagePresentation(
+      ascendingTimeline: ascendingRows,
       layoutMode: ChatRenderMode.group,
     );
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final background = isDark
-        ? Colors.black
-        : Theme.of(context).colorScheme.surfaceContainerHighest;
-    final dateColor = isDark ? Colors.white70 : Colors.black54;
+    final background = surfaceColor ??
+        (isDark
+            ? Colors.black
+            : Theme.of(context).colorScheme.surfaceContainerHighest);
+    final dateColor = dateLabelColor ??
+        (isDark ? Colors.white70 : Colors.black54);
 
     return ColoredBox(
       color: background,
@@ -181,8 +202,9 @@ class GroupChatPreview extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            for (var i = 0; i < items.length; i++) ...[
-              if (items[i].message.content == 'Written in the morning')
+            const SizedBox(height: 16),
+            for (var i = 0; i < messages.length; i++) ...[
+              if (messages[i].content == 'Written in the morning')
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 16),
                   child: Center(
@@ -197,7 +219,8 @@ class GroupChatPreview extends StatelessWidget {
                   ),
                 ),
               _groupPreviewTextRow(
-                items: items,
+                computed: computed,
+                raw: messages,
                 index: i,
                 clock: clock,
               ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/qaul_chat_bubble.dart
@@ -20,6 +20,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.read,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content:
@@ -29,6 +30,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.sent,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content: 'This one is it',
@@ -37,6 +39,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.read,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content: 'Chatpartner is answering',
@@ -45,6 +48,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.sent,
       messageType: MessageType.secondary,
       edges: const [],
+      senderIdBase58: 'user-gm',
     ),
     QaulChatBubbleMessage(
       content: 'Another answer',
@@ -53,6 +57,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.sent,
       messageType: MessageType.secondary,
       edges: const [],
+      senderIdBase58: 'user-g2',
     ),
     QaulChatBubbleMessage(
       content: 'Message',
@@ -61,6 +66,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.read,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content: 'Longer message from the chatpartner',
@@ -69,6 +75,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.sent,
       messageType: MessageType.secondary,
       edges: const [],
+      senderIdBase58: 'user-gm',
     ),
     QaulChatBubbleMessage(
       content: 'followed by one with time',
@@ -77,6 +84,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.sent,
       messageType: MessageType.secondary,
       edges: const [],
+      senderIdBase58: 'user-gm',
     ),
     QaulChatBubbleMessage(
       content: 'Message with delay',
@@ -87,6 +95,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.read,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content: 'Out and delivered',
@@ -95,6 +104,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.read,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content: 'Out but not delivered yet',
@@ -103,6 +113,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.sent,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
     QaulChatBubbleMessage(
       content: 'New Message not out',
@@ -111,6 +122,7 @@ Widget buildChatBubbleConversationUseCase(BuildContext context) {
       status: MessageStatus.notSent,
       messageType: MessageType.primary,
       edges: const [],
+      senderIdBase58: 'me',
     ),
   ];
 


### PR DESCRIPTION
## Description

This PR Implements the new UI for chat group names.

It also refactors chat message presentation so layout, spacing, tails, timestamps, and group sender chrome are derived from a single timeline-aware solution instead of ad hoc logic split across the chat screen and bubble helpers.

## Evidence
<img width="1356" height="822" alt="Screenshot 2026-05-06 at 20 48 48" src="https://github.com/user-attachments/assets/82281b8e-6622-4ea6-abe0-6e726cf04a9d" />
