### PR TITLE
feat(users): echo request_id from UserUpdate to finish future-based RPC

### DIFF
--- a/protobuf/generated/rust/qaul.rpc.users.rs
+++ b/protobuf/generated/rust/qaul.rpc.users.rs
@@ -2,7 +2,7 @@
 /// users rpc message container
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Users {
-    #[prost(oneof = "users::Message", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    #[prost(oneof = "users::Message", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub message: ::core::option::Option<users::Message>,
 }
 /// Nested message and enum types in `Users`.
@@ -66,6 +66,12 @@ pub mod users {
         /// User Search Request returns a user list matching a name query.
         #[prost(message, tag = "9")]
         UserSearchRequest(super::UserSearchRequest),
+        /// User Update Response
+        ///
+        /// Libqaul's acknowledgement for a 'UserUpdate', echoing back the
+        /// updated user entry.
+        #[prost(message, tag = "10")]
+        UserUpdateResponse(super::UserUpdateResponse),
     }
 }
 /// UI request for some users
@@ -208,6 +214,12 @@ pub struct GetUserByIdRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetUserByIdResponse {
     #[prost(message, optional, tag = "10")]
+    pub user: ::core::option::Option<UserEntry>,
+}
+/// Acknowledgement for a UserUpdate, echoing back the updated user entry.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UserUpdateResponse {
+    #[prost(message, optional, tag = "1")]
     pub user: ::core::option::Option<UserEntry>,
 }
 /// Connection modules

--- a/protobuf/proto_definitions/router/users.proto
+++ b/protobuf/proto_definitions/router/users.proto
@@ -52,6 +52,11 @@ message Users {
         GetUserByIDResponse get_user_by_id_response = 8;
         // User Search Request returns a user list matching a name query.
         UserSearchRequest user_search_request = 9;
+        // User Update Response
+        //
+        // Libqaul's acknowledgement for a 'UserUpdate', echoing back the
+        // updated user entry.
+        UserUpdateResponse user_update_response = 10;
     }
 }
 
@@ -182,4 +187,9 @@ message GetUserByIDRequest {
 
 message GetUserByIDResponse {
     UserEntry user = 10;
+}
+
+// Acknowledgement for a UserUpdate, echoing back the updated user entry.
+message UserUpdateResponse {
+    UserEntry user = 1;
 }

--- a/qaul_ui/packages/qaul_rpc/lib/src/generated/router/users.pb.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/generated/router/users.pb.dart
@@ -12,6 +12,7 @@
 
 import 'dart:core' as $core;
 
+import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'users.pbenum.dart';
@@ -30,6 +31,7 @@ enum Users_Message {
   getUserByIdRequest,
   getUserByIdResponse,
   userSearchRequest,
+  userUpdateResponse,
   notSet
 }
 
@@ -45,6 +47,7 @@ class Users extends $pb.GeneratedMessage {
     GetUserByIDRequest? getUserByIdRequest,
     GetUserByIDResponse? getUserByIdResponse,
     UserSearchRequest? userSearchRequest,
+    UserUpdateResponse? userUpdateResponse,
   }) {
     final result = create();
     if (userRequest != null) result.userRequest = userRequest;
@@ -60,6 +63,8 @@ class Users extends $pb.GeneratedMessage {
     if (getUserByIdResponse != null)
       result.getUserByIdResponse = getUserByIdResponse;
     if (userSearchRequest != null) result.userSearchRequest = userSearchRequest;
+    if (userUpdateResponse != null)
+      result.userUpdateResponse = userUpdateResponse;
     return result;
   }
 
@@ -82,13 +87,14 @@ class Users extends $pb.GeneratedMessage {
     7: Users_Message.getUserByIdRequest,
     8: Users_Message.getUserByIdResponse,
     9: Users_Message.userSearchRequest,
+    10: Users_Message.userUpdateResponse,
     0: Users_Message.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       _omitMessageNames ? '' : 'Users',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'qaul.rpc.users'),
       createEmptyInstance: create)
-    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     ..aOM<UserRequest>(1, _omitFieldNames ? '' : 'userRequest',
         subBuilder: UserRequest.create)
     ..aOM<UserOnlineRequest>(2, _omitFieldNames ? '' : 'userOnlineRequest',
@@ -109,6 +115,8 @@ class Users extends $pb.GeneratedMessage {
         subBuilder: GetUserByIDResponse.create)
     ..aOM<UserSearchRequest>(9, _omitFieldNames ? '' : 'userSearchRequest',
         subBuilder: UserSearchRequest.create)
+    ..aOM<UserUpdateResponse>(10, _omitFieldNames ? '' : 'userUpdateResponse',
+        subBuilder: UserUpdateResponse.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -138,6 +146,7 @@ class Users extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   @$pb.TagNumber(8)
   @$pb.TagNumber(9)
+  @$pb.TagNumber(10)
   Users_Message whichMessage() => _Users_MessageByTag[$_whichOneof(0)]!;
   @$pb.TagNumber(1)
   @$pb.TagNumber(2)
@@ -148,6 +157,7 @@ class Users extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   @$pb.TagNumber(8)
   @$pb.TagNumber(9)
+  @$pb.TagNumber(10)
   void clearMessage() => $_clearField($_whichOneof(0));
 
   /// User Request returns a user list
@@ -289,6 +299,21 @@ class Users extends $pb.GeneratedMessage {
   void clearUserSearchRequest() => $_clearField(9);
   @$pb.TagNumber(9)
   UserSearchRequest ensureUserSearchRequest() => $_ensure(8);
+
+  /// User Update Response
+  ///
+  /// Libqaul's acknowledgement for a 'UserUpdate', echoing back the
+  /// updated user entry.
+  @$pb.TagNumber(10)
+  UserUpdateResponse get userUpdateResponse => $_getN(9);
+  @$pb.TagNumber(10)
+  set userUpdateResponse(UserUpdateResponse value) => $_setField(10, value);
+  @$pb.TagNumber(10)
+  $core.bool hasUserUpdateResponse() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearUserUpdateResponse() => $_clearField(10);
+  @$pb.TagNumber(10)
+  UserUpdateResponse ensureUserUpdateResponse() => $_ensure(9);
 }
 
 /// UI request for some users
@@ -681,6 +706,11 @@ class UserEntry extends $pb.GeneratedMessage {
     $core.bool? verified,
     $core.bool? blocked,
     $core.Iterable<RoutingTableConnection>? connections,
+    $core.String? bio,
+    $core.List<$core.int>? avatar,
+    $core.int? profileVersion,
+    $fixnum.Int64? profileUpdatedAt,
+    $core.Iterable<$core.List<$core.int>>? preferredCustodyRoute,
   }) {
     final result = create();
     if (name != null) result.name = name;
@@ -691,6 +721,12 @@ class UserEntry extends $pb.GeneratedMessage {
     if (verified != null) result.verified = verified;
     if (blocked != null) result.blocked = blocked;
     if (connections != null) result.connections.addAll(connections);
+    if (bio != null) result.bio = bio;
+    if (avatar != null) result.avatar = avatar;
+    if (profileVersion != null) result.profileVersion = profileVersion;
+    if (profileUpdatedAt != null) result.profileUpdatedAt = profileUpdatedAt;
+    if (preferredCustodyRoute != null)
+      result.preferredCustodyRoute.addAll(preferredCustodyRoute);
     return result;
   }
 
@@ -719,6 +755,16 @@ class UserEntry extends $pb.GeneratedMessage {
     ..aOB(10, _omitFieldNames ? '' : 'blocked')
     ..pPM<RoutingTableConnection>(11, _omitFieldNames ? '' : 'connections',
         subBuilder: RoutingTableConnection.create)
+    ..aOS(12, _omitFieldNames ? '' : 'bio')
+    ..a<$core.List<$core.int>>(
+        13, _omitFieldNames ? '' : 'avatar', $pb.PbFieldType.OY)
+    ..aI(14, _omitFieldNames ? '' : 'profileVersion',
+        fieldType: $pb.PbFieldType.OU3)
+    ..a<$fixnum.Int64>(
+        15, _omitFieldNames ? '' : 'profileUpdatedAt', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..p<$core.List<$core.int>>(
+        16, _omitFieldNames ? '' : 'preferredCustodyRoute', $pb.PbFieldType.PY)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -815,6 +861,50 @@ class UserEntry extends $pb.GeneratedMessage {
   /// RoutingTableConnection connections = 11;
   @$pb.TagNumber(11)
   $pb.PbList<RoutingTableConnection> get connections => $_getList(7);
+
+  /// bio / status text
+  @$pb.TagNumber(12)
+  $core.String get bio => $_getSZ(8);
+  @$pb.TagNumber(12)
+  set bio($core.String value) => $_setString(8, value);
+  @$pb.TagNumber(12)
+  $core.bool hasBio() => $_has(8);
+  @$pb.TagNumber(12)
+  void clearBio() => $_clearField(12);
+
+  /// avatar bytes (small image)
+  @$pb.TagNumber(13)
+  $core.List<$core.int> get avatar => $_getN(9);
+  @$pb.TagNumber(13)
+  set avatar($core.List<$core.int> value) => $_setBytes(9, value);
+  @$pb.TagNumber(13)
+  $core.bool hasAvatar() => $_has(9);
+  @$pb.TagNumber(13)
+  void clearAvatar() => $_clearField(13);
+
+  /// profile version number — MUST mirror UserProfile.version (uint32).
+  @$pb.TagNumber(14)
+  $core.int get profileVersion => $_getIZ(10);
+  @$pb.TagNumber(14)
+  set profileVersion($core.int value) => $_setUnsignedInt32(10, value);
+  @$pb.TagNumber(14)
+  $core.bool hasProfileVersion() => $_has(10);
+  @$pb.TagNumber(14)
+  void clearProfileVersion() => $_clearField(14);
+
+  /// profile last updated timestamp (ms since epoch)
+  @$pb.TagNumber(15)
+  $fixnum.Int64 get profileUpdatedAt => $_getI64(11);
+  @$pb.TagNumber(15)
+  set profileUpdatedAt($fixnum.Int64 value) => $_setInt64(11, value);
+  @$pb.TagNumber(15)
+  $core.bool hasProfileUpdatedAt() => $_has(11);
+  @$pb.TagNumber(15)
+  void clearProfileUpdatedAt() => $_clearField(15);
+
+  /// preferred custody route for DTN V2 delivery (ordered PeerIds)
+  @$pb.TagNumber(16)
+  $pb.PbList<$core.List<$core.int>> get preferredCustodyRoute => $_getList(12);
 }
 
 /// Routing table connection entry.
@@ -1166,6 +1256,64 @@ class GetUserByIDResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   void clearUser() => $_clearField(10);
   @$pb.TagNumber(10)
+  UserEntry ensureUser() => $_ensure(0);
+}
+
+/// Acknowledgement for a UserUpdate, echoing back the updated user entry.
+class UserUpdateResponse extends $pb.GeneratedMessage {
+  factory UserUpdateResponse({
+    UserEntry? user,
+  }) {
+    final result = create();
+    if (user != null) result.user = user;
+    return result;
+  }
+
+  UserUpdateResponse._();
+
+  factory UserUpdateResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UserUpdateResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UserUpdateResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'qaul.rpc.users'),
+      createEmptyInstance: create)
+    ..aOM<UserEntry>(1, _omitFieldNames ? '' : 'user',
+        subBuilder: UserEntry.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UserUpdateResponse clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UserUpdateResponse copyWith(void Function(UserUpdateResponse) updates) =>
+      super.copyWith((message) => updates(message as UserUpdateResponse))
+          as UserUpdateResponse;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UserUpdateResponse create() => UserUpdateResponse._();
+  @$core.override
+  UserUpdateResponse createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static UserUpdateResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<UserUpdateResponse>(create);
+  static UserUpdateResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  UserEntry get user => $_getN(0);
+  @$pb.TagNumber(1)
+  set user(UserEntry value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasUser() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearUser() => $_clearField(1);
+  @$pb.TagNumber(1)
   UserEntry ensureUser() => $_ensure(0);
 }
 

--- a/qaul_ui/packages/qaul_rpc/lib/src/generated/router/users.pbjson.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/generated/router/users.pbjson.dart
@@ -131,6 +131,15 @@ const Users$json = {
       '9': 0,
       '10': 'userSearchRequest'
     },
+    {
+      '1': 'user_update_response',
+      '3': 10,
+      '4': 1,
+      '5': 11,
+      '6': '.qaul.rpc.users.UserUpdateResponse',
+      '9': 0,
+      '10': 'userUpdateResponse'
+    },
   ],
   '8': [
     {'1': 'message'},
@@ -152,7 +161,9 @@ final $typed_data.Uint8List usersDescriptor = $convert.base64Decode(
     'SWRSZXF1ZXN0ElsKF2dldF91c2VyX2J5X2lkX3Jlc3BvbnNlGAggASgLMiMucWF1bC5ycGMudX'
     'NlcnMuR2V0VXNlckJ5SURSZXNwb25zZUgAUhNnZXRVc2VyQnlJZFJlc3BvbnNlElMKE3VzZXJf'
     'c2VhcmNoX3JlcXVlc3QYCSABKAsyIS5xYXVsLnJwYy51c2Vycy5Vc2VyU2VhcmNoUmVxdWVzdE'
-    'gAUhF1c2VyU2VhcmNoUmVxdWVzdEIJCgdtZXNzYWdl');
+    'gAUhF1c2VyU2VhcmNoUmVxdWVzdBJWChR1c2VyX3VwZGF0ZV9yZXNwb25zZRgKIAEoCzIiLnFh'
+    'dWwucnBjLnVzZXJzLlVzZXJVcGRhdGVSZXNwb25zZUgAUhJ1c2VyVXBkYXRlUmVzcG9uc2VCCQ'
+    'oHbWVzc2FnZQ==');
 
 @$core.Deprecated('Use userRequestDescriptor instead')
 const UserRequest$json = {
@@ -271,6 +282,23 @@ const UserEntry$json = {
       '6': '.qaul.rpc.users.RoutingTableConnection',
       '10': 'connections'
     },
+    {'1': 'bio', '3': 12, '4': 1, '5': 9, '10': 'bio'},
+    {'1': 'avatar', '3': 13, '4': 1, '5': 12, '10': 'avatar'},
+    {'1': 'profile_version', '3': 14, '4': 1, '5': 13, '10': 'profileVersion'},
+    {
+      '1': 'profile_updated_at',
+      '3': 15,
+      '4': 1,
+      '5': 4,
+      '10': 'profileUpdatedAt'
+    },
+    {
+      '1': 'preferred_custody_route',
+      '3': 16,
+      '4': 3,
+      '5': 12,
+      '10': 'preferredCustodyRoute'
+    },
   ],
 };
 
@@ -281,7 +309,10 @@ final $typed_data.Uint8List userEntryDescriptor = $convert.base64Decode(
     'bm5lY3Rpdml0eRgIIAEoDjIcLnFhdWwucnBjLnVzZXJzLkNvbm5lY3Rpdml0eVIMY29ubmVjdG'
     'l2aXR5EhoKCHZlcmlmaWVkGAkgASgIUgh2ZXJpZmllZBIYCgdibG9ja2VkGAogASgIUgdibG9j'
     'a2VkEkgKC2Nvbm5lY3Rpb25zGAsgAygLMiYucWF1bC5ycGMudXNlcnMuUm91dGluZ1RhYmxlQ2'
-    '9ubmVjdGlvblILY29ubmVjdGlvbnM=');
+    '9ubmVjdGlvblILY29ubmVjdGlvbnMSEAoDYmlvGAwgASgJUgNiaW8SFgoGYXZhdGFyGA0gASgM'
+    'UgZhdmF0YXISJwoPcHJvZmlsZV92ZXJzaW9uGA4gASgNUg5wcm9maWxlVmVyc2lvbhIsChJwcm'
+    '9maWxlX3VwZGF0ZWRfYXQYDyABKARSEHByb2ZpbGVVcGRhdGVkQXQSNgoXcHJlZmVycmVkX2N1'
+    'c3RvZHlfcm91dGUYECADKAxSFXByZWZlcnJlZEN1c3RvZHlSb3V0ZQ==');
 
 @$core.Deprecated('Use routingTableConnectionDescriptor instead')
 const RoutingTableConnection$json = {
@@ -374,3 +405,23 @@ const GetUserByIDResponse$json = {
 final $typed_data.Uint8List getUserByIDResponseDescriptor = $convert.base64Decode(
     'ChNHZXRVc2VyQnlJRFJlc3BvbnNlEi0KBHVzZXIYCiABKAsyGS5xYXVsLnJwYy51c2Vycy5Vc2'
     'VyRW50cnlSBHVzZXI=');
+
+@$core.Deprecated('Use userUpdateResponseDescriptor instead')
+const UserUpdateResponse$json = {
+  '1': 'UserUpdateResponse',
+  '2': [
+    {
+      '1': 'user',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.qaul.rpc.users.UserEntry',
+      '10': 'user'
+    },
+  ],
+};
+
+/// Descriptor for `UserUpdateResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List userUpdateResponseDescriptor = $convert.base64Decode(
+    'ChJVc2VyVXBkYXRlUmVzcG9uc2USLQoEdXNlchgBIAEoCzIZLnFhdWwucnBjLnVzZXJzLlVzZX'
+    'JFbnRyeVIEdXNlcg==');

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
@@ -178,27 +178,33 @@ class LibqaulWorker {
   }
 
   Future<void> verifyUser(User u) async {
-    var entry = _baseUserEntryFrom(u);
-    entry.verified = true;
-    await _sendMessage(Modules.USERS, Users(userUpdate: entry));
+    final entry = _baseUserEntryFrom(u)..verified = true;
+    await _updateUser(entry);
   }
 
   Future<void> unverifyUser(User u) async {
-    var entry = _baseUserEntryFrom(u);
-    entry.verified = false;
-    await _sendMessage(Modules.USERS, Users(userUpdate: entry));
+    final entry = _baseUserEntryFrom(u)..verified = false;
+    await _updateUser(entry);
   }
 
   Future<void> blockUser(User u) async {
-    final entry = _baseUserEntryFrom(u);
-    entry.blocked = true;
-    await _sendMessage(Modules.USERS, Users(userUpdate: entry));
+    final entry = _baseUserEntryFrom(u)..blocked = true;
+    await _updateUser(entry);
   }
 
   Future<void> unblockUser(User u) async {
-    final entry = _baseUserEntryFrom(u);
-    entry.blocked = false;
-    await _sendMessage(Modules.USERS, Users(userUpdate: entry));
+    final entry = _baseUserEntryFrom(u)..blocked = false;
+    await _updateUser(entry);
+  }
+
+  /// Sends a [UserEntry] update (verify/block) and awaits libqaul's acknowledgement
+  Future<void> _updateUser(UserEntry entry) async {
+    await _sendRequest<User>(
+      module: Modules.USERS,
+      data: Users(userUpdate: entry),
+      adapter: (res) =>
+          res.data is UserUpdateResult ? (res.data as UserUpdateResult).user : null,
+    );
   }
 
   Future<NodeInfo?> getNodeInfo() async {

--- a/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/rpc_translators/users_translator.dart
@@ -5,6 +5,11 @@ class GetUserByIdResult {
   GetUserByIdResult(this.user);
 }
 
+class UserUpdateResult {
+  final User? user;
+  UserUpdateResult(this.user);
+}
+
 class UsersTranslator extends RpcModuleTranslator {
   @override
   Modules get type => Modules.USERS;
@@ -16,19 +21,7 @@ class UsersTranslator extends RpcModuleTranslator {
     switch (message.whichMessage()) {
       case Users_Message.userList:
         final userList = message.ensureUserList();
-        final users = userList
-            .user
-            .map((u) => User(
-                  name: u.name,
-                  id: Uint8List.fromList(u.id),
-                  conversationId: Uint8List.fromList(u.groupId),
-                  keyBase58: u.keyBase58,
-                  isBlocked: u.blocked,
-                  isVerified: u.verified,
-                  status: _mapFrom(u.connectivity),
-                  availableTypes: _mapFromRoutingTable(u.connections),
-                ))
-            .toList();
+        final users = userList.user.map(_userFromEntry).toList();
 
         PaginationState? pagination;
         if (userList.hasPagination()) {
@@ -57,22 +50,30 @@ class UsersTranslator extends RpcModuleTranslator {
         if (!res.hasUser()) {
           return RpcTranslatorResponse(type, GetUserByIdResult(null));
         }
-        final u = res.user;
-        final user = User(
-          name: u.name,
-          id: Uint8List.fromList(u.id),
-          conversationId: Uint8List.fromList(u.groupId),
-          keyBase58: u.keyBase58,
-          isBlocked: u.blocked,
-          isVerified: u.verified,
-          status: _mapFrom(u.connectivity),
-          availableTypes: _mapFromRoutingTable(u.connections),
-        );
-        return RpcTranslatorResponse(type, GetUserByIdResult(user));
+        return RpcTranslatorResponse(
+            type, GetUserByIdResult(_userFromEntry(res.user)));
+      case Users_Message.userUpdateResponse:
+        final res = message.ensureUserUpdateResponse();
+        if (!res.hasUser()) {
+          return RpcTranslatorResponse(type, UserUpdateResult(null));
+        }
+        return RpcTranslatorResponse(
+            type, UserUpdateResult(_userFromEntry(res.user)));
       default:
         return super.decodeMessageBytes(data, ref);
     }
   }
+
+  User _userFromEntry(UserEntry u) => User(
+        name: u.name,
+        id: Uint8List.fromList(u.id),
+        conversationId: Uint8List.fromList(u.groupId),
+        keyBase58: u.keyBase58,
+        isBlocked: u.blocked,
+        isVerified: u.verified,
+        status: _mapFrom(u.connectivity),
+        availableTypes: _mapFromRoutingTable(u.connections),
+      );
 
   ConnectionStatus _mapFrom(Connectivity c) {
     if (c == Connectivity.Online) return ConnectionStatus.online;

--- a/rust/libqaul/src/router/users.rs
+++ b/rust/libqaul/src/router/users.rs
@@ -681,11 +681,13 @@ impl Users {
                     }
                     Some(proto::users::Message::UserUpdate(updated_user)) => {
                         log::trace!("UserUpdate protobuf RPC message");
+                        // the authenticated account requesting the update
+                        let account_id = PeerId::from_bytes(&user_id).ok();
                         // attempt to find the user with the associated id
                         Self::with_resolved_user(
                             router,
                             &updated_user.id,
-                            |user_id, _q8id, user_result| {
+                            |user_id, q8id, user_result| {
                                 user_result.verified = updated_user.verified;
                                 user_result.blocked = updated_user.blocked;
 
@@ -704,6 +706,19 @@ impl Users {
                                     signed_profile_signature: user_result.signed_profile_signature.clone(),
                                     preferred_custody_route: user_result.preferred_custody_route.clone(),
                                 });
+
+                                // acknowledge the update by echoing back the
+                                // updated user entry (carries the request_id)
+                                let online_users = RoutingTable::get_online_users_info(router);
+                                let entry =
+                                    build_user_entry(user_result, &online_users, &account_id, q8id);
+                                send_users_rpc_message(
+                                    state,
+                                    proto::users::Message::UserUpdateResponse(
+                                        proto::UserUpdateResponse { user: Some(entry) },
+                                    ),
+                                    request_id,
+                                );
                             },
                         );
                     }


### PR DESCRIPTION
Enable future-based implementation for methods driving the users tab in the frontend, we add an echo-back on the remaining method that doesn't yet return the request id