### PR TITLE
Fix wierd chat rooms popping

### DIFF
--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room_list_notifier.dart
@@ -16,13 +16,46 @@ class ChatRoomListNotifier extends Notifier<List<ChatRoom>> {
 
   void add(ChatRoom room) => state = [room, ...state];
 
+  void mergeOrderedFromBackend(List<ChatRoom> rooms) {
+    final currentById = {for (final r in state) r.idBase58: r};
+    final backendIds = rooms.map((r) => r.idBase58).toSet();
+    final mergedOrdered = rooms.map((room) {
+      final existing = currentById[room.idBase58];
+      final isPartialUpdate = room.messages == null && existing?.messages != null;
+      if (!isPartialUpdate) return room;
+      return room.copyWith(
+        lastMessageIndex: existing!.lastMessageIndex,
+        messages: existing.messages,
+      );
+    }).toList();
+
+    final remaining = state.where((r) => !backendIds.contains(r.idBase58));
+    state = [...mergedOrdered, ...remaining];
+  }
+
+  void replacePreservingOrder(ChatRoom room) {
+    assert(contains(room), 'State does not contain room $room');
+    final existingIndex = state.indexWhere((r) => r.idBase58 == room.idBase58);
+    if (existingIndex < 0) return;
+    final existing = state[existingIndex];
+    final isPartialUpdate = room.messages == null && existing.messages != null;
+    final merged = isPartialUpdate
+        ? room.copyWith(
+            lastMessageIndex: existing.lastMessageIndex,
+            messages: existing.messages,
+          )
+        : room;
+    final next = [...state];
+    next[existingIndex] = merged;
+    state = next;
+  }
+
   void update(ChatRoom room) {
     assert(contains(room), 'State does not contain room $room');
     final existing = state.firstWhere((r) => r.idBase58 == room.idBase58);
 
     final isPartialUpdate = room.messages == null && existing.messages != null;
 
-    // if room only has metadata updates, keep the existing messages
     final merged = isPartialUpdate
         ? room.copyWith(
             lastMessageIndex: existing.lastMessageIndex,

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/chat_translator.dart
@@ -35,7 +35,9 @@ class ChatTranslator extends RpcModuleTranslator {
 
       final merged = source.copyWithMessages(res.data);
 
-      if (room != null) state.update(merged);
+      if (room != null) {
+        state.replacePreservingOrder(merged);
+      }
 
       if (isOpenRoom) {
         currentOpenRoom.state = merged;

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/group_translator.dart
@@ -102,13 +102,7 @@ class GroupTranslator extends RpcModuleTranslator {
         state.append(paginated.rooms);
         return;
       }
-      for (final room in paginated.rooms) {
-        if (!state.contains(room)) {
-          state.add(room);
-        } else {
-          state.update(room);
-        }
-      }
+      state.mergeOrderedFromBackend(paginated.rooms);
       return;
     } else if (res.data is ChatRoom) {
       if (!state.contains(res.data)) {


### PR DESCRIPTION
## Description
During the last QA session we saw that the chats were popping while being selected, this PR fixes this behaviour and normalize the chat selection letting the backend decide which one is at the top or not.

## Evidence

https://github.com/user-attachments/assets/8dc66eca-c7d8-4050-a6a6-64118cefa2d6

