### PR TITLE
qauld-ctl: analytics dashboard

### DIFF
--- a/protobuf/generated/rust/qaul.rpc.subscribe.rs
+++ b/protobuf/generated/rust/qaul.rpc.subscribe.rs
@@ -69,16 +69,24 @@ pub struct DtnDeliveryResponseEvent {
     #[prost(uint32, tag = "4")]
     pub reason: u32,
 }
-/// Payload for `topic = "peers.connected"`.
+/// Payload for `topic = "peers.connected"` and `topic =
+/// "peers.disconnected"`.
 ///
-/// Emitted the first time a peer becomes a routing neighbour on a given
-/// transport. Subsequent pings on the same transport do not refire.
+/// `peers.connected` is emitted the first time a peer becomes a
+/// routing neighbour on a given transport. Subsequent pings on the
+/// same transport do not refire.
+///
+/// `peers.disconnected` is emitted when a previously-known neighbour
+/// is dropped from a transport's neighbour set (staleness prune or
+/// explicit `ConnectionClosed`). NOTE: the topic + emitter exist as
+/// of this revision but libqaul does not yet call the emitter from
+/// any prune site — the prune-policy decision (staleness threshold,
+/// per-transport vs global) is still pending. Subscribers may bind
+/// the topic now; they'll start receiving events as soon as the
+/// prune call sites land.
 ///
 /// `module` mirrors `qaul.connections.ConnectionModule`:
 /// 0 = Local, 1 = Lan, 2 = Internet, 3 = Ble, 4 = None.
-///
-/// A `peers.disconnected` companion topic is reserved for a future PR
-/// once libqaul actually prunes stale neighbours from the routing table.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PeerEvent {
     #[prost(bytes = "vec", tag = "1")]

--- a/protobuf/proto_definitions/rpc/subscribe.proto
+++ b/protobuf/proto_definitions/rpc/subscribe.proto
@@ -55,16 +55,24 @@ message DtnDeliveryResponseEvent {
     uint32 reason = 4;
 }
 
-// Payload for `topic = "peers.connected"`.
+// Payload for `topic = "peers.connected"` and `topic =
+// "peers.disconnected"`.
 //
-// Emitted the first time a peer becomes a routing neighbour on a given
-// transport. Subsequent pings on the same transport do not refire.
+// `peers.connected` is emitted the first time a peer becomes a
+// routing neighbour on a given transport. Subsequent pings on the
+// same transport do not refire.
+//
+// `peers.disconnected` is emitted when a previously-known neighbour
+// is dropped from a transport's neighbour set (staleness prune or
+// explicit `ConnectionClosed`). NOTE: the topic + emitter exist as
+// of this revision but libqaul does not yet call the emitter from
+// any prune site — the prune-policy decision (staleness threshold,
+// per-transport vs global) is still pending. Subscribers may bind
+// the topic now; they'll start receiving events as soon as the
+// prune call sites land.
 //
 // `module` mirrors `qaul.connections.ConnectionModule`:
 // 0 = Local, 1 = Lan, 2 = Internet, 3 = Ble, 4 = None.
-//
-// A `peers.disconnected` companion topic is reserved for a future PR
-// once libqaul actually prunes stale neighbours from the routing table.
 message PeerEvent {
     bytes peer_id = 1;
     uint32 module = 2;

--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -5,12 +5,18 @@
 
 use std::collections::VecDeque;
 
+use crate::data::{DtnConfig, DtnState, EventLine};
+
 const MAX_EVENTS: usize = 200;
+const MAX_DTN_EVENTS: usize = 100;
+/// Width of the unconfirmed-count sparkline (number of samples kept).
+pub const UNCONFIRMED_HISTORY: usize = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
     Users,
     Feed,
+    Dtn,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +53,12 @@ pub struct App {
     pub users: Vec<UserRow>,
     pub feed: Vec<FeedRow>,
     pub events: VecDeque<String>,
+    pub dtn_state: Option<DtnState>,
+    pub dtn_config: Option<DtnConfig>,
+    pub dtn_events: VecDeque<String>,
+    /// Rolling samples of `unconfirmed_count` taken once per refresh,
+    /// oldest → newest. Capped at [`UNCONFIRMED_HISTORY`].
+    pub dtn_unconfirmed_history: VecDeque<u64>,
     tab: Tab,
     pub cursor: usize,
     pub input_mode: InputMode,
@@ -61,6 +73,10 @@ impl App {
             users: Vec::new(),
             feed: Vec::new(),
             events: VecDeque::new(),
+            dtn_state: None,
+            dtn_config: None,
+            dtn_events: VecDeque::new(),
+            dtn_unconfirmed_history: VecDeque::new(),
             tab: Tab::Users,
             cursor: 0,
             input_mode: InputMode::Normal,
@@ -75,13 +91,19 @@ impl App {
     pub fn next_tab(&mut self) {
         self.tab = match self.tab {
             Tab::Users => Tab::Feed,
-            Tab::Feed => Tab::Users,
+            Tab::Feed => Tab::Dtn,
+            Tab::Dtn => Tab::Users,
         };
         self.cursor = 0;
     }
 
     pub fn prev_tab(&mut self) {
-        self.next_tab(); // only two tabs, same as next
+        self.tab = match self.tab {
+            Tab::Users => Tab::Dtn,
+            Tab::Feed => Tab::Users,
+            Tab::Dtn => Tab::Feed,
+        };
+        self.cursor = 0;
     }
 
     pub fn cursor_down(&mut self) {
@@ -103,6 +125,21 @@ impl App {
         match self.tab {
             Tab::Users => self.users.len(),
             Tab::Feed => self.feed.len(),
+            Tab::Dtn => self.dtn_config.as_ref().map(|c| c.users.len()).unwrap_or(0),
+        }
+    }
+
+    /// Route a structured event from the subscribe stream. DTN
+    /// delivery responses get their own deque (rendered on the DTN
+    /// tab); everything else lands in the general events panel.
+    pub fn push_event_line(&mut self, line: EventLine) {
+        if line.topic == "dtn.delivery_response" {
+            if self.dtn_events.len() >= MAX_DTN_EVENTS {
+                self.dtn_events.pop_front();
+            }
+            self.dtn_events.push_back(line.text);
+        } else {
+            self.push_event(line.text);
         }
     }
 
@@ -111,5 +148,12 @@ impl App {
             self.events.pop_front();
         }
         self.events.push_back(line);
+    }
+
+    pub fn record_unconfirmed(&mut self, n: u32) {
+        if self.dtn_unconfirmed_history.len() >= UNCONFIRMED_HISTORY {
+            self.dtn_unconfirmed_history.pop_front();
+        }
+        self.dtn_unconfirmed_history.push_back(n as u64);
     }
 }

--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -5,7 +5,7 @@
 
 use std::collections::VecDeque;
 
-use crate::data::{DtnConfig, DtnState, EventLine, NetworkSnapshot};
+use crate::data::{CryptoConfig, CryptoRotationEvent, DtnConfig, DtnState, EventLine, NetworkSnapshot};
 
 const MAX_EVENTS: usize = 200;
 const MAX_DTN_EVENTS: usize = 100;
@@ -21,6 +21,7 @@ pub enum Tab {
     Feed,
     Dtn,
     Network,
+    Crypto,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +70,12 @@ pub struct App {
     /// taken once per refresh. Each `Vec` is capped at
     /// [`NETWORK_HISTORY`].
     pub network_history: NetworkHistory,
+    pub crypto_config: Option<CryptoConfig>,
+    pub crypto_events: Vec<CryptoRotationEvent>,
+    /// Wall-clock ms of the newest event seen, used as the floor for
+    /// the next `GetRotationEventsRequest` so we don't refetch the
+    /// whole log on each tick.
+    pub crypto_event_floor_ms: u64,
     tab: Tab,
     pub cursor: usize,
     pub input_mode: InputMode,
@@ -97,6 +104,9 @@ impl App {
             network: None,
             network_events: VecDeque::new(),
             network_history: NetworkHistory::default(),
+            crypto_config: None,
+            crypto_events: Vec::new(),
+            crypto_event_floor_ms: 0,
             tab: Tab::Users,
             cursor: 0,
             input_mode: InputMode::Normal,
@@ -113,17 +123,19 @@ impl App {
             Tab::Users => Tab::Feed,
             Tab::Feed => Tab::Dtn,
             Tab::Dtn => Tab::Network,
-            Tab::Network => Tab::Users,
+            Tab::Network => Tab::Crypto,
+            Tab::Crypto => Tab::Users,
         };
         self.cursor = 0;
     }
 
     pub fn prev_tab(&mut self) {
         self.tab = match self.tab {
-            Tab::Users => Tab::Network,
+            Tab::Users => Tab::Crypto,
             Tab::Feed => Tab::Users,
             Tab::Dtn => Tab::Feed,
             Tab::Network => Tab::Dtn,
+            Tab::Crypto => Tab::Network,
         };
         self.cursor = 0;
     }
@@ -153,6 +165,27 @@ impl App {
                 .as_ref()
                 .map(|n| n.peers.len())
                 .unwrap_or(0),
+            Tab::Crypto => self.crypto_events.len(),
+        }
+    }
+
+    /// Append new rotation events and advance the floor so subsequent
+    /// fetches only ask for what's newer.
+    pub fn append_crypto_events(&mut self, mut new_events: Vec<CryptoRotationEvent>) {
+        if new_events.is_empty() {
+            return;
+        }
+        for e in &new_events {
+            if e.timestamp_ms > self.crypto_event_floor_ms {
+                self.crypto_event_floor_ms = e.timestamp_ms;
+            }
+        }
+        self.crypto_events.append(&mut new_events);
+        // Cap the buffer so it doesn't grow unbounded; keep newest.
+        const MAX: usize = 500;
+        if self.crypto_events.len() > MAX {
+            let drop = self.crypto_events.len() - MAX;
+            self.crypto_events.drain(..drop);
         }
     }
 

--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -5,7 +5,10 @@
 
 use std::collections::VecDeque;
 
-use crate::data::{CryptoConfig, CryptoRotationEvent, DtnConfig, DtnState, EventLine, NetworkSnapshot};
+use crate::data::{
+    CryptoConfig, CryptoRotationEvent, DtnConfig, DtnState, EventLine, NetworkSnapshot,
+    ParsedEvent,
+};
 
 const MAX_EVENTS: usize = 200;
 const MAX_DTN_EVENTS: usize = 100;
@@ -191,8 +194,15 @@ impl App {
 
     /// Route a structured event from the subscribe stream. DTN
     /// delivery responses go to the DTN tab, peer events go to the
-    /// Network tab, everything else lands in the general events panel.
+    /// Network tab, crypto rotations go to the Crypto tab's typed
+    /// buffer (deduped against poll-based fetches), and anything
+    /// else lands in the general events panel.
     pub fn push_event_line(&mut self, line: EventLine) {
+        // Merge typed payloads first so the typed buffers stay in
+        // sync regardless of which buffer the text line lands in.
+        if let ParsedEvent::CryptoRotation(ref ev) = line.parsed {
+            self.merge_crypto_event(ev.clone());
+        }
         match line.topic.as_str() {
             "dtn.delivery_response" => {
                 if self.dtn_events.len() >= MAX_DTN_EVENTS {
@@ -206,8 +216,31 @@ impl App {
                 }
                 self.network_events.push_back(line.text);
             }
+            "crypto.rotation" => {
+                // Already merged into crypto_events above; don't
+                // also clutter the general events panel.
+            }
             _ => self.push_event(line.text),
         }
+    }
+
+    /// Merge a rotation event from the push channel, deduping
+    /// against anything the poll path already buffered. Same
+    /// (timestamp_ms, kind, primary, draining) tuple ⇒ same event.
+    fn merge_crypto_event(&mut self, ev: CryptoRotationEvent) {
+        let duplicate = self.crypto_events.iter().any(|existing| {
+            existing.timestamp_ms == ev.timestamp_ms
+                && existing.kind == ev.kind
+                && existing.primary_session_id == ev.primary_session_id
+                && existing.draining_session_id == ev.draining_session_id
+        });
+        if duplicate {
+            return;
+        }
+        if ev.timestamp_ms > self.crypto_event_floor_ms {
+            self.crypto_event_floor_ms = ev.timestamp_ms;
+        }
+        self.crypto_events.push(ev);
     }
 
     pub fn push_event(&mut self, line: String) {

--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -5,18 +5,22 @@
 
 use std::collections::VecDeque;
 
-use crate::data::{DtnConfig, DtnState, EventLine};
+use crate::data::{DtnConfig, DtnState, EventLine, NetworkSnapshot};
 
 const MAX_EVENTS: usize = 200;
 const MAX_DTN_EVENTS: usize = 100;
+const MAX_NETWORK_EVENTS: usize = 100;
 /// Width of the unconfirmed-count sparkline (number of samples kept).
 pub const UNCONFIRMED_HISTORY: usize = 60;
+/// Width of the per-module-total sparklines on the Network tab.
+pub const NETWORK_HISTORY: usize = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
     Users,
     Feed,
     Dtn,
+    Network,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,10 +63,23 @@ pub struct App {
     /// Rolling samples of `unconfirmed_count` taken once per refresh,
     /// oldest → newest. Capped at [`UNCONFIRMED_HISTORY`].
     pub dtn_unconfirmed_history: VecDeque<u64>,
+    pub network: Option<NetworkSnapshot>,
+    pub network_events: VecDeque<String>,
+    /// Rolling per-module connection counts (LAN, Internet, BLE),
+    /// taken once per refresh. Each `Vec` is capped at
+    /// [`NETWORK_HISTORY`].
+    pub network_history: NetworkHistory,
     tab: Tab,
     pub cursor: usize,
     pub input_mode: InputMode,
     pub compose_buffer: String,
+}
+
+#[derive(Default)]
+pub struct NetworkHistory {
+    pub lan: VecDeque<u64>,
+    pub internet: VecDeque<u64>,
+    pub ble: VecDeque<u64>,
 }
 
 impl App {
@@ -77,6 +94,9 @@ impl App {
             dtn_config: None,
             dtn_events: VecDeque::new(),
             dtn_unconfirmed_history: VecDeque::new(),
+            network: None,
+            network_events: VecDeque::new(),
+            network_history: NetworkHistory::default(),
             tab: Tab::Users,
             cursor: 0,
             input_mode: InputMode::Normal,
@@ -92,16 +112,18 @@ impl App {
         self.tab = match self.tab {
             Tab::Users => Tab::Feed,
             Tab::Feed => Tab::Dtn,
-            Tab::Dtn => Tab::Users,
+            Tab::Dtn => Tab::Network,
+            Tab::Network => Tab::Users,
         };
         self.cursor = 0;
     }
 
     pub fn prev_tab(&mut self) {
         self.tab = match self.tab {
-            Tab::Users => Tab::Dtn,
+            Tab::Users => Tab::Network,
             Tab::Feed => Tab::Users,
             Tab::Dtn => Tab::Feed,
+            Tab::Network => Tab::Dtn,
         };
         self.cursor = 0;
     }
@@ -126,20 +148,32 @@ impl App {
             Tab::Users => self.users.len(),
             Tab::Feed => self.feed.len(),
             Tab::Dtn => self.dtn_config.as_ref().map(|c| c.users.len()).unwrap_or(0),
+            Tab::Network => self
+                .network
+                .as_ref()
+                .map(|n| n.peers.len())
+                .unwrap_or(0),
         }
     }
 
     /// Route a structured event from the subscribe stream. DTN
-    /// delivery responses get their own deque (rendered on the DTN
-    /// tab); everything else lands in the general events panel.
+    /// delivery responses go to the DTN tab, peer events go to the
+    /// Network tab, everything else lands in the general events panel.
     pub fn push_event_line(&mut self, line: EventLine) {
-        if line.topic == "dtn.delivery_response" {
-            if self.dtn_events.len() >= MAX_DTN_EVENTS {
-                self.dtn_events.pop_front();
+        match line.topic.as_str() {
+            "dtn.delivery_response" => {
+                if self.dtn_events.len() >= MAX_DTN_EVENTS {
+                    self.dtn_events.pop_front();
+                }
+                self.dtn_events.push_back(line.text);
             }
-            self.dtn_events.push_back(line.text);
-        } else {
-            self.push_event(line.text);
+            "peers.connected" | "peers.disconnected" => {
+                if self.network_events.len() >= MAX_NETWORK_EVENTS {
+                    self.network_events.pop_front();
+                }
+                self.network_events.push_back(line.text);
+            }
+            _ => self.push_event(line.text),
         }
     }
 
@@ -156,4 +190,20 @@ impl App {
         }
         self.dtn_unconfirmed_history.push_back(n as u64);
     }
+
+    pub fn record_network(&mut self, snapshot: &NetworkSnapshot) {
+        push_capped(&mut self.network_history.lan, snapshot.lan_peers as u64);
+        push_capped(
+            &mut self.network_history.internet,
+            snapshot.internet_peers as u64,
+        );
+        push_capped(&mut self.network_history.ble, snapshot.ble_peers as u64);
+    }
+}
+
+fn push_capped(buf: &mut VecDeque<u64>, value: u64) {
+    if buf.len() >= NETWORK_HISTORY {
+        buf.pop_front();
+    }
+    buf.push_back(value);
 }

--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -5,7 +5,7 @@
 
 use std::collections::VecDeque;
 
-use crate::data::{
+use super::data::{
     CryptoConfig, CryptoRotationEvent, DtnConfig, DtnState, EventLine, NetworkSnapshot,
     ParsedEvent,
 };
@@ -209,7 +209,7 @@ impl App {
         })
     }
 
-    pub fn filtered_peers(&self) -> impl Iterator<Item = &crate::data::PeerRow> {
+    pub fn filtered_peers(&self) -> impl Iterator<Item = &super::data::PeerRow> {
         self.network.iter().flat_map(move |n| {
             n.peers.iter().filter(move |p| {
                 self.matches_filter(&format!("{} {} h{} rtt{}", p.module, p.user_id, p.hops, p.rtt_ms))

--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -30,7 +30,12 @@ pub enum Tab {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
     Normal,
+    /// Typing a feed message into the compose modal.
     Composing,
+    /// Typing into the per-tab filter input.
+    Filtering,
+    /// A modal is open showing the selected row's untruncated detail.
+    Viewing,
 }
 
 #[derive(Debug, Clone)]
@@ -83,6 +88,9 @@ pub struct App {
     pub cursor: usize,
     pub input_mode: InputMode,
     pub compose_buffer: String,
+    /// Per-session filter text. Applies to the active tab and is
+    /// cleared on tab switch so each tab starts fresh.
+    pub filter: String,
 }
 
 #[derive(Default)]
@@ -114,6 +122,7 @@ impl App {
             cursor: 0,
             input_mode: InputMode::Normal,
             compose_buffer: String::new(),
+            filter: String::new(),
         }
     }
 
@@ -130,6 +139,7 @@ impl App {
             Tab::Crypto => Tab::Users,
         };
         self.cursor = 0;
+        self.filter.clear();
     }
 
     pub fn prev_tab(&mut self) {
@@ -141,10 +151,11 @@ impl App {
             Tab::Crypto => Tab::Network,
         };
         self.cursor = 0;
+        self.filter.clear();
     }
 
     pub fn cursor_down(&mut self) {
-        let len = self.list_len();
+        let len = self.filtered_len();
         if len == 0 {
             self.cursor = 0;
         } else if self.cursor + 1 < len {
@@ -158,17 +169,136 @@ impl App {
         }
     }
 
-    fn list_len(&self) -> usize {
+    /// Number of rows currently visible on the active tab (after
+    /// filter). Used by the cursor + the title bar of each table.
+    pub fn filtered_len(&self) -> usize {
         match self.tab {
-            Tab::Users => self.users.len(),
-            Tab::Feed => self.feed.len(),
-            Tab::Dtn => self.dtn_config.as_ref().map(|c| c.users.len()).unwrap_or(0),
-            Tab::Network => self
-                .network
-                .as_ref()
-                .map(|n| n.peers.len())
-                .unwrap_or(0),
-            Tab::Crypto => self.crypto_events.len(),
+            Tab::Users => self.filtered_users().count(),
+            Tab::Feed => self.filtered_feed().count(),
+            Tab::Dtn => self.filtered_dtn_custodians().count(),
+            Tab::Network => self.filtered_peers().count(),
+            Tab::Crypto => self.filtered_crypto_events().count(),
+        }
+    }
+
+    /// Substring match against the active filter; empty filter
+    /// passes everything. Lower-cased on both sides.
+    fn matches_filter(&self, hay: &str) -> bool {
+        if self.filter.is_empty() {
+            return true;
+        }
+        let needle = self.filter.to_ascii_lowercase();
+        hay.to_ascii_lowercase().contains(&needle)
+    }
+
+    pub fn filtered_users(&self) -> impl Iterator<Item = &UserRow> {
+        self.users.iter().filter(move |u| {
+            self.matches_filter(&format!(
+                "{} {} {} {}",
+                u.name, u.id, u.connectivity, u.bio
+            ))
+        })
+    }
+
+    pub fn filtered_feed(&self) -> impl Iterator<Item = &FeedRow> {
+        self.feed.iter().filter(move |m| {
+            self.matches_filter(&format!(
+                "{} {} {} {}",
+                m.index, m.sender, m.content, m.time_sent
+            ))
+        })
+    }
+
+    pub fn filtered_peers(&self) -> impl Iterator<Item = &crate::data::PeerRow> {
+        self.network.iter().flat_map(move |n| {
+            n.peers.iter().filter(move |p| {
+                self.matches_filter(&format!("{} {} h{} rtt{}", p.module, p.user_id, p.hops, p.rtt_ms))
+            })
+        })
+    }
+
+    pub fn filtered_dtn_custodians(&self) -> impl Iterator<Item = &String> {
+        self.dtn_config
+            .iter()
+            .flat_map(move |cfg| cfg.users.iter().filter(move |u| self.matches_filter(u)))
+    }
+
+    pub fn filtered_crypto_events(&self) -> impl Iterator<Item = &CryptoRotationEvent> {
+        self.crypto_events.iter().filter(move |e| {
+            self.matches_filter(&format!(
+                "{} {} {} {} {}",
+                e.timestamp_ms, e.kind, e.remote_id, e.primary_session_id, e.draining_session_id
+            ))
+        })
+    }
+
+    /// Returns labelled (key, value) pairs for the currently selected
+    /// row on the active tab. `None` when nothing is selected
+    /// (e.g. empty table after filter). Used by the detail modal.
+    pub fn selected_detail(&self) -> Option<(String, Vec<(String, String)>)> {
+        match self.tab {
+            Tab::Users => {
+                let u = self.filtered_users().nth(self.cursor)?;
+                Some((
+                    format!("User: {}", u.name),
+                    vec![
+                        ("name".into(), u.name.clone()),
+                        ("id".into(), u.id.clone()),
+                        ("connectivity".into(), u.connectivity.clone()),
+                        ("profile version".into(), u.profile_version.to_string()),
+                        ("bio".into(), u.bio.clone()),
+                    ],
+                ))
+            }
+            Tab::Feed => {
+                let m = self.filtered_feed().nth(self.cursor)?;
+                Some((
+                    format!("Feed message #{}", m.index),
+                    vec![
+                        ("index".into(), m.index.to_string()),
+                        ("sender".into(), m.sender.clone()),
+                        ("time sent".into(), m.time_sent.clone()),
+                        ("content".into(), m.content.clone()),
+                    ],
+                ))
+            }
+            Tab::Dtn => {
+                let id = self.filtered_dtn_custodians().nth(self.cursor)?;
+                Some((
+                    "Custodian".to_string(),
+                    vec![("peer id".into(), id.clone())],
+                ))
+            }
+            Tab::Network => {
+                let p = self.filtered_peers().nth(self.cursor)?;
+                Some((
+                    format!("Peer via {}", p.module),
+                    vec![
+                        ("module".into(), p.module.to_string()),
+                        ("peer id".into(), p.user_id.clone()),
+                        ("hops".into(), p.hops.to_string()),
+                        ("rtt".into(), format!("{} ms", p.rtt_ms)),
+                    ],
+                ))
+            }
+            Tab::Crypto => {
+                // Filtered events are reversed (newest-first) for
+                // display; selected_detail must match the rendered
+                // order so the cursor lines up with what the user
+                // sees.
+                let events: Vec<_> = self.filtered_crypto_events().collect();
+                let e = events.iter().rev().nth(self.cursor)?;
+                Some((
+                    format!("Rotation event: {}", e.kind),
+                    vec![
+                        ("timestamp (ms)".into(), e.timestamp_ms.to_string()),
+                        ("kind".into(), e.kind.to_string()),
+                        ("remote peer".into(), e.remote_id.clone()),
+                        ("primary session".into(), e.primary_session_id.to_string()),
+                        ("draining session".into(), e.draining_session_id.to_string()),
+                    ],
+                ))
+            }
         }
     }
 

--- a/rust/clients/qauld-ctl/src/tui/data.rs
+++ b/rust/clients/qauld-ctl/src/tui/data.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use super::app::{FeedRow, UserRow};
 
+use qaul_proto::qaul_rpc_crypto as crypto_proto;
 use qaul_proto::qaul_rpc_dtn as dtn_proto;
 use qaul_proto::qaul_rpc_feed as feed_proto;
 use qaul_proto::qaul_rpc_router as router_proto;
@@ -258,6 +259,88 @@ fn push_peers(
             });
         }
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CryptoConfig {
+    pub enabled: bool,
+    pub period_seconds: u64,
+    pub volume_messages: u64,
+    pub grace_period_seconds: u64,
+    pub grace_volume_messages: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CryptoRotationEvent {
+    pub timestamp_ms: u64,
+    pub kind: &'static str,
+    pub remote_id: String,
+    pub primary_session_id: u32,
+    pub draining_session_id: u32,
+}
+
+pub async fn fetch_crypto_config(
+    connect: &ConnectInfo,
+    timeout: Duration,
+) -> Result<CryptoConfig, Box<dyn std::error::Error>> {
+    let req = crypto_proto::Crypto {
+        message: Some(crypto_proto::crypto::Message::GetConfigRequest(
+            crypto_proto::GetConfigRequest {},
+        )),
+    };
+    let mut t = open(connect).await?;
+    let resp = round_trip(&mut t, proto::Modules::Crypto, req.encode_to_vec(), timeout).await?;
+    let parsed = crypto_proto::Crypto::decode(&resp.data[..])?;
+    if let Some(crypto_proto::crypto::Message::GetConfigResponse(c)) = parsed.message {
+        return Ok(CryptoConfig {
+            enabled: c.enabled,
+            period_seconds: c.period_seconds,
+            volume_messages: c.volume_messages,
+            grace_period_seconds: c.grace_period_seconds,
+            grace_volume_messages: c.grace_volume_messages,
+        });
+    }
+    Err("unexpected crypto config response".into())
+}
+
+pub async fn fetch_crypto_events(
+    connect: &ConnectInfo,
+    timeout: Duration,
+    since_ms: u64,
+) -> Result<Vec<CryptoRotationEvent>, Box<dyn std::error::Error>> {
+    let req = crypto_proto::Crypto {
+        message: Some(crypto_proto::crypto::Message::GetEventsRequest(
+            crypto_proto::GetRotationEventsRequest {
+                since_ms,
+                limit: 0,
+            },
+        )),
+    };
+    let mut t = open(connect).await?;
+    let resp = round_trip(&mut t, proto::Modules::Crypto, req.encode_to_vec(), timeout).await?;
+    let parsed = crypto_proto::Crypto::decode(&resp.data[..])?;
+    if let Some(crypto_proto::crypto::Message::GetEventsResponse(r)) = parsed.message {
+        let mut out = Vec::with_capacity(r.events.len());
+        for ev in r.events {
+            let kind = match crypto_proto::RotationEventKind::try_from(ev.kind) {
+                Ok(crypto_proto::RotationEventKind::Rotated) => "rotated",
+                Ok(crypto_proto::RotationEventKind::GraceExpired) => "grace_expired",
+                Ok(crypto_proto::RotationEventKind::MessageDroppedPastGrace) => "msg_dropped_past_grace",
+                _ => "unspecified",
+            };
+            out.push(CryptoRotationEvent {
+                timestamp_ms: ev.timestamp_ms,
+                kind,
+                remote_id: bs58::encode(&ev.remote_id).into_string(),
+                primary_session_id: ev.primary_session_id,
+                draining_session_id: ev.draining_session_id,
+            });
+        }
+        // Caller asked for since_ms, so dedupe just in case the
+        // daemon returned events at exactly that timestamp twice.
+        return Ok(out);
+    }
+    Err("unexpected crypto events response".into())
 }
 
 pub async fn fetch_feed(

--- a/rust/clients/qauld-ctl/src/tui/data.rs
+++ b/rust/clients/qauld-ctl/src/tui/data.rs
@@ -19,6 +19,7 @@ use super::app::{FeedRow, UserRow};
 
 use qaul_proto::qaul_rpc_dtn as dtn_proto;
 use qaul_proto::qaul_rpc_feed as feed_proto;
+use qaul_proto::qaul_rpc_router as router_proto;
 use qaul_proto::qaul_rpc_subscribe as sub_proto;
 use qaul_proto::qaul_rpc_user_accounts as ua_proto;
 use qaul_proto::qaul_rpc_users as users_proto;
@@ -182,6 +183,81 @@ pub async fn fetch_dtn_config(
         });
     }
     Err("unexpected DTN config response".into())
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NetworkSnapshot {
+    pub lan_peers: u32,
+    pub internet_peers: u32,
+    pub ble_peers: u32,
+    pub local_peers: u32,
+    /// Flat per-peer view: (module, user_id_base58, hop_count, rtt_ms).
+    /// One row per (peer × module) so the same peer reachable via two
+    /// transports gets two rows — matches what the router actually
+    /// tracks.
+    pub peers: Vec<PeerRow>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerRow {
+    pub module: &'static str,
+    pub user_id: String,
+    pub hops: u32,
+    pub rtt_ms: u32,
+}
+
+pub async fn fetch_network(
+    connect: &ConnectInfo,
+    timeout: Duration,
+) -> Result<NetworkSnapshot, Box<dyn std::error::Error>> {
+    let req = router_proto::Router {
+        message: Some(router_proto::router::Message::ConnectionsRequest(
+            router_proto::ConnectionsRequest {},
+        )),
+    };
+    let mut t = open(connect).await?;
+    let resp = round_trip(&mut t, proto::Modules::Router, req.encode_to_vec(), timeout).await?;
+    let parsed = router_proto::Router::decode(&resp.data[..])?;
+    let mut snap = NetworkSnapshot::default();
+    if let Some(router_proto::router::Message::ConnectionsList(list)) = parsed.message {
+        snap.lan_peers = list.lan.len() as u32;
+        snap.internet_peers = list.internet.len() as u32;
+        snap.ble_peers = list.ble.len() as u32;
+        snap.local_peers = list.local.len() as u32;
+        push_peers(&mut snap.peers, "LAN", &list.lan);
+        push_peers(&mut snap.peers, "Internet", &list.internet);
+        push_peers(&mut snap.peers, "BLE", &list.ble);
+        push_peers(&mut snap.peers, "Local", &list.local);
+    }
+    Ok(snap)
+}
+
+fn push_peers(
+    rows: &mut Vec<PeerRow>,
+    module: &'static str,
+    entries: &[router_proto::ConnectionsUserEntry],
+) {
+    for entry in entries {
+        let best = entry
+            .connections
+            .iter()
+            .min_by_key(|c| (c.hop_count, c.rtt));
+        if let Some(c) = best {
+            rows.push(PeerRow {
+                module,
+                user_id: bs58::encode(&entry.user_id).into_string(),
+                hops: c.hop_count,
+                rtt_ms: c.rtt,
+            });
+        } else {
+            rows.push(PeerRow {
+                module,
+                user_id: bs58::encode(&entry.user_id).into_string(),
+                hops: 0,
+                rtt_ms: 0,
+            });
+        }
+    }
 }
 
 pub async fn fetch_feed(

--- a/rust/clients/qauld-ctl/src/tui/data.rs
+++ b/rust/clients/qauld-ctl/src/tui/data.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 use super::app::{FeedRow, UserRow};
 
 use qaul_proto::qaul_rpc_crypto as crypto_proto;
+use qaul_proto::qaul_rpc_crypto::RotationEventKind;
 use qaul_proto::qaul_rpc_dtn as dtn_proto;
 use qaul_proto::qaul_rpc_feed as feed_proto;
 use qaul_proto::qaul_rpc_router as router_proto;
@@ -28,10 +29,25 @@ use qaul_proto::qaul_rpc_users as users_proto;
 /// One event line pushed onto the UI's deque, tagged so the UI can
 /// route DTN events to the DTN tab and everything else to the
 /// generic events panel.
+///
+/// Some topics carry structured payloads the UI wants to merge
+/// into a typed buffer rather than render as a string — that's
+/// what `parsed` is for.
 #[derive(Debug, Clone)]
 pub struct EventLine {
     pub topic: String,
     pub text: String,
+    pub parsed: ParsedEvent,
+}
+
+/// Structured payloads broken out for tabs that maintain their own
+/// typed buffers (e.g. the Crypto tab merges these into its
+/// `crypto_events` list so push and poll converge on the same view).
+#[derive(Debug, Clone, Default)]
+pub enum ParsedEvent {
+    #[default]
+    None,
+    CryptoRotation(CryptoRotationEvent),
 }
 
 async fn open(connect: &ConnectInfo) -> Result<SocketTransport, Box<dyn std::error::Error>> {
@@ -320,25 +336,7 @@ pub async fn fetch_crypto_events(
     let resp = round_trip(&mut t, proto::Modules::Crypto, req.encode_to_vec(), timeout).await?;
     let parsed = crypto_proto::Crypto::decode(&resp.data[..])?;
     if let Some(crypto_proto::crypto::Message::GetEventsResponse(r)) = parsed.message {
-        let mut out = Vec::with_capacity(r.events.len());
-        for ev in r.events {
-            let kind = match crypto_proto::RotationEventKind::try_from(ev.kind) {
-                Ok(crypto_proto::RotationEventKind::Rotated) => "rotated",
-                Ok(crypto_proto::RotationEventKind::GraceExpired) => "grace_expired",
-                Ok(crypto_proto::RotationEventKind::MessageDroppedPastGrace) => "msg_dropped_past_grace",
-                _ => "unspecified",
-            };
-            out.push(CryptoRotationEvent {
-                timestamp_ms: ev.timestamp_ms,
-                kind,
-                remote_id: bs58::encode(&ev.remote_id).into_string(),
-                primary_session_id: ev.primary_session_id,
-                draining_session_id: ev.draining_session_id,
-            });
-        }
-        // Caller asked for since_ms, so dedupe just in case the
-        // daemon returned events at exactly that timestamp twice.
-        return Ok(out);
+        return Ok(r.events.iter().map(rotation_event_to_row).collect());
     }
     Err("unexpected crypto events response".into())
 }
@@ -446,6 +444,7 @@ fn format_event(data: &[u8]) -> Option<EventLine> {
         _ => return None,
     };
     let topic = event.topic.clone();
+    let mut parsed = ParsedEvent::None;
     let text = match event.topic.as_str() {
         "chat.message" => match sub_proto::ChatMessageEvent::decode(&event.payload[..]) {
             Ok(m) => format!(
@@ -489,6 +488,22 @@ fn format_event(data: &[u8]) -> Option<EventLine> {
                 Err(_) => format!("[{}] dtn.delivery_response <decode failed>", event.timestamp),
             }
         }
+        "crypto.rotation" => match crypto_proto::RotationEvent::decode(&event.payload[..]) {
+            Ok(r) => {
+                let row = rotation_event_to_row(&r);
+                let line = format!(
+                    "[{}] crypto.rotation {} remote={}… p={} d={}",
+                    event.timestamp,
+                    row.kind,
+                    &row.remote_id[..8.min(row.remote_id.len())],
+                    row.primary_session_id,
+                    row.draining_session_id,
+                );
+                parsed = ParsedEvent::CryptoRotation(row);
+                line
+            }
+            Err(_) => format!("[{}] crypto.rotation <decode failed>", event.timestamp),
+        },
         other => format!(
             "[{}] {} ({} bytes)",
             event.timestamp,
@@ -496,7 +511,23 @@ fn format_event(data: &[u8]) -> Option<EventLine> {
             event.payload.len()
         ),
     };
-    Some(EventLine { topic, text })
+    Some(EventLine { topic, text, parsed })
+}
+
+fn rotation_event_to_row(ev: &crypto_proto::RotationEvent) -> CryptoRotationEvent {
+    let kind = match RotationEventKind::try_from(ev.kind) {
+        Ok(RotationEventKind::Rotated) => "rotated",
+        Ok(RotationEventKind::GraceExpired) => "grace_expired",
+        Ok(RotationEventKind::MessageDroppedPastGrace) => "msg_dropped_past_grace",
+        _ => "unspecified",
+    };
+    CryptoRotationEvent {
+        timestamp_ms: ev.timestamp_ms,
+        kind,
+        remote_id: bs58::encode(&ev.remote_id).into_string(),
+        primary_session_id: ev.primary_session_id,
+        draining_session_id: ev.draining_session_id,
+    }
 }
 
 // Unused helpers from the framing codec; kept to compile if needed.

--- a/rust/clients/qauld-ctl/src/tui/data.rs
+++ b/rust/clients/qauld-ctl/src/tui/data.rs
@@ -280,10 +280,7 @@ fn push_peers(
 #[derive(Debug, Clone, Default)]
 pub struct CryptoConfig {
     pub enabled: bool,
-    pub period_seconds: u64,
     pub volume_messages: u64,
-    pub grace_period_seconds: u64,
-    pub grace_volume_messages: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -310,10 +307,7 @@ pub async fn fetch_crypto_config(
     if let Some(crypto_proto::crypto::Message::GetConfigResponse(c)) = parsed.message {
         return Ok(CryptoConfig {
             enabled: c.enabled,
-            period_seconds: c.period_seconds,
             volume_messages: c.volume_messages,
-            grace_period_seconds: c.grace_period_seconds,
-            grace_volume_messages: c.grace_volume_messages,
         });
     }
     Err("unexpected crypto config response".into())
@@ -517,8 +511,8 @@ fn format_event(data: &[u8]) -> Option<EventLine> {
 fn rotation_event_to_row(ev: &crypto_proto::RotationEvent) -> CryptoRotationEvent {
     let kind = match RotationEventKind::try_from(ev.kind) {
         Ok(RotationEventKind::Rotated) => "rotated",
-        Ok(RotationEventKind::GraceExpired) => "grace_expired",
-        Ok(RotationEventKind::MessageDroppedPastGrace) => "msg_dropped_past_grace",
+        Ok(RotationEventKind::DrainCompleted) => "drain_completed",
+        Ok(RotationEventKind::MessageDroppedPostDrain) => "msg_dropped_post_drain",
         _ => "unspecified",
     };
     CryptoRotationEvent {

--- a/rust/clients/qauld-ctl/src/tui/data.rs
+++ b/rust/clients/qauld-ctl/src/tui/data.rs
@@ -17,10 +17,20 @@ use uuid::Uuid;
 
 use super::app::{FeedRow, UserRow};
 
+use qaul_proto::qaul_rpc_dtn as dtn_proto;
 use qaul_proto::qaul_rpc_feed as feed_proto;
 use qaul_proto::qaul_rpc_subscribe as sub_proto;
 use qaul_proto::qaul_rpc_user_accounts as ua_proto;
 use qaul_proto::qaul_rpc_users as users_proto;
+
+/// One event line pushed onto the UI's deque, tagged so the UI can
+/// route DTN events to the DTN tab and everything else to the
+/// generic events panel.
+#[derive(Debug, Clone)]
+pub struct EventLine {
+    pub topic: String,
+    pub text: String,
+}
 
 async fn open(connect: &ConnectInfo) -> Result<SocketTransport, Box<dyn std::error::Error>> {
     SocketTransport::connect(connect).await
@@ -114,6 +124,66 @@ pub async fn fetch_users(
     Ok(rows)
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DtnState {
+    pub used_size: u64,
+    pub message_count: u32,
+    pub unconfirmed_count: u32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DtnConfig {
+    pub total_size: u32,
+    pub users: Vec<String>,
+}
+
+pub async fn fetch_dtn_state(
+    connect: &ConnectInfo,
+    timeout: Duration,
+) -> Result<DtnState, Box<dyn std::error::Error>> {
+    let req = dtn_proto::Dtn {
+        message: Some(dtn_proto::dtn::Message::DtnStateRequest(
+            dtn_proto::DtnStateRequest {},
+        )),
+    };
+    let mut t = open(connect).await?;
+    let resp = round_trip(&mut t, proto::Modules::Dtn, req.encode_to_vec(), timeout).await?;
+    let parsed = dtn_proto::Dtn::decode(&resp.data[..])?;
+    if let Some(dtn_proto::dtn::Message::DtnStateResponse(s)) = parsed.message {
+        return Ok(DtnState {
+            used_size: s.used_size,
+            message_count: s.dtn_message_count,
+            unconfirmed_count: s.unconfirmed_count,
+        });
+    }
+    Err("unexpected DTN state response".into())
+}
+
+pub async fn fetch_dtn_config(
+    connect: &ConnectInfo,
+    timeout: Duration,
+) -> Result<DtnConfig, Box<dyn std::error::Error>> {
+    let req = dtn_proto::Dtn {
+        message: Some(dtn_proto::dtn::Message::DtnConfigRequest(
+            dtn_proto::DtnConfigRequest {},
+        )),
+    };
+    let mut t = open(connect).await?;
+    let resp = round_trip(&mut t, proto::Modules::Dtn, req.encode_to_vec(), timeout).await?;
+    let parsed = dtn_proto::Dtn::decode(&resp.data[..])?;
+    if let Some(dtn_proto::dtn::Message::DtnConfigResponse(c)) = parsed.message {
+        return Ok(DtnConfig {
+            total_size: c.total_size,
+            users: c
+                .users
+                .iter()
+                .map(|u| bs58::encode(u).into_string())
+                .collect(),
+        });
+    }
+    Err("unexpected DTN config response".into())
+}
+
 pub async fn fetch_feed(
     connect: &ConnectInfo,
     timeout: Duration,
@@ -178,7 +248,7 @@ pub async fn send_feed(
 /// until the connection drops.
 pub async fn spawn_subscribe(
     connect: ConnectInfo,
-    tx: UnboundedSender<String>,
+    tx: UnboundedSender<EventLine>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let transport = SocketTransport::connect(&connect).await?;
     let mut framed = transport.into_framed();
@@ -210,13 +280,14 @@ pub async fn spawn_subscribe(
     Ok(())
 }
 
-fn format_event(data: &[u8]) -> Option<String> {
+fn format_event(data: &[u8]) -> Option<EventLine> {
     let env = sub_proto::Subscribe::decode(data).ok()?;
     let event = match env.message? {
         sub_proto::subscribe::Message::Event(e) => e,
         _ => return None,
     };
-    Some(match event.topic.as_str() {
+    let topic = event.topic.clone();
+    let text = match event.topic.as_str() {
         "chat.message" => match sub_proto::ChatMessageEvent::decode(&event.payload[..]) {
             Ok(m) => format!(
                 "[{}] chat.message {}…: {}",
@@ -234,13 +305,39 @@ fn format_event(data: &[u8]) -> Option<String> {
             ),
             Err(_) => format!("[{}] peers.connected <decode failed>", event.timestamp),
         },
+        "dtn.delivery_response" => {
+            match sub_proto::DtnDeliveryResponseEvent::decode(&event.payload[..]) {
+                Ok(d) => {
+                    let status = match d.response_type {
+                        1 => "accepted",
+                        2 => "rejected",
+                        _ => "unknown",
+                    };
+                    let reason = if d.reason != 0 {
+                        format!(" reason={}", d.reason)
+                    } else {
+                        String::new()
+                    };
+                    format!(
+                        "[{}] delivery {} via {}…  sig {}…{}",
+                        event.timestamp,
+                        status,
+                        &bs58::encode(&d.storage_node).into_string()[..10],
+                        &bs58::encode(&d.signature).into_string()[..8],
+                        reason,
+                    )
+                }
+                Err(_) => format!("[{}] dtn.delivery_response <decode failed>", event.timestamp),
+            }
+        }
         other => format!(
             "[{}] {} ({} bytes)",
             event.timestamp,
             other,
             event.payload.len()
         ),
-    })
+    };
+    Some(EventLine { topic, text })
 }
 
 // Unused helpers from the framing codec; kept to compile if needed.

--- a/rust/clients/qauld-ctl/src/tui/mod.rs
+++ b/rust/clients/qauld-ctl/src/tui/mod.rs
@@ -200,4 +200,11 @@ async fn refresh(
         Ok(cfg) => app.dtn_config = Some(cfg),
         Err(e) => app.push_event(format!("dtn config fetch failed: {e}")),
     }
+    match data::fetch_network(connect, timeout).await {
+        Ok(snapshot) => {
+            app.record_network(&snapshot);
+            app.network = Some(snapshot);
+        }
+        Err(e) => app.push_event(format!("network fetch failed: {e}")),
+    }
 }

--- a/rust/clients/qauld-ctl/src/tui/mod.rs
+++ b/rust/clients/qauld-ctl/src/tui/mod.rs
@@ -207,4 +207,21 @@ async fn refresh(
         }
         Err(e) => app.push_event(format!("network fetch failed: {e}")),
     }
+    match data::fetch_crypto_config(connect, timeout).await {
+        Ok(cfg) => app.crypto_config = Some(cfg),
+        Err(e) => app.push_event(format!("crypto config fetch failed: {e}")),
+    }
+    let since = app.crypto_event_floor_ms;
+    match data::fetch_crypto_events(connect, timeout, since).await {
+        Ok(events) => {
+            // The `since_ms` filter is inclusive on the daemon side, so
+            // drop anything we've already buffered.
+            let fresh: Vec<_> = events
+                .into_iter()
+                .filter(|e| since == 0 || e.timestamp_ms > since)
+                .collect();
+            app.append_crypto_events(fresh);
+        }
+        Err(e) => app.push_event(format!("crypto events fetch failed: {e}")),
+    }
 }

--- a/rust/clients/qauld-ctl/src/tui/mod.rs
+++ b/rust/clients/qauld-ctl/src/tui/mod.rs
@@ -56,6 +56,7 @@ pub async fn run(cli: Cli, refresh_secs: u64) -> Result<(), Box<dyn std::error::
                 let _ = event_tx.send(data::EventLine {
                     topic: "tui.internal".into(),
                     text: format!("subscribe stream ended: {e}"),
+                    parsed: data::ParsedEvent::None,
                 });
             }
         });

--- a/rust/clients/qauld-ctl/src/tui/mod.rs
+++ b/rust/clients/qauld-ctl/src/tui/mod.rs
@@ -48,12 +48,15 @@ pub async fn run(cli: Cli, refresh_secs: u64) -> Result<(), Box<dyn std::error::
     }
 
     // Subscribe stream (bg task pushes events into a channel).
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<data::EventLine>();
     {
         let connect = connect.clone();
         tokio::spawn(async move {
             if let Err(e) = data::spawn_subscribe(connect, event_tx.clone()).await {
-                let _ = event_tx.send(format!("subscribe stream ended: {e}"));
+                let _ = event_tx.send(data::EventLine {
+                    topic: "tui.internal".into(),
+                    text: format!("subscribe stream ended: {e}"),
+                });
             }
         });
     }
@@ -87,7 +90,7 @@ pub async fn run(cli: Cli, refresh_secs: u64) -> Result<(), Box<dyn std::error::
                 None => break Ok(()),
             },
             line = event_rx.recv() => if let Some(line) = line {
-                app.push_event(line);
+                app.push_event_line(line);
             },
             _ = tick => {
                 refresh(&mut app, &connect, timeout).await;
@@ -185,5 +188,16 @@ async fn refresh(
     match data::fetch_feed(connect, timeout).await {
         Ok(feed) => app.feed = feed,
         Err(e) => app.push_event(format!("feed fetch failed: {e}")),
+    }
+    match data::fetch_dtn_state(connect, timeout).await {
+        Ok(state) => {
+            app.record_unconfirmed(state.unconfirmed_count);
+            app.dtn_state = Some(state);
+        }
+        Err(e) => app.push_event(format!("dtn state fetch failed: {e}")),
+    }
+    match data::fetch_dtn_config(connect, timeout).await {
+        Ok(cfg) => app.dtn_config = Some(cfg),
+        Err(e) => app.push_event(format!("dtn config fetch failed: {e}")),
     }
 }

--- a/rust/clients/qauld-ctl/src/tui/mod.rs
+++ b/rust/clients/qauld-ctl/src/tui/mod.rs
@@ -151,6 +151,40 @@ async fn handle_key(
         return None;
     }
 
+    if app.input_mode == InputMode::Filtering {
+        match key.code {
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                app.filter.clear();
+                app.cursor = 0;
+            }
+            KeyCode::Enter => {
+                // Accept the filter; stay in Normal mode so the
+                // user can navigate the filtered list.
+                app.input_mode = InputMode::Normal;
+            }
+            KeyCode::Backspace => {
+                app.filter.pop();
+                app.cursor = 0;
+            }
+            KeyCode::Char(c) => {
+                app.filter.push(c);
+                app.cursor = 0;
+            }
+            _ => {}
+        }
+        return None;
+    }
+
+    if app.input_mode == InputMode::Viewing {
+        // Any key dismisses the detail modal. Esc is the obvious
+        // one; Enter feels natural too.
+        if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
+            app.input_mode = InputMode::Normal;
+        }
+        return None;
+    }
+
     match key.code {
         KeyCode::Char('q') => return Some(Ok(())),
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -159,6 +193,16 @@ async fn handle_key(
         KeyCode::Tab => app.next_tab(),
         KeyCode::BackTab => app.prev_tab(),
         KeyCode::Char('r') => refresh(app, connect, timeout).await,
+        KeyCode::Char('/') => {
+            app.input_mode = InputMode::Filtering;
+            app.filter.clear();
+            app.cursor = 0;
+        }
+        KeyCode::Enter => {
+            if app.selected_detail().is_some() {
+                app.input_mode = InputMode::Viewing;
+            }
+        }
         KeyCode::Char('s') if app.current_tab() == Tab::Feed => {
             app.input_mode = InputMode::Composing;
             app.compose_buffer.clear();

--- a/rust/clients/qauld-ctl/src/tui/ui.rs
+++ b/rust/clients/qauld-ctl/src/tui/ui.rs
@@ -39,6 +39,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
     if app.input_mode == InputMode::Composing {
         draw_compose_modal(frame, area, app);
     }
+    if app.input_mode == InputMode::Viewing {
+        draw_detail_modal(frame, area, app);
+    }
 }
 
 fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
@@ -73,8 +76,9 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_users(frame: &mut Frame, area: Rect, app: &App) {
-    let rows: Vec<Row> = app
-        .users
+    let visible: Vec<_> = app.filtered_users().collect();
+    let total = app.users.len();
+    let rows: Vec<Row> = visible
         .iter()
         .enumerate()
         .map(|(i, u)| {
@@ -108,14 +112,25 @@ fn draw_users(frame: &mut Frame, area: Rect, app: &App) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(format!("Users ({})", app.users.len())),
+                .title(filtered_title("Users", visible.len(), total, &app.filter)),
         );
     frame.render_widget(table, area);
 }
 
+/// Returns "<label> (filtered <n>/<total> for "<filter>")" when a
+/// filter is active, otherwise "<label> (<total>)".
+fn filtered_title(label: &str, visible: usize, total: usize, filter: &str) -> String {
+    if filter.is_empty() {
+        format!("{} ({})", label, total)
+    } else {
+        format!("{} (filtered {}/{} for \"{}\")", label, visible, total, filter)
+    }
+}
+
 fn draw_feed(frame: &mut Frame, area: Rect, app: &App) {
-    let rows: Vec<Row> = app
-        .feed
+    let visible: Vec<_> = app.filtered_feed().collect();
+    let total = app.feed.len();
+    let rows: Vec<Row> = visible
         .iter()
         .enumerate()
         .map(|(i, m)| {
@@ -147,7 +162,7 @@ fn draw_feed(frame: &mut Frame, area: Rect, app: &App) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(format!("Feed ({})", app.feed.len())),
+                .title(filtered_title("Feed", visible.len(), total, &app.filter)),
         );
     frame.render_widget(table, area);
 }
@@ -239,24 +254,21 @@ fn draw_unconfirmed_sparkline(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_dtn_custodians(frame: &mut Frame, area: Rect, app: &App) {
-    let rows: Vec<Row> = match &app.dtn_config {
-        Some(cfg) => cfg
-            .users
-            .iter()
-            .enumerate()
-            .map(|(i, u)| {
-                let style = if i == app.cursor {
-                    Style::default().bg(Color::DarkGray)
-                } else {
-                    Style::default()
-                };
-                Row::new(vec![Cell::from(short_id(u))]).style(style)
-            })
-            .collect(),
-        None => Vec::new(),
-    };
+    let visible: Vec<_> = app.filtered_dtn_custodians().collect();
+    let total = app.dtn_config.as_ref().map(|c| c.users.len()).unwrap_or(0);
+    let rows: Vec<Row> = visible
+        .iter()
+        .enumerate()
+        .map(|(i, u)| {
+            let style = if i == app.cursor {
+                Style::default().bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![Cell::from(short_id(u))]).style(style)
+        })
+        .collect();
     let widths = [Constraint::Min(20)];
-    let count = app.dtn_config.as_ref().map(|c| c.users.len()).unwrap_or(0);
     let table = Table::new(rows, widths)
         .header(
             Row::new(vec!["Configured custodian users"])
@@ -265,7 +277,7 @@ fn draw_dtn_custodians(frame: &mut Frame, area: Rect, app: &App) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(format!("Allowed custodians ({})", count)),
+                .title(filtered_title("Allowed custodians", visible.len(), total, &app.filter)),
         );
     frame.render_widget(table, area);
 }
@@ -394,12 +406,9 @@ fn draw_module_card(
 }
 
 fn draw_network_peers(frame: &mut Frame, area: Rect, app: &App) {
-    let peers: Vec<_> = app
-        .network
-        .as_ref()
-        .map(|n| n.peers.clone())
-        .unwrap_or_default();
-    let rows: Vec<Row> = peers
+    let visible: Vec<_> = app.filtered_peers().collect();
+    let total = app.network.as_ref().map(|n| n.peers.len()).unwrap_or(0);
+    let rows: Vec<Row> = visible
         .iter()
         .enumerate()
         .map(|(i, p)| {
@@ -431,7 +440,7 @@ fn draw_network_peers(frame: &mut Frame, area: Rect, app: &App) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(format!("Peers ({})", peers.len())),
+                .title(filtered_title("Peers", visible.len(), total, &app.filter)),
         );
     frame.render_widget(table, area);
 }
@@ -535,9 +544,12 @@ fn draw_crypto_counts(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_crypto_events(frame: &mut Frame, area: Rect, app: &App) {
+    let total = app.crypto_events.len();
+    // Filtered events rendered newest-first to match selected_detail.
     let visible: Vec<_> = app
-        .crypto_events
-        .iter()
+        .filtered_crypto_events()
+        .collect::<Vec<_>>()
+        .into_iter()
         .rev()
         .take(area.height.saturating_sub(3) as usize)
         .collect();
@@ -571,19 +583,22 @@ fn draw_crypto_events(frame: &mut Frame, area: Rect, app: &App) {
         Constraint::Length(20),
         Constraint::Min(8),
     ];
+    let title = if app.filter.is_empty() {
+        format!("Rotation events ({} buffered, newest first)", total)
+    } else {
+        format!(
+            "Rotation events (filtered {}/{} for \"{}\", newest first)",
+            visible.len(),
+            total,
+            app.filter
+        )
+    };
     let table = Table::new(rows, widths)
         .header(
             Row::new(vec!["Time (ms)", "Kind", "Remote peer", "Sessions"])
                 .style(Style::default().add_modifier(Modifier::BOLD)),
         )
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!(
-                    "Rotation events ({} buffered, newest first)",
-                    app.crypto_events.len()
-                )),
-        );
+        .block(Block::default().borders(Borders::ALL).title(title));
     frame.render_widget(table, area);
 }
 
@@ -607,20 +622,62 @@ fn draw_events(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_help(frame: &mut Frame, area: Rect, app: &App) {
-    let msg = match app.input_mode {
-        InputMode::Composing => "Enter: send  Esc: cancel",
-        InputMode::Normal => match app.current_tab() {
-            Tab::Users => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
-            Tab::Feed => "[Tab] switch  [↑/↓] move  [s] send  [r] refresh  [q] quit",
-            Tab::Dtn => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
-            Tab::Network => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
-            Tab::Crypto => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
-        },
+    let msg: String = match app.input_mode {
+        InputMode::Composing => "Enter: send  Esc: cancel".into(),
+        InputMode::Filtering => format!("filter: /{}_   Enter: accept  Esc: clear", app.filter),
+        InputMode::Viewing => "Esc/Enter: close detail".into(),
+        InputMode::Normal => {
+            let send = matches!(app.current_tab(), Tab::Feed);
+            let mut parts =
+                vec!["[Tab] switch", "[↑/↓] move", "[Enter] detail", "[/] filter"];
+            if send {
+                parts.push("[s] send");
+            }
+            parts.push("[r] refresh");
+            parts.push("[q] quit");
+            parts.join("  ")
+        }
     };
     frame.render_widget(
         Paragraph::new(msg).style(Style::default().fg(Color::DarkGray)),
         area,
     );
+}
+
+fn draw_detail_modal(frame: &mut Frame, area: Rect, app: &App) {
+    let (title, fields) = match app.selected_detail() {
+        Some(d) => d,
+        None => ("(no selection)".to_string(), Vec::new()),
+    };
+    let width = area.width.saturating_sub(8).min(120);
+    let height = ((fields.len() as u16) * 2 + 4).min(area.height.saturating_sub(4));
+    let modal = Rect {
+        x: (area.width.saturating_sub(width)) / 2,
+        y: (area.height.saturating_sub(height)) / 2,
+        width,
+        height,
+    };
+    frame.render_widget(Clear, modal);
+
+    // One Line per field: bold label, then the value wrapped on the
+    // next line so untruncated ids don't blow out the column.
+    let mut lines: Vec<Line> = Vec::with_capacity(fields.len() * 2);
+    for (label, value) in &fields {
+        lines.push(Line::from(Span::styled(
+            format!("{label}:"),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::raw(value.clone())));
+    }
+    let p = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .style(Style::default().fg(Color::Yellow)),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(p, modal);
 }
 
 fn draw_compose_modal(frame: &mut Frame, area: Rect, app: &App) {

--- a/rust/clients/qauld-ctl/src/tui/ui.rs
+++ b/rust/clients/qauld-ctl/src/tui/ui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Tabs, Wrap},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Sparkline, Table, Tabs, Wrap},
     Frame,
 };
 
@@ -29,6 +29,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     match app.current_tab() {
         Tab::Users => draw_users(frame, chunks[1], app),
         Tab::Feed => draw_feed(frame, chunks[1], app),
+        Tab::Dtn => draw_dtn(frame, chunks[1], app),
     }
     draw_events(frame, chunks[2], app);
     draw_help(frame, chunks[3], app);
@@ -44,13 +45,14 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
         .constraints([Constraint::Min(20), Constraint::Length(40)])
         .split(area);
 
-    let titles: Vec<Line> = vec!["Users", "Feed"]
+    let titles: Vec<Line> = vec!["Users", "Feed", "DTN"]
         .into_iter()
         .map(|t| Line::from(Span::raw(t)))
         .collect();
     let idx = match app.current_tab() {
         Tab::Users => 0,
         Tab::Feed => 1,
+        Tab::Dtn => 2,
     };
     let tabs = Tabs::new(titles)
         .select(idx)
@@ -146,6 +148,146 @@ fn draw_feed(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(table, area);
 }
 
+fn draw_dtn(frame: &mut Frame, area: Rect, app: &App) {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(7),  // stats + sparkline
+            Constraint::Length(8),  // custodian users
+            Constraint::Min(4),     // delivery events
+        ])
+        .split(area);
+
+    // Stats row split into KPI cards on the left and sparkline on the right.
+    let top = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(38), Constraint::Min(20)])
+        .split(vertical[0]);
+    draw_dtn_kpis(frame, top[0], app);
+    draw_unconfirmed_sparkline(frame, top[1], app);
+
+    // Configured custodian users
+    draw_dtn_custodians(frame, vertical[1], app);
+
+    // Delivery-response event log
+    draw_dtn_delivery_events(frame, vertical[2], app);
+}
+
+fn draw_dtn_kpis(frame: &mut Frame, area: Rect, app: &App) {
+    let lines: Vec<Line> = match &app.dtn_state {
+        Some(s) => {
+            let limit = app
+                .dtn_config
+                .as_ref()
+                .map(|c| format!("/{} MB cap", c.total_size))
+                .unwrap_or_default();
+            vec![
+                Line::from(vec![
+                    Span::raw("used:        "),
+                    Span::styled(
+                        format!("{} MB{}", s.used_size, limit),
+                        Style::default().fg(Color::Cyan),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::raw("messages:    "),
+                    Span::styled(
+                        s.message_count.to_string(),
+                        Style::default().fg(Color::Cyan),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::raw("unconfirmed: "),
+                    Span::styled(
+                        s.unconfirmed_count.to_string(),
+                        Style::default()
+                            .fg(if s.unconfirmed_count > 0 {
+                                Color::Yellow
+                            } else {
+                                Color::Green
+                            })
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ]),
+            ]
+        }
+        None => vec![Line::from(Span::raw("(no DTN state yet)"))],
+    };
+    let p = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("DTN state"),
+    );
+    frame.render_widget(p, area);
+}
+
+fn draw_unconfirmed_sparkline(frame: &mut Frame, area: Rect, app: &App) {
+    let samples: Vec<u64> = app.dtn_unconfirmed_history.iter().copied().collect();
+    let sparkline = Sparkline::default()
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Unconfirmed (rolling)"),
+        )
+        .data(&samples)
+        .style(Style::default().fg(Color::Magenta));
+    frame.render_widget(sparkline, area);
+}
+
+fn draw_dtn_custodians(frame: &mut Frame, area: Rect, app: &App) {
+    let rows: Vec<Row> = match &app.dtn_config {
+        Some(cfg) => cfg
+            .users
+            .iter()
+            .enumerate()
+            .map(|(i, u)| {
+                let style = if i == app.cursor {
+                    Style::default().bg(Color::DarkGray)
+                } else {
+                    Style::default()
+                };
+                Row::new(vec![Cell::from(short_id(u))]).style(style)
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+    let widths = [Constraint::Min(20)];
+    let count = app.dtn_config.as_ref().map(|c| c.users.len()).unwrap_or(0);
+    let table = Table::new(rows, widths)
+        .header(
+            Row::new(vec!["Configured custodian users"])
+                .style(Style::default().add_modifier(Modifier::BOLD)),
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("Allowed custodians ({})", count)),
+        );
+    frame.render_widget(table, area);
+}
+
+fn draw_dtn_delivery_events(frame: &mut Frame, area: Rect, app: &App) {
+    let lines: Vec<Line> = app
+        .dtn_events
+        .iter()
+        .rev()
+        .take(area.height.saturating_sub(2) as usize)
+        .rev()
+        .map(|e| Line::from(Span::raw(e.clone())))
+        .collect();
+    let p = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(
+                    "Delivery responses (live, {} buffered)",
+                    app.dtn_events.len()
+                )),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(p, area);
+}
+
 fn draw_events(frame: &mut Frame, area: Rect, app: &App) {
     let lines: Vec<Line> = app
         .events
@@ -171,6 +313,7 @@ fn draw_help(frame: &mut Frame, area: Rect, app: &App) {
         InputMode::Normal => match app.current_tab() {
             Tab::Users => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
             Tab::Feed => "[Tab] switch  [↑/↓] move  [s] send  [r] refresh  [q] quit",
+            Tab::Dtn => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
         },
     };
     frame.render_widget(

--- a/rust/clients/qauld-ctl/src/tui/ui.rs
+++ b/rust/clients/qauld-ctl/src/tui/ui.rs
@@ -30,6 +30,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
         Tab::Users => draw_users(frame, chunks[1], app),
         Tab::Feed => draw_feed(frame, chunks[1], app),
         Tab::Dtn => draw_dtn(frame, chunks[1], app),
+        Tab::Network => draw_network(frame, chunks[1], app),
     }
     draw_events(frame, chunks[2], app);
     draw_help(frame, chunks[3], app);
@@ -45,7 +46,7 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
         .constraints([Constraint::Min(20), Constraint::Length(40)])
         .split(area);
 
-    let titles: Vec<Line> = vec!["Users", "Feed", "DTN"]
+    let titles: Vec<Line> = vec!["Users", "Feed", "DTN", "Network"]
         .into_iter()
         .map(|t| Line::from(Span::raw(t)))
         .collect();
@@ -53,6 +54,7 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
         Tab::Users => 0,
         Tab::Feed => 1,
         Tab::Dtn => 2,
+        Tab::Network => 3,
     };
     let tabs = Tabs::new(titles)
         .select(idx)
@@ -288,6 +290,172 @@ fn draw_dtn_delivery_events(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(p, area);
 }
 
+fn draw_network(frame: &mut Frame, area: Rect, app: &App) {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(9),  // per-module KPIs + sparklines
+            Constraint::Min(6),     // peers table
+            Constraint::Length(6),  // recent peer events
+        ])
+        .split(area);
+
+    draw_network_kpis(frame, vertical[0], app);
+    draw_network_peers(frame, vertical[1], app);
+    draw_network_events(frame, vertical[2], app);
+}
+
+fn draw_network_kpis(frame: &mut Frame, area: Rect, app: &App) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+            Constraint::Percentage(34),
+        ])
+        .split(area);
+
+    let (lan, internet, ble, local) = match &app.network {
+        Some(n) => (n.lan_peers, n.internet_peers, n.ble_peers, n.local_peers),
+        None => (0, 0, 0, 0),
+    };
+
+    draw_module_card(
+        frame,
+        cols[0],
+        "LAN",
+        lan,
+        local,
+        &app.network_history.lan,
+        Color::Cyan,
+    );
+    draw_module_card(
+        frame,
+        cols[1],
+        "Internet",
+        internet,
+        0,
+        &app.network_history.internet,
+        Color::Green,
+    );
+    draw_module_card(
+        frame,
+        cols[2],
+        "BLE",
+        ble,
+        0,
+        &app.network_history.ble,
+        Color::Magenta,
+    );
+}
+
+fn draw_module_card(
+    frame: &mut Frame,
+    area: Rect,
+    label: &str,
+    count: u32,
+    local: u32,
+    history: &std::collections::VecDeque<u64>,
+    color: Color,
+) {
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(2)])
+        .split(area);
+
+    let mut headline = vec![Line::from(vec![
+        Span::raw("peers: "),
+        Span::styled(
+            count.to_string(),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+    ])];
+    if label == "LAN" && local > 0 {
+        headline.push(Line::from(vec![
+            Span::raw("local: "),
+            Span::styled(local.to_string(), Style::default().fg(Color::Gray)),
+        ]));
+    }
+    let stats = Paragraph::new(headline).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(label.to_string()),
+    );
+    frame.render_widget(stats, inner[0]);
+
+    let samples: Vec<u64> = history.iter().copied().collect();
+    let sparkline = Sparkline::default()
+        .block(Block::default().borders(Borders::ALL).title("trend"))
+        .data(&samples)
+        .style(Style::default().fg(color));
+    frame.render_widget(sparkline, inner[1]);
+}
+
+fn draw_network_peers(frame: &mut Frame, area: Rect, app: &App) {
+    let peers: Vec<_> = app
+        .network
+        .as_ref()
+        .map(|n| n.peers.clone())
+        .unwrap_or_default();
+    let rows: Vec<Row> = peers
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let style = if i == app.cursor {
+                Style::default().bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![
+                Cell::from(p.module),
+                Cell::from(short_id(&p.user_id)),
+                Cell::from(p.hops.to_string()),
+                Cell::from(format!("{} ms", p.rtt_ms)),
+            ])
+            .style(style)
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Length(20),
+        Constraint::Length(5),
+        Constraint::Min(8),
+    ];
+    let table = Table::new(rows, widths)
+        .header(
+            Row::new(vec!["Module", "Peer", "Hops", "RTT"])
+                .style(Style::default().add_modifier(Modifier::BOLD)),
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("Peers ({})", peers.len())),
+        );
+    frame.render_widget(table, area);
+}
+
+fn draw_network_events(frame: &mut Frame, area: Rect, app: &App) {
+    let lines: Vec<Line> = app
+        .network_events
+        .iter()
+        .rev()
+        .take(area.height.saturating_sub(2) as usize)
+        .rev()
+        .map(|e| Line::from(Span::raw(e.clone())))
+        .collect();
+    let p = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(
+                    "Peer events (live, {} buffered)",
+                    app.network_events.len()
+                )),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(p, area);
+}
+
 fn draw_events(frame: &mut Frame, area: Rect, app: &App) {
     let lines: Vec<Line> = app
         .events
@@ -314,6 +482,7 @@ fn draw_help(frame: &mut Frame, area: Rect, app: &App) {
             Tab::Users => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
             Tab::Feed => "[Tab] switch  [↑/↓] move  [s] send  [r] refresh  [q] quit",
             Tab::Dtn => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
+            Tab::Network => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
         },
     };
     frame.render_widget(

--- a/rust/clients/qauld-ctl/src/tui/ui.rs
+++ b/rust/clients/qauld-ctl/src/tui/ui.rs
@@ -494,10 +494,7 @@ fn draw_crypto_config(frame: &mut Frame, area: Rect, app: &App) {
                         .add_modifier(Modifier::BOLD),
                 ),
             ]),
-            Line::from(format!("period (s):           {}", c.period_seconds)),
             Line::from(format!("volume (msgs):        {}", c.volume_messages)),
-            Line::from(format!("grace period (s):     {}", c.grace_period_seconds)),
-            Line::from(format!("grace volume (msgs):  {}", c.grace_volume_messages)),
         ],
         None => vec![Line::from(Span::raw("(no config yet)"))],
     };

--- a/rust/clients/qauld-ctl/src/tui/ui.rs
+++ b/rust/clients/qauld-ctl/src/tui/ui.rs
@@ -31,6 +31,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
         Tab::Feed => draw_feed(frame, chunks[1], app),
         Tab::Dtn => draw_dtn(frame, chunks[1], app),
         Tab::Network => draw_network(frame, chunks[1], app),
+        Tab::Crypto => draw_crypto(frame, chunks[1], app),
     }
     draw_events(frame, chunks[2], app);
     draw_help(frame, chunks[3], app);
@@ -46,7 +47,7 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
         .constraints([Constraint::Min(20), Constraint::Length(40)])
         .split(area);
 
-    let titles: Vec<Line> = vec!["Users", "Feed", "DTN", "Network"]
+    let titles: Vec<Line> = vec!["Users", "Feed", "DTN", "Network", "Crypto"]
         .into_iter()
         .map(|t| Line::from(Span::raw(t)))
         .collect();
@@ -55,6 +56,7 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
         Tab::Feed => 1,
         Tab::Dtn => 2,
         Tab::Network => 3,
+        Tab::Crypto => 4,
     };
     let tabs = Tabs::new(titles)
         .select(idx)
@@ -456,6 +458,135 @@ fn draw_network_events(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(p, area);
 }
 
+fn draw_crypto(frame: &mut Frame, area: Rect, app: &App) {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(8),  // config card
+            Constraint::Length(4),  // counts strip
+            Constraint::Min(4),     // rotation events table
+        ])
+        .split(area);
+
+    draw_crypto_config(frame, vertical[0], app);
+    draw_crypto_counts(frame, vertical[1], app);
+    draw_crypto_events(frame, vertical[2], app);
+}
+
+fn draw_crypto_config(frame: &mut Frame, area: Rect, app: &App) {
+    let lines: Vec<Line> = match &app.crypto_config {
+        Some(c) => vec![
+            Line::from(vec![
+                Span::raw("master switch:        "),
+                Span::styled(
+                    if c.enabled { "enabled" } else { "disabled" },
+                    Style::default()
+                        .fg(if c.enabled { Color::Green } else { Color::Red })
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(format!("period (s):           {}", c.period_seconds)),
+            Line::from(format!("volume (msgs):        {}", c.volume_messages)),
+            Line::from(format!("grace period (s):     {}", c.grace_period_seconds)),
+            Line::from(format!("grace volume (msgs):  {}", c.grace_volume_messages)),
+        ],
+        None => vec![Line::from(Span::raw("(no config yet)"))],
+    };
+    let p = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Noise rotation config"),
+    );
+    frame.render_widget(p, area);
+}
+
+fn draw_crypto_counts(frame: &mut Frame, area: Rect, app: &App) {
+    let mut rotated = 0u32;
+    let mut grace_expired = 0u32;
+    let mut dropped = 0u32;
+    for e in &app.crypto_events {
+        match e.kind {
+            "rotated" => rotated += 1,
+            "grace_expired" => grace_expired += 1,
+            "msg_dropped_past_grace" => dropped += 1,
+            _ => {}
+        }
+    }
+    let line = Line::from(vec![
+        Span::raw("buffered events: "),
+        Span::styled(
+            format!("rotated={rotated}"),
+            Style::default().fg(Color::Green),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("grace_expired={grace_expired}"),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("dropped_past_grace={dropped}"),
+            Style::default().fg(if dropped > 0 { Color::Red } else { Color::Gray }),
+        ),
+    ]);
+    let p = Paragraph::new(vec![line])
+        .block(Block::default().borders(Borders::ALL).title("Counts"));
+    frame.render_widget(p, area);
+}
+
+fn draw_crypto_events(frame: &mut Frame, area: Rect, app: &App) {
+    let visible: Vec<_> = app
+        .crypto_events
+        .iter()
+        .rev()
+        .take(area.height.saturating_sub(3) as usize)
+        .collect();
+    let rows: Vec<Row> = visible
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            let style = if i == app.cursor {
+                Style::default().bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            let kind_color = match e.kind {
+                "rotated" => Color::Green,
+                "grace_expired" => Color::Yellow,
+                "msg_dropped_past_grace" => Color::Red,
+                _ => Color::Gray,
+            };
+            Row::new(vec![
+                Cell::from(e.timestamp_ms.to_string()),
+                Cell::from(Span::styled(e.kind.to_string(), Style::default().fg(kind_color))),
+                Cell::from(short_id(&e.remote_id)),
+                Cell::from(format!("p={} d={}", e.primary_session_id, e.draining_session_id)),
+            ])
+            .style(style)
+        })
+        .collect();
+    let widths = [
+        Constraint::Length(14),
+        Constraint::Length(22),
+        Constraint::Length(20),
+        Constraint::Min(8),
+    ];
+    let table = Table::new(rows, widths)
+        .header(
+            Row::new(vec!["Time (ms)", "Kind", "Remote peer", "Sessions"])
+                .style(Style::default().add_modifier(Modifier::BOLD)),
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(
+                    "Rotation events ({} buffered, newest first)",
+                    app.crypto_events.len()
+                )),
+        );
+    frame.render_widget(table, area);
+}
+
 fn draw_events(frame: &mut Frame, area: Rect, app: &App) {
     let lines: Vec<Line> = app
         .events
@@ -483,6 +614,7 @@ fn draw_help(frame: &mut Frame, area: Rect, app: &App) {
             Tab::Feed => "[Tab] switch  [↑/↓] move  [s] send  [r] refresh  [q] quit",
             Tab::Dtn => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
             Tab::Network => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
+            Tab::Crypto => "[Tab] switch  [↑/↓] move  [r] refresh  [q] quit",
         },
     };
     frame.render_widget(

--- a/rust/libqaul/src/rpc/subscribe.rs
+++ b/rust/libqaul/src/rpc/subscribe.rs
@@ -222,6 +222,12 @@ pub const TOPIC_PEERS_DISCONNECTED: &str = "peers.disconnected";
 /// has accepted or rejected one of our DTN-stored messages).
 pub const TOPIC_DTN_DELIVERY_RESPONSE: &str = "dtn.delivery_response";
 
+/// Topic name for Noise session rotation events. Payload is the same
+/// `qaul.rpc.crypto.RotationEvent` proto already used by the
+/// `GetRotationEventsRequest` poll path; clients can reuse the
+/// existing decoder.
+pub const TOPIC_CRYPTO_ROTATION: &str = "crypto.rotation";
+
 /// Emit a `DtnDeliveryResponseEvent` to all active subscribers.
 ///
 /// Fired from the sender's side when a storage node returns a
@@ -271,6 +277,27 @@ pub fn emit_peer_disconnected(
     module: crate::connections::ConnectionModule,
 ) {
     emit_peer_event(state, TOPIC_PEERS_DISCONNECTED, peer_id, module);
+}
+
+/// Emit a `RotationEvent` (already in `qaul.rpc.crypto` proto shape)
+/// to all active subscribers on the `crypto.rotation` topic.
+///
+/// Mirrors what's recorded in the in-memory rotation event log —
+/// poll-based clients use `GetRotationEventsRequest`, push-based
+/// clients (e.g. qauld-tui's Crypto tab) bind this topic.
+pub fn emit_crypto_rotation(
+    state: &crate::QaulState,
+    event: &qaul_proto::qaul_rpc_crypto::RotationEvent,
+) {
+    if state.subscriptions.len() == 0 {
+        return;
+    }
+    let mut payload = Vec::with_capacity(event.encoded_len());
+    if let Err(e) = event.encode(&mut payload) {
+        log::error!("emit_crypto_rotation: encode failed: {e}");
+        return;
+    }
+    Subscribe::fire(state, TOPIC_CRYPTO_ROTATION, payload);
 }
 
 fn emit_peer_event(
@@ -470,6 +497,55 @@ mod tests {
         let payload = proto::PeerEvent::decode(&event.payload[..]).expect("PeerEvent decodes");
         assert_eq!(payload.peer_id, peer.to_bytes());
         assert_eq!(payload.module, ConnectionModule::Internet.as_int() as u32);
+    }
+
+    /// `emit_crypto_rotation` produces a frame on the libqaul→client
+    /// RPC channel for every active subscriber, carrying a
+    /// `crypto.rotation` topic and a `qaul.rpc.crypto.RotationEvent`
+    /// payload. Push parity for the poll-based event log.
+    #[test]
+    fn crypto_rotation_event_is_delivered_to_subscribers() {
+        let state = crate::QaulState::new_for_simulation();
+
+        let req = proto::Subscribe {
+            message: Some(proto::subscribe::Message::Request(
+                proto::SubscribeRequest { topics: Vec::new() },
+            )),
+        };
+        let mut data = Vec::new();
+        req.encode(&mut data).unwrap();
+        Subscribe::rpc(&state, data, Vec::new(), "sub-1".to_string());
+
+        let peer = libp2p::PeerId::from(libp2p::identity::Keypair::generate_ed25519().public());
+        let event = qaul_proto::qaul_rpc_crypto::RotationEvent {
+            kind: qaul_proto::qaul_rpc_crypto::RotationEventKind::Rotated as i32,
+            remote_id: peer.to_bytes(),
+            primary_session_id: 42,
+            draining_session_id: 41,
+            timestamp_ms: 123_456,
+        };
+        emit_crypto_rotation(&state, &event);
+
+        let frame = match Rpc::receive_from_libqaul(&state) {
+            Ok(f) => f,
+            Err(e) => panic!("expected one frame, got {e:?}"),
+        };
+        let qrpc = rpc_proto::QaulRpc::decode(&frame[..]).expect("QaulRpc decodes");
+        assert_eq!(qrpc.module, rpc_proto::Modules::Subscribe as i32);
+        assert_eq!(qrpc.request_id, "sub-1");
+
+        let envelope = proto::Subscribe::decode(&qrpc.data[..]).expect("Subscribe decodes");
+        let ev = match envelope.message {
+            Some(proto::subscribe::Message::Event(e)) => e,
+            other => panic!("expected Event, got {other:?}"),
+        };
+        assert_eq!(ev.topic, TOPIC_CRYPTO_ROTATION);
+
+        let payload = qaul_proto::qaul_rpc_crypto::RotationEvent::decode(&ev.payload[..])
+            .expect("RotationEvent decodes");
+        assert_eq!(payload.primary_session_id, 42);
+        assert_eq!(payload.draining_session_id, 41);
+        assert_eq!(payload.timestamp_ms, 123_456);
     }
 
     /// `emit_dtn_delivery_response` produces a frame on the libqaul→client

--- a/rust/libqaul/src/rpc/subscribe.rs
+++ b/rust/libqaul/src/rpc/subscribe.rs
@@ -203,6 +203,21 @@ pub const TOPIC_CHAT_MESSAGE: &str = "chat.message";
 /// Topic name for first-sighting of a peer on a transport.
 pub const TOPIC_PEERS_CONNECTED: &str = "peers.connected";
 
+/// Topic name for peer-disconnect / prune events.
+///
+/// Fired by the routing-table prune path when a previously-known
+/// neighbour is dropped from a transport's neighbour set (e.g. its
+/// `updated_at` aged past the staleness threshold, or the transport
+/// reported a `ConnectionClosed`). Payload is the same `PeerEvent`
+/// shape as `peers.connected` so subscribers can write one decoder.
+///
+/// Note: this is plumbing-only as of this commit — libqaul does not
+/// yet call `emit_peer_disconnected` from any prune site. The
+/// helper exists so the prune logic (when it lands as a separate
+/// design decision around the staleness threshold) doesn't have to
+/// touch the subscribe layer.
+pub const TOPIC_PEERS_DISCONNECTED: &str = "peers.disconnected";
+
 /// Topic name for DTN delivery responses (sender side: a storage node
 /// has accepted or rejected one of our DTN-stored messages).
 pub const TOPIC_DTN_DELIVERY_RESPONSE: &str = "dtn.delivery_response";
@@ -243,6 +258,27 @@ pub fn emit_peer_connected(
     peer_id: &libp2p::PeerId,
     module: crate::connections::ConnectionModule,
 ) {
+    emit_peer_event(state, TOPIC_PEERS_CONNECTED, peer_id, module);
+}
+
+/// Emit a `PeerEvent` on the `peers.disconnected` topic. Call this
+/// from the routing-table prune path when a neighbour is removed.
+///
+/// No call sites yet — see [`TOPIC_PEERS_DISCONNECTED`] for context.
+pub fn emit_peer_disconnected(
+    state: &crate::QaulState,
+    peer_id: &libp2p::PeerId,
+    module: crate::connections::ConnectionModule,
+) {
+    emit_peer_event(state, TOPIC_PEERS_DISCONNECTED, peer_id, module);
+}
+
+fn emit_peer_event(
+    state: &crate::QaulState,
+    topic: &'static str,
+    peer_id: &libp2p::PeerId,
+    module: crate::connections::ConnectionModule,
+) {
     if state.subscriptions.len() == 0 {
         return;
     }
@@ -253,11 +289,11 @@ pub fn emit_peer_connected(
     };
     let mut payload = Vec::with_capacity(event.encoded_len());
     if let Err(e) = event.encode(&mut payload) {
-        log::error!("emit_peer_connected: encode failed: {}", e);
+        log::error!("emit_peer_event({topic}): encode failed: {e}");
         return;
     }
 
-    Subscribe::fire(state, TOPIC_PEERS_CONNECTED, payload);
+    Subscribe::fire(state, topic, payload);
 }
 
 /// Emit a `ChatMessageEvent` to all active subscribers.
@@ -391,6 +427,49 @@ mod tests {
         let payload = proto::PeerEvent::decode(&event.payload[..]).expect("PeerEvent decodes");
         assert_eq!(payload.peer_id, peer.to_bytes());
         assert_eq!(payload.module, ConnectionModule::Lan.as_int() as u32);
+    }
+
+    /// `emit_peer_disconnected` shares the same wire shape as
+    /// `emit_peer_connected` (a `PeerEvent` payload) but fires on the
+    /// `peers.disconnected` topic. The plumbing must be in place even
+    /// though no routing-table prune call site exists yet — clients
+    /// (including qauld-tui) already subscribe to the topic.
+    #[test]
+    fn peer_disconnected_event_is_delivered_to_subscribers() {
+        use crate::connections::ConnectionModule;
+
+        let state = crate::QaulState::new_for_simulation();
+
+        let req = proto::Subscribe {
+            message: Some(proto::subscribe::Message::Request(
+                proto::SubscribeRequest { topics: Vec::new() },
+            )),
+        };
+        let mut data = Vec::new();
+        req.encode(&mut data).unwrap();
+        Subscribe::rpc(&state, data, Vec::new(), "sub-1".to_string());
+
+        let peer = libp2p::PeerId::from(libp2p::identity::Keypair::generate_ed25519().public());
+        emit_peer_disconnected(&state, &peer, ConnectionModule::Internet);
+
+        let frame = match Rpc::receive_from_libqaul(&state) {
+            Ok(f) => f,
+            Err(e) => panic!("expected one frame, got {e:?}"),
+        };
+        let qrpc = rpc_proto::QaulRpc::decode(&frame[..]).expect("QaulRpc decodes");
+        assert_eq!(qrpc.module, rpc_proto::Modules::Subscribe as i32);
+        assert_eq!(qrpc.request_id, "sub-1");
+
+        let envelope = proto::Subscribe::decode(&qrpc.data[..]).expect("Subscribe decodes");
+        let event = match envelope.message {
+            Some(proto::subscribe::Message::Event(ev)) => ev,
+            other => panic!("expected Event, got {other:?}"),
+        };
+        assert_eq!(event.topic, TOPIC_PEERS_DISCONNECTED);
+
+        let payload = proto::PeerEvent::decode(&event.payload[..]).expect("PeerEvent decodes");
+        assert_eq!(payload.peer_id, peer.to_bytes());
+        assert_eq!(payload.module, ConnectionModule::Internet.as_int() as u32);
     }
 
     /// `emit_dtn_delivery_response` produces a frame on the libqaul→client

--- a/rust/libqaul/src/services/crypto/events.rs
+++ b/rust/libqaul/src/services/crypto/events.rs
@@ -84,6 +84,52 @@ pub fn record(mut event: RotationEvent) {
     log.push_back(event);
 }
 
+/// Record the event in the in-memory log AND push it onto the
+/// `crypto.rotation` subscribe topic. Production call sites should
+/// use this so push-based clients (qauld-tui's Crypto tab) see
+/// rotations within ms instead of waiting for the next 3-second
+/// poll tick. `state` is `Option` so unit tests that exercise the
+/// rotation primitives without a full `QaulState` can keep calling
+/// `events::record` directly via `None` here.
+pub fn record_and_emit(state: Option<&crate::QaulState>, event: RotationEvent) {
+    // Stamp the timestamp before cloning so both the log and the
+    // emitted proto carry the same wall-clock value.
+    let stamped = if event.timestamp_ms == 0 {
+        RotationEvent {
+            timestamp_ms: Timestamp::get_timestamp(),
+            ..event
+        }
+    } else {
+        event
+    };
+
+    if let Some(s) = state {
+        let proto_event = to_proto(&stamped);
+        crate::rpc::subscribe::emit_crypto_rotation(s, &proto_event);
+    }
+    record(stamped);
+}
+
+fn to_proto(
+    event: &RotationEvent,
+) -> qaul_proto::qaul_rpc_crypto::RotationEvent {
+    use qaul_proto::qaul_rpc_crypto as proto;
+    let kind = match event.kind {
+        RotationEventKind::Rotated => proto::RotationEventKind::Rotated,
+        RotationEventKind::DrainCompleted => proto::RotationEventKind::DrainCompleted,
+        RotationEventKind::MessageDroppedPostDrain => {
+            proto::RotationEventKind::MessageDroppedPostDrain
+        }
+    };
+    proto::RotationEvent {
+        kind: kind as i32,
+        remote_id: event.remote_id.to_bytes(),
+        primary_session_id: event.primary_session_id,
+        draining_session_id: event.draining_session_id,
+        timestamp_ms: event.timestamp_ms,
+    }
+}
+
 /// Return every event with `timestamp_ms >= since_ms`, capped at
 /// `limit` (0 = unlimited). Ordered oldest → newest.
 pub fn query(since_ms: u64, limit: usize) -> Vec<RotationEvent> {

--- a/rust/libqaul/src/services/crypto/mod.rs
+++ b/rust/libqaul/src/services/crypto/mod.rs
@@ -1407,6 +1407,12 @@ mod phase2_tests {
             cipher_in: Some(vec![0u8; 32]),
             highest_index_nonce_in: 0,
             out_of_order_indexes: false,
+            pre_cipher_out: None,
+            pre_index_out: 0,
+            pre_cipher_in: None,
+            pre_index_in_highest: 0,
+            pre_index_in_seen: Vec::new(),
+            pre_bytes_accounted: 0,
             established_at: 0,
         }
     }
@@ -2134,6 +2140,12 @@ mod phase3_events_tests {
             cipher_in: Some(vec![0u8; 32]),
             highest_index_nonce_in: 0,
             out_of_order_indexes: false,
+            pre_cipher_out: None,
+            pre_index_out: 0,
+            pre_cipher_in: None,
+            pre_index_in_highest: 0,
+            pre_index_in_seen: Vec::new(),
+            pre_bytes_accounted: 0,
             established_at: 0,
         }
     }

--- a/rust/libqaul/src/services/crypto/mod.rs
+++ b/rust/libqaul/src/services/crypto/mod.rs
@@ -630,7 +630,7 @@ impl Crypto {
         if !Self::outbound_confirmed_on_session(state, remote_id, drain_id) {
             return; // unconfirmed outbound still references the old session
         }
-        CryptoNoise::retire_drain(crypto_account, remote_id, meta);
+        CryptoNoise::retire_drain(Some(state), crypto_account, remote_id, meta);
     }
 
     /// Re-check drain retirement after one of our outbound messages to
@@ -833,13 +833,16 @@ impl Crypto {
                             message.session_id,
                             remote_id.to_base58()
                         );
-                        events::record(events::RotationEvent {
-                            kind: events::RotationEventKind::MessageDroppedPostDrain,
-                            remote_id,
-                            primary_session_id: 0,
-                            draining_session_id: message.session_id,
-                            timestamp_ms: 0,
-                        });
+                        events::record_and_emit(
+                            Some(state),
+                            events::RotationEvent {
+                                kind: events::RotationEventKind::MessageDroppedPostDrain,
+                                remote_id,
+                                primary_session_id: 0,
+                                draining_session_id: message.session_id,
+                                timestamp_ms: 0,
+                            },
+                        );
                         return None;
                     }
                 }

--- a/rust/libqaul/src/services/crypto/noise.rs
+++ b/rust/libqaul/src/services/crypto/noise.rs
@@ -1138,6 +1138,12 @@ mod rotation_tests {
             cipher_in: Some(vec![0u8; 32]),
             highest_index_nonce_in: 0,
             out_of_order_indexes: false,
+            pre_cipher_out: None,
+            pre_index_out: 0,
+            pre_cipher_in: None,
+            pre_index_in_highest: 0,
+            pre_index_in_seen: Vec::new(),
+            pre_bytes_accounted: 0,
             established_at: 0,
         }
     }
@@ -1322,6 +1328,7 @@ mod handshake_extras_primitive_tests {
             pre_index_in_highest: 0,
             pre_index_in_seen: Vec::new(),
             pre_bytes_accounted: 0,
+            established_at: 0,
         }
     }
 

--- a/rust/libqaul/src/services/crypto/noise.rs
+++ b/rust/libqaul/src/services/crypto/noise.rs
@@ -965,6 +965,7 @@ impl CryptoNoise {
     /// the ACK's `final_nonce_out` at send time and sends it under the
     /// old (draining) session.
     pub fn rotate_finalize_initiator<D, C, H, P>(
+        state: Option<&crate::QaulState>,
         storage: CryptoAccount,
         remote_id: PeerId,
         incoming: proto_net::RotateHandshakeSecond,
@@ -1038,15 +1039,18 @@ impl CryptoNoise {
         };
         storage.save_rotation_meta(remote_id, &new_meta);
 
-        // Emit a `Rotated` event so clients can surface the state
-        // transition to the UI.
-        events::record(RotationEvent {
-            kind: RotationEventKind::Rotated,
-            remote_id,
-            primary_session_id: incoming.new_session_id,
-            draining_session_id: old_primary,
-            timestamp_ms: now_ms,
-        });
+        // Emit a `Rotated` event (record + push to crypto.rotation
+        // subscribers) so clients can surface the transition to the UI.
+        events::record_and_emit(
+            state,
+            RotationEvent {
+                kind: RotationEventKind::Rotated,
+                remote_id,
+                primary_session_id: incoming.new_session_id,
+                draining_session_id: old_primary,
+                timestamp_ms: now_ms,
+            },
+        );
 
         // `final_nonce_out` (our last A->B nonce on the old session) is
         // filled in by the caller at send time.
@@ -1078,7 +1082,12 @@ impl CryptoNoise {
     /// draining fields on the meta, and emit `DrainCompleted`. The
     /// caller is responsible for having checked both the inbound drain
     /// (`RotationMeta::drain_complete`) and outbound confirmation.
-    pub fn retire_drain(storage: &CryptoAccount, remote_id: PeerId, mut meta: RotationMeta) {
+    pub fn retire_drain(
+        state: Option<&crate::QaulState>,
+        storage: &CryptoAccount,
+        remote_id: PeerId,
+        mut meta: RotationMeta,
+    ) {
         let drain_id = match meta.draining_session_id {
             Some(id) => id,
             None => return,
@@ -1086,13 +1095,18 @@ impl CryptoNoise {
         storage.delete_state(remote_id, drain_id);
         meta.clear_drain(drain_id);
         storage.save_rotation_meta(remote_id, &meta);
-        events::record(RotationEvent {
-            kind: RotationEventKind::DrainCompleted,
-            remote_id,
-            primary_session_id: 0,
-            draining_session_id: drain_id,
-            timestamp_ms: 0,
-        });
+        // record + push to crypto.rotation subscribers (the TUI Crypto
+        // analytics tab). `state` is None only in unit tests.
+        events::record_and_emit(
+            state,
+            RotationEvent {
+                kind: RotationEventKind::DrainCompleted,
+                remote_id,
+                primary_session_id: 0,
+                draining_session_id: drain_id,
+                timestamp_ms: 0,
+            },
+        );
     }
 }
 
@@ -1205,7 +1219,7 @@ mod rotation_tests {
         };
         acct.save_rotation_meta(remote, &meta);
 
-        CryptoNoise::retire_drain(&acct, remote, meta);
+        CryptoNoise::retire_drain(None, &acct, remote, meta);
 
         assert!(acct.get_state_by_id(remote, 7).is_none());
         let after = acct.get_rotation_meta(remote).unwrap();

--- a/rust/libqaul/src/services/crypto/sessionmanager.rs
+++ b/rust/libqaul/src/services/crypto/sessionmanager.rs
@@ -251,7 +251,7 @@ impl CryptoSessionManager {
             ChaCha20Poly1305,
             Sha256,
             &[u8],
-        >(crypto_account.clone(), *sender_id, rotate_second)
+        >(Some(state), crypto_account.clone(), *sender_id, rotate_second)
         {
             Some(rf) => rf,
             None => {

--- a/rust/libqaul/src/services/crypto/storage.rs
+++ b/rust/libqaul/src/services/crypto/storage.rs
@@ -551,21 +551,6 @@ impl CryptoStorage {
         // State already exists in QaulState.services.crypto
     }
 
-    /// Build a `CryptoAccount` backed by anonymous in-memory sled
-    /// databases. Tests use this to exercise the storage-shaped APIs
-    /// (`save_state`, `get_state`, `get_state_by_id`) without
-    /// touching the daemon's `QaulState.database` and without any
-    /// disk I/O. Each call returns an independent account.
-    #[cfg(test)]
-    pub fn test_account() -> CryptoAccount {
-        use sled::Config;
-        let state_db = Config::new().temporary(true).open().unwrap();
-        let cache_db = Config::new().temporary(true).open().unwrap();
-        CryptoAccount {
-            state: state_db.open_tree("crypto_state").unwrap(),
-            cache: cache_db.open_tree("crypto_cache").unwrap(),
-        }
-    }
 
     /// get DB refs for user account
     pub fn get_db_ref(state: &crate::QaulState, account_id: PeerId) -> CryptoAccount {
@@ -864,6 +849,7 @@ mod legacy_state_decode_tests {
             pre_index_in_highest: 4,
             pre_index_in_seen: vec![0b1011],
             pre_bytes_accounted: 4096,
+            established_at: 0,
         };
         acct.save_state(remote, 9, state);
 


### PR DESCRIPTION
- Adds three analytics tabs to the qauld-ctl TUI (`qauld-ctl tui`):
    - **DTN** — custody routing health, in-flight messages, delivery responses
    - **Network** — peer connectivity per transport, with `peers.disconnected` plumbing
    - **Crypto** — session rotation events, currently-primary / draining session ids, grace-window state
  - Detail drawer (`Enter`) for inspecting the focused row in any tab
  - Per-tab filter (`/`) for narrowing rows by text match
  - libqaul: `peers.disconnected` subscribe topic plumbing (emitter + topic registration; prune call-sites land separately)
  - libqaul: push-based `crypto.rotation` subscribe topic — the Crypto tab consumes this instead of polling
Depends on (and is based on) these open PRs: #872 #853 