### PR TITLE
feat: crdt for group membership and metadata

### DIFF
--- a/protobuf/generated/rust/qaul.net.group.rs
+++ b/protobuf/generated/rust/qaul.net.group.rs
@@ -153,6 +153,10 @@ pub struct GroupInfo {
     /// updated members
     #[prost(message, repeated, tag = "5")]
     pub members: ::prost::alloc::vec::Vec<GroupMember>,
+    /// group founder (CRDT bootstrap admin); carried so invitees learn
+    /// it and can derive the membership CRDT. Empty from pre-CRDT peers.
+    #[prost(bytes = "vec", tag = "6")]
+    pub founder: ::prost::alloc::vec::Vec<u8>,
 }
 /// Reply to Invite
 ///

--- a/protobuf/generated/rust/qaul.net.group.rs
+++ b/protobuf/generated/rust/qaul.net.group.rs
@@ -2,7 +2,7 @@
 /// Group network message container
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GroupContainer {
-    #[prost(oneof = "group_container::Message", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "group_container::Message", tags = "1, 2, 3, 4, 5")]
     pub message: ::core::option::Option<group_container::Message>,
 }
 /// Nested message and enum types in `GroupContainer`.
@@ -21,7 +21,91 @@ pub mod group_container {
         /// member removed
         #[prost(message, tag = "4")]
         Removed(super::RemovedMember),
+        /// CRDT signed membership/metadata operation. Sent by nodes that
+        /// advertise Capabilities::GROUP_CRDT; see
+        /// docs/proposals/Group-State-CRDT.md.
+        #[prost(message, tag = "5")]
+        GroupOp(super::GroupOp),
     }
+}
+/// A single signed group CRDT operation.
+///
+/// The signature in field 9 covers the deterministic protobuf encoding
+/// of this same message with `signature` left empty — i.e. fields 1..8
+/// plus the `op` oneof — produced by the actor's identity (Ed25519) key.
+/// Verifiers look the actor's public key up by `actor_id` (a PeerId is a
+/// hash of the key) and check both the signature and that `actor_id`
+/// matches that key.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GroupOp {
+    /// the group this op belongs to
+    #[prost(bytes = "vec", tag = "1")]
+    pub group_id: ::prost::alloc::vec::Vec<u8>,
+    /// 16-byte random operation id (dedup key for the grow-only op set)
+    #[prost(bytes = "vec", tag = "2")]
+    pub op_id: ::prost::alloc::vec::Vec<u8>,
+    /// PeerId bytes of the signer
+    #[prost(bytes = "vec", tag = "3")]
+    pub actor_id: ::prost::alloc::vec::Vec<u8>,
+    /// group-local lamport clock value
+    #[prost(uint64, tag = "4")]
+    pub lamport: u64,
+    /// wall-clock ms at creation (display/diagnostics only)
+    #[prost(uint64, tag = "5")]
+    pub created_at: u64,
+    /// Ed25519 signature over the op with this field empty
+    #[prost(bytes = "vec", tag = "9")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    #[prost(oneof = "group_op::Op", tags = "6, 7, 8, 10")]
+    pub op: ::core::option::Option<group_op::Op>,
+}
+/// Nested message and enum types in `GroupOp`.
+pub mod group_op {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Op {
+        #[prost(message, tag = "6")]
+        Add(super::AddMemberOp),
+        #[prost(message, tag = "7")]
+        Remove(super::RemoveMemberOp),
+        #[prost(message, tag = "8")]
+        Meta(super::UpdateMetadataOp),
+        #[prost(message, tag = "10")]
+        Compact(super::CompactOp),
+    }
+}
+/// Add (or re-add, or promote) a member.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AddMemberOp {
+    #[prost(bytes = "vec", tag = "1")]
+    pub member_id: ::prost::alloc::vec::Vec<u8>,
+    /// 0 = member, 255 = admin
+    #[prost(int32, tag = "2")]
+    pub role: i32,
+}
+/// Remove a member, tombstoning the add op_ids it has observed.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RemoveMemberOp {
+    #[prost(bytes = "vec", tag = "1")]
+    pub member_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub observed_adds: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+/// Update group metadata (only present fields are written, LWW).
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct UpdateMetadataOp {
+    #[prost(string, optional, tag = "1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(bytes = "vec", optional, tag = "2")]
+    pub avatar: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
+/// Compaction barrier: collapse tombstones below `below`, raising the
+/// epoch. Admin-issued.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CompactOp {
+    #[prost(uint64, tag = "1")]
+    pub epoch: u64,
+    #[prost(uint64, tag = "2")]
+    pub below: u64,
 }
 /// Invite member
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/protobuf/generated/rust/qaul.rpc.group.rs
+++ b/protobuf/generated/rust/qaul.rpc.group.rs
@@ -5,7 +5,7 @@ pub struct Group {
     /// message type
     #[prost(
         oneof = "group::Message",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
     )]
     pub message: ::core::option::Option<group::Message>,
 }
@@ -69,7 +69,48 @@ pub mod group {
         /// more recently active rooms breaking ties.
         #[prost(message, tag = "17")]
         GroupSearchRequest(super::GroupSearchRequest),
+        /// CRDT membership/metadata view (read the derived state)
+        #[prost(message, tag = "18")]
+        GroupCrdtViewRequest(super::GroupCrdtViewRequest),
+        #[prost(message, tag = "19")]
+        GroupCrdtViewResponse(super::GroupCrdtViewResponse),
     }
+}
+/// Read the converged CRDT view of a group's membership & metadata.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GroupCrdtViewRequest {
+    #[prost(bytes = "vec", tag = "1")]
+    pub group_id: ::prost::alloc::vec::Vec<u8>,
+}
+/// One member in the derived CRDT view.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GroupCrdtMember {
+    #[prost(bytes = "vec", tag = "1")]
+    pub user_id: ::prost::alloc::vec::Vec<u8>,
+    /// 0 = member, 255 = admin
+    #[prost(int32, tag = "2")]
+    pub role: i32,
+}
+/// The derived CRDT view.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GroupCrdtViewResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub group_id: ::prost::alloc::vec::Vec<u8>,
+    /// false when the group is unknown or predates the CRDT (no founder)
+    #[prost(bool, tag = "2")]
+    pub found: bool,
+    /// group founder (bootstrap admin)
+    #[prost(bytes = "vec", tag = "3")]
+    pub founder: ::prost::alloc::vec::Vec<u8>,
+    /// derived metadata name (empty if unset)
+    #[prost(string, tag = "4")]
+    pub name: ::prost::alloc::string::String,
+    /// number of ops retained in the op set
+    #[prost(uint32, tag = "5")]
+    pub op_count: u32,
+    /// present members with their effective role
+    #[prost(message, repeated, tag = "6")]
+    pub members: ::prost::alloc::vec::Vec<GroupCrdtMember>,
 }
 /// Group Result
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/protobuf/generated/rust/qaul.rpc.group.rs
+++ b/protobuf/generated/rust/qaul.rpc.group.rs
@@ -5,7 +5,7 @@ pub struct Group {
     /// message type
     #[prost(
         oneof = "group::Message",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
     )]
     pub message: ::core::option::Option<group::Message>,
 }
@@ -62,15 +62,22 @@ pub mod group {
         /// group invited response
         #[prost(message, tag = "16")]
         GroupInvitedResponse(super::GroupInvitedResponse),
-        /// CRDT membership/metadata view (read the derived state)
+        /// group search request
+        ///
+        /// Searches groups/rooms by name (direct chats match the partner's
+        /// username) and returns a GroupListResponse ranked by relevance, with
+        /// more recently active rooms breaking ties.
         #[prost(message, tag = "17")]
-        GroupCrdtViewRequest(super::GroupCrdtViewRequest),
+        GroupSearchRequest(super::GroupSearchRequest),
+        /// CRDT membership/metadata view (read the derived state)
         #[prost(message, tag = "18")]
+        GroupCrdtViewRequest(super::GroupCrdtViewRequest),
+        #[prost(message, tag = "19")]
         GroupCrdtViewResponse(super::GroupCrdtViewResponse),
         /// CRDT compaction (admin: collapse tombstone history)
-        #[prost(message, tag = "19")]
-        GroupCrdtCompactRequest(super::GroupCrdtCompactRequest),
         #[prost(message, tag = "20")]
+        GroupCrdtCompactRequest(super::GroupCrdtCompactRequest),
+        #[prost(message, tag = "21")]
         GroupCrdtCompactResponse(super::GroupCrdtCompactResponse),
     }
 }
@@ -326,6 +333,19 @@ pub struct GroupInfo {
 /// Group list request
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GroupListRequest {
+    #[prost(uint32, tag = "10")]
+    pub offset: u32,
+    #[prost(uint32, tag = "20")]
+    pub limit: u32,
+}
+/// Group search request
+///
+/// Returns a GroupListResponse. An empty/whitespace query falls back to the
+/// recency-sorted full group list.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GroupSearchRequest {
+    #[prost(string, tag = "1")]
+    pub query: ::prost::alloc::string::String,
     #[prost(uint32, tag = "10")]
     pub offset: u32,
     #[prost(uint32, tag = "20")]

--- a/protobuf/generated/rust/qaul.rpc.group.rs
+++ b/protobuf/generated/rust/qaul.rpc.group.rs
@@ -5,7 +5,7 @@ pub struct Group {
     /// message type
     #[prost(
         oneof = "group::Message",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
     )]
     pub message: ::core::option::Option<group::Message>,
 }
@@ -62,19 +62,40 @@ pub mod group {
         /// group invited response
         #[prost(message, tag = "16")]
         GroupInvitedResponse(super::GroupInvitedResponse),
-        /// group search request
-        ///
-        /// Searches groups/rooms by name (direct chats match the partner's
-        /// username) and returns a GroupListResponse ranked by relevance, with
-        /// more recently active rooms breaking ties.
-        #[prost(message, tag = "17")]
-        GroupSearchRequest(super::GroupSearchRequest),
         /// CRDT membership/metadata view (read the derived state)
-        #[prost(message, tag = "18")]
+        #[prost(message, tag = "17")]
         GroupCrdtViewRequest(super::GroupCrdtViewRequest),
-        #[prost(message, tag = "19")]
+        #[prost(message, tag = "18")]
         GroupCrdtViewResponse(super::GroupCrdtViewResponse),
+        /// CRDT compaction (admin: collapse tombstone history)
+        #[prost(message, tag = "19")]
+        GroupCrdtCompactRequest(super::GroupCrdtCompactRequest),
+        #[prost(message, tag = "20")]
+        GroupCrdtCompactResponse(super::GroupCrdtCompactResponse),
     }
+}
+/// Trigger a CRDT compaction for a group: raise the epoch and collapse
+/// op history below the floor, preserving the live view. Admin-only.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GroupCrdtCompactRequest {
+    #[prost(bytes = "vec", tag = "1")]
+    pub group_id: ::prost::alloc::vec::Vec<u8>,
+    /// ops strictly below this lamport are collapsed / no longer
+    /// accepted. 0 = let libqaul choose the current max lamport.
+    #[prost(uint64, tag = "2")]
+    pub below: u64,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GroupCrdtCompactResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub group_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "2")]
+    pub result: ::core::option::Option<GroupResult>,
+    /// epoch and op_count after compaction
+    #[prost(uint64, tag = "3")]
+    pub epoch: u64,
+    #[prost(uint32, tag = "4")]
+    pub op_count: u32,
 }
 /// Read the converged CRDT view of a group's membership & metadata.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -111,6 +132,9 @@ pub struct GroupCrdtViewResponse {
     /// present members with their effective role
     #[prost(message, repeated, tag = "6")]
     pub members: ::prost::alloc::vec::Vec<GroupCrdtMember>,
+    /// current compaction epoch
+    #[prost(uint64, tag = "7")]
+    pub epoch: u64,
 }
 /// Group Result
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -302,19 +326,6 @@ pub struct GroupInfo {
 /// Group list request
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GroupListRequest {
-    #[prost(uint32, tag = "10")]
-    pub offset: u32,
-    #[prost(uint32, tag = "20")]
-    pub limit: u32,
-}
-/// Group search request
-///
-/// Returns a GroupListResponse. An empty/whitespace query falls back to the
-/// recency-sorted full group list.
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GroupSearchRequest {
-    #[prost(string, tag = "1")]
-    pub query: ::prost::alloc::string::String,
     #[prost(uint32, tag = "10")]
     pub offset: u32,
     #[prost(uint32, tag = "20")]

--- a/protobuf/proto_definitions/services/group/group_net.proto
+++ b/protobuf/proto_definitions/services/group/group_net.proto
@@ -12,7 +12,66 @@ message GroupContainer {
         GroupInfo group_info = 3;
         // member removed
         RemovedMember removed = 4;
+        // CRDT signed membership/metadata operation. Sent by nodes that
+        // advertise Capabilities::GROUP_CRDT; see
+        // docs/proposals/Group-State-CRDT.md.
+        GroupOp group_op = 5;
     }
+}
+
+// A single signed group CRDT operation.
+//
+// The signature in field 9 covers the deterministic protobuf encoding
+// of this same message with `signature` left empty — i.e. fields 1..8
+// plus the `op` oneof — produced by the actor's identity (Ed25519) key.
+// Verifiers look the actor's public key up by `actor_id` (a PeerId is a
+// hash of the key) and check both the signature and that `actor_id`
+// matches that key.
+message GroupOp {
+    // the group this op belongs to
+    bytes group_id = 1;
+    // 16-byte random operation id (dedup key for the grow-only op set)
+    bytes op_id = 2;
+    // PeerId bytes of the signer
+    bytes actor_id = 3;
+    // group-local lamport clock value
+    uint64 lamport = 4;
+    // wall-clock ms at creation (display/diagnostics only)
+    uint64 created_at = 5;
+    oneof op {
+        AddMemberOp add = 6;
+        RemoveMemberOp remove = 7;
+        UpdateMetadataOp meta = 8;
+        CompactOp compact = 10;
+    }
+    // Ed25519 signature over the op with this field empty
+    bytes signature = 9;
+}
+
+// Add (or re-add, or promote) a member.
+message AddMemberOp {
+    bytes member_id = 1;
+    // 0 = member, 255 = admin
+    int32 role = 2;
+}
+
+// Remove a member, tombstoning the add op_ids it has observed.
+message RemoveMemberOp {
+    bytes member_id = 1;
+    repeated bytes observed_adds = 2;
+}
+
+// Update group metadata (only present fields are written, LWW).
+message UpdateMetadataOp {
+    optional string name = 1;
+    optional bytes avatar = 2;
+}
+
+// Compaction barrier: collapse tombstones below `below`, raising the
+// epoch. Admin-issued.
+message CompactOp {
+    uint64 epoch = 1;
+    uint64 below = 2;
 }
 
 // Invite member

--- a/protobuf/proto_definitions/services/group/group_net.proto
+++ b/protobuf/proto_definitions/services/group/group_net.proto
@@ -122,6 +122,9 @@ message GroupInfo {
     uint32 revision = 4;
     // updated members
     repeated GroupMember members = 5;
+    // group founder (CRDT bootstrap admin); carried so invitees learn
+    // it and can derive the membership CRDT. Empty from pre-CRDT peers.
+    bytes founder = 6;
 }
 
 // Reply to Invite

--- a/protobuf/proto_definitions/services/group/group_rpc.proto
+++ b/protobuf/proto_definitions/services/group/group_rpc.proto
@@ -52,7 +52,28 @@ message Group {
         // CRDT membership/metadata view (read the derived state)
         GroupCrdtViewRequest group_crdt_view_request = 18;
         GroupCrdtViewResponse group_crdt_view_response = 19;
+
+        // CRDT compaction (admin: collapse tombstone history)
+        GroupCrdtCompactRequest group_crdt_compact_request = 20;
+        GroupCrdtCompactResponse group_crdt_compact_response = 21;
     }
+}
+
+// Trigger a CRDT compaction for a group: raise the epoch and collapse
+// op history below the floor, preserving the live view. Admin-only.
+message GroupCrdtCompactRequest {
+    bytes group_id = 1;
+    // ops strictly below this lamport are collapsed / no longer
+    // accepted. 0 = let libqaul choose the current max lamport.
+    uint64 below = 2;
+}
+
+message GroupCrdtCompactResponse {
+    bytes group_id = 1;
+    GroupResult result = 2;
+    // epoch and op_count after compaction
+    uint64 epoch = 3;
+    uint32 op_count = 4;
 }
 
 // Read the converged CRDT view of a group's membership & metadata.
@@ -80,6 +101,8 @@ message GroupCrdtViewResponse {
     uint32 op_count = 5;
     // present members with their effective role
     repeated GroupCrdtMember members = 6;
+    // current compaction epoch
+    uint64 epoch = 7;
 }
 
 // Group Result

--- a/protobuf/proto_definitions/services/group/group_rpc.proto
+++ b/protobuf/proto_definitions/services/group/group_rpc.proto
@@ -49,7 +49,37 @@ message Group {
         // username) and returns a GroupListResponse ranked by relevance, with
         // more recently active rooms breaking ties.
         GroupSearchRequest group_search_request = 17;
+        // CRDT membership/metadata view (read the derived state)
+        GroupCrdtViewRequest group_crdt_view_request = 18;
+        GroupCrdtViewResponse group_crdt_view_response = 19;
     }
+}
+
+// Read the converged CRDT view of a group's membership & metadata.
+message GroupCrdtViewRequest {
+    bytes group_id = 1;
+}
+
+// One member in the derived CRDT view.
+message GroupCrdtMember {
+    bytes user_id = 1;
+    // 0 = member, 255 = admin
+    int32 role = 2;
+}
+
+// The derived CRDT view.
+message GroupCrdtViewResponse {
+    bytes group_id = 1;
+    // false when the group is unknown or predates the CRDT (no founder)
+    bool found = 2;
+    // group founder (bootstrap admin)
+    bytes founder = 3;
+    // derived metadata name (empty if unset)
+    string name = 4;
+    // number of ops retained in the op set
+    uint32 op_count = 5;
+    // present members with their effective role
+    repeated GroupCrdtMember members = 6;
 }
 
 // Group Result

--- a/rust/clients/qauld-ctl/src/cli.rs
+++ b/rust/clients/qauld-ctl/src/cli.rs
@@ -533,6 +533,12 @@ pub enum GroupSubcmd {
         #[arg(short, long)]
         name: String,
     },
+    /// show the derived CRDT membership/metadata view of a group
+    CrdtView {
+        /// the group id
+        #[arg(short, long)]
+        group_id: String,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/rust/clients/qauld-ctl/src/cli.rs
+++ b/rust/clients/qauld-ctl/src/cli.rs
@@ -539,6 +539,15 @@ pub enum GroupSubcmd {
         #[arg(short, long)]
         group_id: String,
     },
+    /// compact a group's CRDT op history (admin; collapses tombstones)
+    CrdtCompact {
+        /// the group id
+        #[arg(short, long)]
+        group_id: String,
+        /// collapse ops below this lamport (0 = current max lamport)
+        #[arg(short, long, default_value_t = 0)]
+        below: u64,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/rust/clients/qauld-ctl/src/commands/group.rs
+++ b/rust/clients/qauld-ctl/src/commands/group.rs
@@ -8,9 +8,10 @@ use qaul_proto::qaul_rpc_group as proto;
 
 use prost::Message;
 use proto::{
-    group, Group, GroupCreateRequest, GroupInfoRequest, GroupInviteMemberRequest,
-    GroupInvitedRequest, GroupListRequest, GroupMemberRole, GroupMemberState,
-    GroupRemoveMemberRequest, GroupRenameRequest, GroupReplyInviteRequest, GroupStatus,
+    group, Group, GroupCreateRequest, GroupCrdtViewRequest, GroupInfoRequest,
+    GroupInviteMemberRequest, GroupInvitedRequest, GroupListRequest, GroupMemberRole,
+    GroupMemberState, GroupRemoveMemberRequest, GroupRenameRequest, GroupReplyInviteRequest,
+    GroupStatus,
 };
 use proto_chat::{chat_content_message, ChatContentMessage, GroupEventType};
 
@@ -177,6 +178,15 @@ impl RpcCommand for GroupSubcmd {
                             user_id: user_id.clone(),
                         },
                     )),
+                };
+                Ok((proto_message.encode_to_vec(), Modules::Group))
+            }
+            GroupSubcmd::CrdtView { group_id } => {
+                let group_id = uuid_string_to_bin(group_id.to_string())?;
+                let proto_message = Group {
+                    message: Some(group::Message::GroupCrdtViewRequest(GroupCrdtViewRequest {
+                        group_id,
+                    })),
                 };
                 Ok((proto_message.encode_to_vec(), Modules::Group))
             }
@@ -504,6 +514,48 @@ impl RpcCommand for GroupSubcmd {
                                 group.members.len()
                             );
                         }
+                    }
+                }
+            }
+            Some(group::Message::GroupCrdtViewResponse(r)) => {
+                if !r.found {
+                    if json {
+                        println!("{}", serde_json::json!({ "found": false }));
+                    } else {
+                        println!("no CRDT view (unknown group or pre-CRDT group)");
+                    }
+                    return Ok(());
+                }
+                if json {
+                    let members: Vec<_> = r
+                        .members
+                        .iter()
+                        .map(|m| {
+                            serde_json::json!({
+                                "user_id": bs58::encode(&m.user_id).into_string(),
+                                "role": if m.role == 255 { "admin" } else { "member" },
+                            })
+                        })
+                        .collect();
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "found": true,
+                            "founder": bs58::encode(&r.founder).into_string(),
+                            "name": r.name,
+                            "op_count": r.op_count,
+                            "members": members,
+                        }))?
+                    );
+                } else {
+                    println!("==== Group CRDT view ====");
+                    println!("\tfounder: {}", bs58::encode(&r.founder).into_string());
+                    println!("\tname: {}", r.name);
+                    println!("\tops: {}", r.op_count);
+                    println!("\tmembers ({}):", r.members.len());
+                    for m in &r.members {
+                        let role = if m.role == 255 { "admin" } else { "member" };
+                        println!("\t  {} [{}]", bs58::encode(&m.user_id).into_string(), role);
                     }
                 }
             }

--- a/rust/clients/qauld-ctl/src/commands/group.rs
+++ b/rust/clients/qauld-ctl/src/commands/group.rs
@@ -8,10 +8,10 @@ use qaul_proto::qaul_rpc_group as proto;
 
 use prost::Message;
 use proto::{
-    group, Group, GroupCreateRequest, GroupCrdtViewRequest, GroupInfoRequest,
-    GroupInviteMemberRequest, GroupInvitedRequest, GroupListRequest, GroupMemberRole,
-    GroupMemberState, GroupRemoveMemberRequest, GroupRenameRequest, GroupReplyInviteRequest,
-    GroupStatus,
+    group, Group, GroupCreateRequest, GroupCrdtCompactRequest, GroupCrdtViewRequest,
+    GroupInfoRequest, GroupInviteMemberRequest, GroupInvitedRequest, GroupListRequest,
+    GroupMemberRole, GroupMemberState, GroupRemoveMemberRequest, GroupRenameRequest,
+    GroupReplyInviteRequest, GroupStatus,
 };
 use proto_chat::{chat_content_message, ChatContentMessage, GroupEventType};
 
@@ -187,6 +187,18 @@ impl RpcCommand for GroupSubcmd {
                     message: Some(group::Message::GroupCrdtViewRequest(GroupCrdtViewRequest {
                         group_id,
                     })),
+                };
+                Ok((proto_message.encode_to_vec(), Modules::Group))
+            }
+            GroupSubcmd::CrdtCompact { group_id, below } => {
+                let group_id = uuid_string_to_bin(group_id.to_string())?;
+                let proto_message = Group {
+                    message: Some(group::Message::GroupCrdtCompactRequest(
+                        GroupCrdtCompactRequest {
+                            group_id,
+                            below: *below,
+                        },
+                    )),
                 };
                 Ok((proto_message.encode_to_vec(), Modules::Group))
             }
@@ -551,12 +563,35 @@ impl RpcCommand for GroupSubcmd {
                     println!("==== Group CRDT view ====");
                     println!("\tfounder: {}", bs58::encode(&r.founder).into_string());
                     println!("\tname: {}", r.name);
+                    println!("\tepoch: {}", r.epoch);
                     println!("\tops: {}", r.op_count);
                     println!("\tmembers ({}):", r.members.len());
                     for m in &r.members {
                         let role = if m.role == 255 { "admin" } else { "member" };
                         println!("\t  {} [{}]", bs58::encode(&m.user_id).into_string(), role);
                     }
+                }
+            }
+            Some(group::Message::GroupCrdtCompactResponse(r)) => {
+                let ok = r.result.as_ref().map(|x| x.status).unwrap_or(false);
+                let msg = r.result.as_ref().map(|x| x.message.clone()).unwrap_or_default();
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "status": ok,
+                            "message": msg,
+                            "epoch": r.epoch,
+                            "op_count": r.op_count,
+                        }))?
+                    );
+                } else if ok {
+                    println!(
+                        "CRDT compaction done: epoch={} ops={}",
+                        r.epoch, r.op_count
+                    );
+                } else {
+                    println!("CRDT compaction failed: {}", msg);
                 }
             }
             _ => {

--- a/rust/libqaul/src/router/users.rs
+++ b/rust/libqaul/src/router/users.rs
@@ -1116,10 +1116,16 @@ impl Capabilities {
     /// initiators should not attempt to rotate with them.
     pub const ROTATION: u32 = 1 << 0;
 
+    /// Supports the signed-op group membership/metadata CRDT
+    /// (`GroupContainer::group_op`). A peer without this bit keeps the
+    /// legacy invite/reply path; the CRDT layer translates while a
+    /// mixed group exists. See `docs/proposals/Group-State-CRDT.md`.
+    pub const GROUP_CRDT: u32 = 1 << 3;
+
     /// Everything this binary can handle — advertised by the local
     /// user to its peers. Kept small; new bits are `|=`'d here as
     /// features land.
-    pub const LOCAL: u32 = Self::ROTATION;
+    pub const LOCAL: u32 = Self::ROTATION | Self::GROUP_CRDT;
 
     /// Convenience: does `caps` advertise every bit in `required`?
     pub fn supports(caps: u32, required: u32) -> bool {

--- a/rust/libqaul/src/services/group/crdt.rs
+++ b/rust/libqaul/src/services/group/crdt.rs
@@ -219,11 +219,11 @@ impl GroupCrdt {
     }
 
     /// Re-derive the compaction floor from authorized `Compact` ops and
-    /// prune ops that fall below it.
+    /// prune the dead history below it, **preserving the live view**.
     fn recompute_compaction(&mut self) {
-        // Derive the view first (authorization needs it), then find the
-        // highest authorized Compact.
-        let view = self.view();
+        // Derive the view + load-bearing op_ids first (authorization
+        // needs the view; pruning must keep the load-bearing ops).
+        let (view, load_bearing) = self.derive();
         let mut floor = 0u64;
         let mut epoch = 0u64;
         for op in self.ops.values() {
@@ -240,10 +240,15 @@ impl GroupCrdt {
         self.compaction_below = floor;
         self.epoch = epoch;
         if floor > 0 {
-            // prune ops strictly below the floor (keep Compact ops so
-            // the floor stays derivable)
-            self.ops.retain(|_, op| {
-                op.lamport >= floor || matches!(op.kind, OpKind::Compact { .. })
+            // Drop ops below the floor EXCEPT those still load-bearing
+            // for the current view (live member adds, winning metadata)
+            // and the Compact ops themselves (so the floor stays
+            // derivable). This collapses tombstone/dead-op bloat while
+            // leaving the derived membership & metadata unchanged.
+            self.ops.retain(|op_id, op| {
+                op.lamport >= floor
+                    || matches!(op.kind, OpKind::Compact { .. })
+                    || load_bearing.contains(op_id)
             });
         }
     }
@@ -258,6 +263,15 @@ impl GroupCrdt {
     /// op set in total `(lamport, actor_id, op_id)` order, enforcing
     /// authorization against the view built so far.
     pub fn view(&self) -> GroupView {
+        self.derive().0
+    }
+
+    /// Like [`view`](Self::view), but also returns the set of op_ids
+    /// that are *load-bearing* for the current view — the live (not
+    /// tombstoned) member adds and the winning metadata writes.
+    /// Compaction keeps these so collapsing history never changes the
+    /// derived state.
+    fn derive(&self) -> (GroupView, BTreeSet<OpId>) {
         // total order: lamport, then actor, then op_id — deterministic
         // across replicas regardless of merge/arrival order.
         let mut ordered: Vec<&GroupOp> = self.ops.values().collect();
@@ -374,6 +388,7 @@ impl GroupCrdt {
                             name_reg = Some(LwwReg {
                                 key: key.clone(),
                                 value: n.clone(),
+                                op_id: op.op_id,
                             });
                         }
                     }
@@ -382,6 +397,7 @@ impl GroupCrdt {
                             avatar_reg = Some(LwwReg {
                                 key: key.clone(),
                                 value: a.clone(),
+                                op_id: op.op_id,
                             });
                         }
                     }
@@ -392,8 +408,10 @@ impl GroupCrdt {
             }
         }
 
-        // build member view: a member is present iff it has ≥1 live add
+        // build member view: a member is present iff it has ≥1 live add.
+        // collect the load-bearing op_ids alongside.
         let mut members = BTreeMap::new();
+        let mut load_bearing: BTreeSet<OpId> = BTreeSet::new();
         for (id, adds) in &live_adds {
             if adds.is_empty() {
                 continue;
@@ -404,14 +422,27 @@ impl GroupCrdt {
                     role: effective_role(adds),
                 },
             );
+            for op_id in adds.keys() {
+                // skip the synthetic founder add (all-zero op_id)
+                if *op_id != [0u8; 16] {
+                    load_bearing.insert(*op_id);
+                }
+            }
+        }
+        if let Some(reg) = &name_reg {
+            load_bearing.insert(reg.op_id);
+        }
+        if let Some(reg) = &avatar_reg {
+            load_bearing.insert(reg.op_id);
         }
 
-        GroupView {
+        let view = GroupView {
             members,
             name: name_reg.map(|r| r.value),
             avatar: avatar_reg.map(|r| r.value),
             max_lamport,
-        }
+        };
+        (view, load_bearing)
     }
 }
 
@@ -453,6 +484,9 @@ impl LwwKey {
 struct LwwReg<T> {
     key: LwwKey,
     value: T,
+    /// op_id of the write that currently holds the register (load-bearing
+    /// for compaction so the winning metadata op is never pruned).
+    op_id: OpId,
 }
 
 impl<T> LwwReg<T> {
@@ -709,6 +743,37 @@ mod tests {
         let accepted = c.merge_op(remove(60, 1, 5, 3, &[11]));
         assert!(!accepted, "op below compaction floor is rejected");
         assert!(c.view().is_member(&id(3)), "stale remove never applied");
+    }
+
+    // compaction must collapse dead history WITHOUT dropping the live
+    // view: a member added long ago (below the floor) and a metadata
+    // name set long ago must survive a compaction; a dead tombstoned
+    // add below the floor is pruned.
+    #[test]
+    fn compaction_preserves_live_view() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_ADMIN)); // 2 admin (old, live)
+        c.merge_op(meta(11, 1, 2, Some("name-old"))); // old metadata (live)
+        c.merge_op(add(12, 1, 3, 4, ROLE_MEMBER)); // 4 added (old)
+        c.merge_op(remove(13, 1, 4, 4, &[12])); // 4 removed (dead pair)
+        let before = c.op_count();
+
+        // founder compacts everything below lamport 100
+        c.merge_op(GroupOp {
+            op_id: oid(50),
+            actor_id: id(1),
+            lamport: 100,
+            created_at: 0,
+            kind: OpKind::Compact { epoch: 1, below: 100 },
+        });
+
+        // live view is unchanged: 2 (admin) present, name retained, 4 gone
+        let v = c.view();
+        assert!(v.is_admin(&id(2)), "old live admin survives compaction");
+        assert!(!v.is_member(&id(4)), "removed member stays gone");
+        assert_eq!(v.name.as_deref(), Some("name-old"), "old metadata survives");
+        // dead ops were collapsed (fewer ops than before + the compact)
+        assert!(c.op_count() < before + 1, "dead history pruned");
     }
 
     // a non-admin Compact does not move the floor.

--- a/rust/libqaul/src/services/group/crdt.rs
+++ b/rust/libqaul/src/services/group/crdt.rs
@@ -1,0 +1,715 @@
+// Copyright (c) 2026 Open Community Project Association https://ocpa.ch
+// This software is published under the AGPLv3 license.
+
+//! # Group membership & metadata CRDT
+//!
+//! Replaces the monotonic `Group::revision` last-writer-wins merge with
+//! a conflict-free replicated data type so two partitioned members can
+//! concurrently invite / remove members and edit metadata, and every
+//! replica converges to the same state deterministically.
+//!
+//! See `docs/proposals/Group-State-CRDT.md`.
+//!
+//! ## Model
+//!
+//! The state is a **grow-only set of signed operations** (`GroupOp`),
+//! deduplicated by `op_id`. Merge is the set union — unconditional and
+//! commutative/associative/idempotent, so it is a proper CRDT.
+//!
+//! The membership / metadata *view* is **derived** from the op set by a
+//! deterministic fold in total `(lamport, actor_id, op_id)` order:
+//!
+//! - **Membership** is an Observed-Remove Set (OR-Set) keyed by
+//!   `member_id`: every `Add` carries a unique `op_id`; a `Remove`
+//!   tombstones the `op_id`s it observed. A member is present iff it has
+//!   at least one `Add` whose `op_id` is not tombstoned, so a concurrent
+//!   re-add (fresh `op_id`) survives a remove — **add-wins** on a
+//!   concurrent add-vs-remove of the same member (the right default for
+//!   mesh invites; flagged for product review in the proposal).
+//! - **Metadata** (name, avatar) is a per-field last-writer-wins
+//!   register keyed by `(lamport, actor_id)`.
+//!
+//! ## Authorization is checked at *apply* time, not merge time
+//!
+//! Every op merges regardless of whether its actor was allowed to issue
+//! it; the fold simply skips ops that fail the authorization check
+//! against the view built so far. Because the view is re-derived from
+//! the whole op set, an op that was unauthorized when first received can
+//! become authorized later — e.g. once an admin-promotion with a lower
+//! lamport is merged, an op that depended on that admin status applies
+//! retroactively, with no rebroadcast.
+//!
+//! This core module is deliberately free of protobuf / signature /
+//! storage concerns so the merge + authorization logic can be unit
+//! tested in isolation. Ops handed to [`GroupCrdt::merge_op`] are
+//! assumed already signature-verified by the caller.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// 16-byte random operation id (UUID).
+pub type OpId = [u8; 16];
+
+/// Role byte: `0` = member, `255` = admin (matches the wire `role`).
+pub const ROLE_MEMBER: i32 = 0;
+pub const ROLE_ADMIN: i32 = 255;
+
+/// A single signed group operation. `signature` and decoding live in
+/// the wire layer; this core treats an op as already-verified data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupOp {
+    pub op_id: OpId,
+    /// PeerId bytes of the signer.
+    pub actor_id: Vec<u8>,
+    /// Group-local lamport clock value of this op.
+    pub lamport: u64,
+    /// Wall-clock ms at creation — display/diagnostics only; never a
+    /// merge or authorization input.
+    pub created_at: u64,
+    pub kind: OpKind,
+}
+
+/// The operation payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpKind {
+    /// Add (or re-add, or promote) a member.
+    Add { member_id: Vec<u8>, role: i32 },
+    /// Remove a member, tombstoning the add `op_id`s it observed.
+    Remove {
+        member_id: Vec<u8>,
+        observed_adds: Vec<OpId>,
+    },
+    /// Update metadata fields (only the `Some` fields are written).
+    UpdateMetadata {
+        name: Option<String>,
+        avatar: Option<Vec<u8>>,
+    },
+    /// Compaction barrier: ops with `lamport < below` are no longer
+    /// accepted once this epoch is in effect (tombstone GC). See
+    /// [`GroupCrdt::merge_op`].
+    Compact { epoch: u64, below: u64 },
+}
+
+/// A member as seen in the derived view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemberView {
+    pub role: i32,
+}
+
+impl MemberView {
+    pub fn is_admin(&self) -> bool {
+        self.role == ROLE_ADMIN
+    }
+}
+
+/// The derived, converged view of a group's membership and metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GroupView {
+    /// Present members, keyed by member_id, with their effective role.
+    pub members: BTreeMap<Vec<u8>, MemberView>,
+    pub name: Option<String>,
+    pub avatar: Option<Vec<u8>>,
+    /// Highest lamport observed across applied ops (for the next tick).
+    pub max_lamport: u64,
+}
+
+impl GroupView {
+    pub fn is_member(&self, id: &[u8]) -> bool {
+        self.members.contains_key(id)
+    }
+    pub fn is_admin(&self, id: &[u8]) -> bool {
+        self.members.get(id).is_some_and(|m| m.is_admin())
+    }
+}
+
+/// CRDT state for one group: the founder, the grow-only op set, and the
+/// compaction horizon.
+#[derive(Debug, Clone)]
+pub struct GroupCrdt {
+    /// The group creator. Bootstrap admin, always present, can never be
+    /// removed, and is the only actor allowed to remove an admin.
+    founder: Vec<u8>,
+    /// When true, only admins may `Add` members (invite-only); when
+    /// false, any member may add (open invite). Apply-time policy only —
+    /// the same op wire shape is used either way.
+    invite_only: bool,
+    /// All merged ops, deduplicated by `op_id`.
+    ops: BTreeMap<OpId, GroupOp>,
+    /// Active compaction floor: ops with `lamport < compaction_below`
+    /// are rejected by `merge_op` (a peer resurfacing beyond the
+    /// horizon cannot reintroduce collapsed state). 0 = no compaction.
+    compaction_below: u64,
+    /// Highest compaction epoch applied.
+    epoch: u64,
+}
+
+impl GroupCrdt {
+    /// Create CRDT state for a group founded by `founder`.
+    pub fn new(founder: Vec<u8>) -> Self {
+        GroupCrdt {
+            founder,
+            invite_only: false,
+            ops: BTreeMap::new(),
+            compaction_below: 0,
+            epoch: 0,
+        }
+    }
+
+    /// Set invite-only policy (admins-only adds). Apply-time only.
+    pub fn set_invite_only(&mut self, invite_only: bool) {
+        self.invite_only = invite_only;
+    }
+
+    pub fn founder(&self) -> &[u8] {
+        &self.founder
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Number of ops currently retained (for tests / metrics).
+    pub fn op_count(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// Merge one op into the set. Idempotent (dedup by `op_id`) and
+    /// order-independent. Returns `true` if the op was newly stored.
+    ///
+    /// Ops below the active compaction floor are **rejected, not
+    /// merged** — a peer that resurfaces beyond the compaction horizon
+    /// cannot reintroduce state that was collapsed away. A `Compact` op
+    /// raises the floor (and, being itself an op, also advances the
+    /// lamport clock and prunes now-stale ops).
+    pub fn merge_op(&mut self, op: GroupOp) -> bool {
+        // reject ops below the compaction floor (except Compact itself,
+        // which establishes the floor)
+        if op.lamport < self.compaction_below && !matches!(op.kind, OpKind::Compact { .. }) {
+            return false;
+        }
+        if self.ops.contains_key(&op.op_id) {
+            return false;
+        }
+
+        // A Compact op raises the floor for everyone and prunes ops
+        // that are now below it. Authorization for Compact is enforced
+        // in the fold (admin-only); but the floor is structural so it
+        // applies regardless — an unauthorized Compact still merges as
+        // an op and is simply ignored by the view if it didn't come
+        // from an admin. To avoid an unauthorized peer collapsing
+        // state, only honour the floor for Compacts that the view
+        // accepts; see `recompute_compaction`.
+        let newly = self.ops.insert(op.op_id, op).is_none();
+        if newly {
+            self.recompute_compaction();
+        }
+        newly
+    }
+
+    /// Re-derive the compaction floor from authorized `Compact` ops and
+    /// prune ops that fall below it.
+    fn recompute_compaction(&mut self) {
+        // Derive the view first (authorization needs it), then find the
+        // highest authorized Compact.
+        let view = self.view();
+        let mut floor = 0u64;
+        let mut epoch = 0u64;
+        for op in self.ops.values() {
+            if let OpKind::Compact { epoch: e, below } = op.kind {
+                // Only admins may compact.
+                if view.is_admin(&op.actor_id) || op.actor_id == self.founder {
+                    if e > epoch {
+                        epoch = e;
+                        floor = below;
+                    }
+                }
+            }
+        }
+        self.compaction_below = floor;
+        self.epoch = epoch;
+        if floor > 0 {
+            // prune ops strictly below the floor (keep Compact ops so
+            // the floor stays derivable)
+            self.ops.retain(|_, op| {
+                op.lamport >= floor || matches!(op.kind, OpKind::Compact { .. })
+            });
+        }
+    }
+
+    /// The next lamport value this replica should stamp on a new op:
+    /// one above the highest lamport seen.
+    pub fn next_lamport(&self) -> u64 {
+        self.ops.values().map(|o| o.lamport).max().unwrap_or(0) + 1
+    }
+
+    /// Derive the converged membership / metadata view by folding the
+    /// op set in total `(lamport, actor_id, op_id)` order, enforcing
+    /// authorization against the view built so far.
+    pub fn view(&self) -> GroupView {
+        // total order: lamport, then actor, then op_id — deterministic
+        // across replicas regardless of merge/arrival order.
+        let mut ordered: Vec<&GroupOp> = self.ops.values().collect();
+        ordered.sort_by(|a, b| {
+            a.lamport
+                .cmp(&b.lamport)
+                .then_with(|| a.actor_id.cmp(&b.actor_id))
+                .then_with(|| a.op_id.cmp(&b.op_id))
+        });
+
+        // OR-Set working state: per member, the live (non-tombstoned)
+        // add op_ids with their role + ordering key.
+        let mut live_adds: BTreeMap<Vec<u8>, BTreeMap<OpId, AddTag>> = BTreeMap::new();
+        let mut tombstoned: BTreeSet<OpId> = BTreeSet::new();
+
+        // founder is a synthetic, un-removable admin add at the very
+        // bottom of the order.
+        live_adds
+            .entry(self.founder.clone())
+            .or_default()
+            .insert(
+                [0u8; 16],
+                AddTag {
+                    role: ROLE_ADMIN,
+                    lamport: 0,
+                    actor: self.founder.clone(),
+                },
+            );
+
+        // metadata LWW registers
+        let mut name_reg: Option<LwwReg<String>> = None;
+        let mut avatar_reg: Option<LwwReg<Vec<u8>>> = None;
+        let mut max_lamport = 0u64;
+
+        // helper: is `id` an admin given current live_adds?
+        let is_admin = |live: &BTreeMap<Vec<u8>, BTreeMap<OpId, AddTag>>, id: &[u8], founder: &[u8]| -> bool {
+            if id == founder {
+                return true;
+            }
+            match live.get(id) {
+                Some(adds) if !adds.is_empty() => effective_role(adds) == ROLE_ADMIN,
+                _ => false,
+            }
+        };
+        let is_member = |live: &BTreeMap<Vec<u8>, BTreeMap<OpId, AddTag>>, id: &[u8], founder: &[u8]| -> bool {
+            id == founder || live.get(id).is_some_and(|a| !a.is_empty())
+        };
+
+        for op in ordered {
+            max_lamport = max_lamport.max(op.lamport);
+            match &op.kind {
+                OpKind::Add { member_id, role } => {
+                    // tombstoned adds never come alive
+                    if tombstoned.contains(&op.op_id) {
+                        continue;
+                    }
+                    // authorization: promotion to admin requires actor
+                    // be an admin; a plain add requires actor be a
+                    // member (or admin if invite-only).
+                    let authorized = if *role == ROLE_ADMIN {
+                        is_admin(&live_adds, &op.actor_id, &self.founder)
+                    } else if self.invite_only {
+                        is_admin(&live_adds, &op.actor_id, &self.founder)
+                    } else {
+                        is_member(&live_adds, &op.actor_id, &self.founder)
+                    };
+                    if !authorized {
+                        continue;
+                    }
+                    live_adds.entry(member_id.clone()).or_default().insert(
+                        op.op_id,
+                        AddTag {
+                            role: *role,
+                            lamport: op.lamport,
+                            actor: op.actor_id.clone(),
+                        },
+                    );
+                }
+                OpKind::Remove {
+                    member_id,
+                    observed_adds,
+                } => {
+                    // the founder can never be removed
+                    if member_id.as_slice() == self.founder.as_slice() {
+                        continue;
+                    }
+                    // actor must be an admin...
+                    if !is_admin(&live_adds, &op.actor_id, &self.founder) {
+                        continue;
+                    }
+                    // ...and removing an admin requires the founder.
+                    let target_is_admin = is_admin(&live_adds, member_id, &self.founder);
+                    if target_is_admin && op.actor_id.as_slice() != self.founder.as_slice() {
+                        continue;
+                    }
+                    // tombstone observed adds (OR-Set semantics)
+                    for add_id in observed_adds {
+                        tombstoned.insert(*add_id);
+                        if let Some(adds) = live_adds.get_mut(member_id) {
+                            adds.remove(add_id);
+                        }
+                    }
+                }
+                OpKind::UpdateMetadata { name, avatar } => {
+                    if !is_admin(&live_adds, &op.actor_id, &self.founder) {
+                        continue;
+                    }
+                    let key = LwwKey {
+                        lamport: op.lamport,
+                        actor: op.actor_id.clone(),
+                    };
+                    if let Some(n) = name {
+                        if LwwReg::should_write(&name_reg, &key) {
+                            name_reg = Some(LwwReg {
+                                key: key.clone(),
+                                value: n.clone(),
+                            });
+                        }
+                    }
+                    if let Some(a) = avatar {
+                        if LwwReg::should_write(&avatar_reg, &key) {
+                            avatar_reg = Some(LwwReg {
+                                key: key.clone(),
+                                value: a.clone(),
+                            });
+                        }
+                    }
+                }
+                OpKind::Compact { .. } => {
+                    // structural; handled in recompute_compaction
+                }
+            }
+        }
+
+        // build member view: a member is present iff it has ≥1 live add
+        let mut members = BTreeMap::new();
+        for (id, adds) in &live_adds {
+            if adds.is_empty() {
+                continue;
+            }
+            members.insert(
+                id.clone(),
+                MemberView {
+                    role: effective_role(adds),
+                },
+            );
+        }
+
+        GroupView {
+            members,
+            name: name_reg.map(|r| r.value),
+            avatar: avatar_reg.map(|r| r.value),
+            max_lamport,
+        }
+    }
+}
+
+/// A live add's role plus its ordering key.
+#[derive(Debug, Clone)]
+struct AddTag {
+    role: i32,
+    lamport: u64,
+    actor: Vec<u8>,
+}
+
+/// The effective role for a member is taken from its live add with the
+/// highest `(lamport, actor)` — so the most recent promotion/demotion
+/// among concurrent adds wins deterministically.
+fn effective_role(adds: &BTreeMap<OpId, AddTag>) -> i32 {
+    adds.values()
+        .max_by(|a, b| {
+            a.lamport
+                .cmp(&b.lamport)
+                .then_with(|| a.actor.cmp(&b.actor))
+        })
+        .map(|t| t.role)
+        .unwrap_or(ROLE_MEMBER)
+}
+
+/// Ordering key for an LWW register write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LwwKey {
+    lamport: u64,
+    actor: Vec<u8>,
+}
+
+impl LwwKey {
+    fn gt(&self, other: &LwwKey) -> bool {
+        (self.lamport, &self.actor) > (other.lamport, &other.actor)
+    }
+}
+
+struct LwwReg<T> {
+    key: LwwKey,
+    value: T,
+}
+
+impl<T> LwwReg<T> {
+    /// A write with `key` wins over the current register iff the
+    /// register is empty or `key` is strictly greater.
+    fn should_write(current: &Option<LwwReg<T>>, key: &LwwKey) -> bool {
+        match current {
+            None => true,
+            Some(reg) => key.gt(&reg.key),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(b: u8) -> Vec<u8> {
+        vec![b; 4]
+    }
+    fn oid(b: u8) -> OpId {
+        let mut o = [0u8; 16];
+        o[0] = b;
+        o
+    }
+
+    fn add(op_id: u8, actor: u8, lamport: u64, member: u8, role: i32) -> GroupOp {
+        GroupOp {
+            op_id: oid(op_id),
+            actor_id: id(actor),
+            lamport,
+            created_at: 0,
+            kind: OpKind::Add { member_id: id(member), role },
+        }
+    }
+    fn remove(op_id: u8, actor: u8, lamport: u64, member: u8, observed: &[u8]) -> GroupOp {
+        GroupOp {
+            op_id: oid(op_id),
+            actor_id: id(actor),
+            lamport,
+            created_at: 0,
+            kind: OpKind::Remove {
+                member_id: id(member),
+                observed_adds: observed.iter().map(|b| oid(*b)).collect(),
+            },
+        }
+    }
+    fn meta(op_id: u8, actor: u8, lamport: u64, name: Option<&str>) -> GroupOp {
+        GroupOp {
+            op_id: oid(op_id),
+            actor_id: id(actor),
+            lamport,
+            created_at: 0,
+            kind: OpKind::UpdateMetadata { name: name.map(|s| s.to_string()), avatar: None },
+        }
+    }
+
+    // founder (id 1) is always an admin member with no ops.
+    #[test]
+    fn founder_is_bootstrap_admin() {
+        let c = GroupCrdt::new(id(1));
+        let v = c.view();
+        assert!(v.is_member(&id(1)));
+        assert!(v.is_admin(&id(1)));
+        assert_eq!(v.members.len(), 1);
+    }
+
+    // founder adds a member (open invite); member is present, not admin.
+    #[test]
+    fn open_invite_add() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER));
+        let v = c.view();
+        assert!(v.is_member(&id(2)));
+        assert!(!v.is_admin(&id(2)));
+    }
+
+    // a non-member cannot add under open invite (not a member yet).
+    #[test]
+    fn non_member_cannot_add() {
+        let mut c = GroupCrdt::new(id(1));
+        // actor 9 is not a member
+        c.merge_op(add(10, 9, 1, 2, ROLE_MEMBER));
+        assert!(!c.view().is_member(&id(2)), "add by non-member is a no-op");
+    }
+
+    // remove tombstones the observed add → member gone.
+    #[test]
+    fn remove_member() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER));
+        // founder removes member 2, observing add op 10
+        c.merge_op(remove(11, 1, 2, 2, &[10]));
+        assert!(!c.view().is_member(&id(2)));
+    }
+
+    // re-add after a remove works (fresh op_id not tombstoned).
+    #[test]
+    fn re_add_after_remove() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER));
+        c.merge_op(remove(11, 1, 2, 2, &[10]));
+        c.merge_op(add(12, 1, 3, 2, ROLE_MEMBER)); // fresh add
+        assert!(c.view().is_member(&id(2)), "re-add resurrects the member");
+    }
+
+    // concurrent add-vs-remove of the same member: the remove only
+    // tombstones the add it observed; a concurrent fresh add survives
+    // (ADD-WINS).
+    #[test]
+    fn concurrent_add_wins_over_remove() {
+        let mut c = GroupCrdt::new(id(1));
+        // founder promotes 2 to admin so 2 can add; and adds 3 originally
+        c.merge_op(add(10, 1, 1, 2, ROLE_ADMIN));
+        c.merge_op(add(11, 1, 2, 3, ROLE_MEMBER)); // original add of 3 (op 11)
+        // partition: admin 2 removes 3 observing op 11; concurrently
+        // founder re-adds 3 with a fresh op 12 it has NOT observed.
+        c.merge_op(remove(20, 2, 5, 3, &[11]));
+        c.merge_op(add(12, 1, 5, 3, ROLE_MEMBER));
+        assert!(c.view().is_member(&id(3)), "concurrent fresh add wins");
+    }
+
+    // merge order does not affect the converged view (commutativity).
+    #[test]
+    fn merge_order_independent() {
+        let ops = vec![
+            add(10, 1, 1, 2, ROLE_ADMIN),
+            add(11, 2, 2, 3, ROLE_MEMBER),
+            remove(12, 1, 3, 3, &[11]),
+            add(13, 1, 4, 3, ROLE_MEMBER),
+            meta(14, 2, 5, Some("hello")),
+        ];
+        let mut a = GroupCrdt::new(id(1));
+        for op in &ops {
+            a.merge_op(op.clone());
+        }
+        let mut b = GroupCrdt::new(id(1));
+        for op in ops.iter().rev() {
+            b.merge_op(op.clone());
+        }
+        assert_eq!(a.view(), b.view(), "view is independent of merge order");
+    }
+
+    // an op that needs admin rights but arrives before the promotion
+    // that grants them is retroactively legitimised once the promotion
+    // (with a lower lamport) is merged.
+    #[test]
+    fn retroactive_legitimization() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER)); // 2 is a plain member
+        c.merge_op(add(11, 1, 2, 3, ROLE_MEMBER)); // 3 is a member
+        // 2 (not admin) removes 3 at lamport 5 → unauthorized, no-op
+        c.merge_op(remove(20, 2, 5, 3, &[11]));
+        assert!(c.view().is_member(&id(3)), "remove by non-admin is a no-op");
+        // founder promotes 2 to admin at lamport 3 (< 5)
+        c.merge_op(add(21, 1, 3, 2, ROLE_ADMIN));
+        // now, re-derived in lamport order, 2 is admin by the time its
+        // remove at L5 is folded → the remove applies retroactively
+        assert!(!c.view().is_member(&id(3)), "remove now legitimised");
+    }
+
+    // only admins may remove; and only the founder may remove an admin.
+    #[test]
+    fn only_founder_removes_admin() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_ADMIN)); // 2 admin
+        c.merge_op(add(11, 1, 2, 3, ROLE_ADMIN)); // 3 admin
+        // admin 2 tries to remove admin 3 → not allowed (not founder)
+        c.merge_op(remove(20, 2, 5, 3, &[11]));
+        assert!(c.view().is_admin(&id(3)), "admin cannot remove another admin");
+        // founder removes admin 3 → allowed
+        c.merge_op(remove(21, 1, 6, 3, &[11]));
+        assert!(!c.view().is_member(&id(3)), "founder can remove an admin");
+    }
+
+    // an admin CAN remove a plain member.
+    #[test]
+    fn admin_removes_plain_member() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_ADMIN)); // 2 admin
+        c.merge_op(add(11, 1, 2, 3, ROLE_MEMBER)); // 3 member
+        c.merge_op(remove(20, 2, 5, 3, &[11])); // admin 2 removes member 3
+        assert!(!c.view().is_member(&id(3)));
+    }
+
+    // the founder can never be removed, even by themselves.
+    #[test]
+    fn founder_cannot_be_removed() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(remove(20, 1, 5, 1, &[]));
+        assert!(c.view().is_member(&id(1)), "founder is un-removable");
+        assert!(c.view().is_admin(&id(1)));
+    }
+
+    // invite-only flips add authorization to admins-only.
+    #[test]
+    fn invite_only_requires_admin() {
+        let mut c = GroupCrdt::new(id(1));
+        c.set_invite_only(true);
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER)); // founder(admin) adds 2: ok
+        c.merge_op(add(11, 2, 2, 3, ROLE_MEMBER)); // member 2 adds 3: NOT ok
+        let v = c.view();
+        assert!(v.is_member(&id(2)));
+        assert!(!v.is_member(&id(3)), "non-admin add blocked in invite-only");
+    }
+
+    // metadata LWW: the write with the higher (lamport, actor) wins.
+    #[test]
+    fn metadata_lww() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_ADMIN)); // 2 admin so it can edit
+        c.merge_op(meta(20, 1, 5, Some("from-founder")));
+        c.merge_op(meta(21, 2, 7, Some("from-admin-2"))); // higher lamport wins
+        assert_eq!(c.view().name.as_deref(), Some("from-admin-2"));
+        // a lower-lamport write does not override
+        c.merge_op(meta(22, 1, 3, Some("stale")));
+        assert_eq!(c.view().name.as_deref(), Some("from-admin-2"));
+    }
+
+    // non-admin metadata edit is a no-op.
+    #[test]
+    fn metadata_requires_admin() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER)); // 2 plain member
+        c.merge_op(meta(20, 2, 5, Some("nope")));
+        assert_eq!(c.view().name, None, "non-admin metadata edit ignored");
+    }
+
+    // merging the same op twice is idempotent.
+    #[test]
+    fn idempotent_merge() {
+        let mut c = GroupCrdt::new(id(1));
+        assert!(c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER)));
+        assert!(!c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER)), "dup op rejected");
+        assert_eq!(c.op_count(), 1);
+    }
+
+    // compaction raises the floor; ops below it are rejected on merge.
+    #[test]
+    fn compaction_rejects_stale_ops() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_ADMIN));
+        c.merge_op(add(11, 1, 10, 3, ROLE_MEMBER));
+        // founder compacts everything below lamport 8
+        c.merge_op(GroupOp {
+            op_id: oid(50),
+            actor_id: id(1),
+            lamport: 11,
+            created_at: 0,
+            kind: OpKind::Compact { epoch: 1, below: 8 },
+        });
+        assert_eq!(c.epoch(), 1);
+        // a late op from a resurfacing peer below the floor is rejected
+        let accepted = c.merge_op(remove(60, 1, 5, 3, &[11]));
+        assert!(!accepted, "op below compaction floor is rejected");
+        assert!(c.view().is_member(&id(3)), "stale remove never applied");
+    }
+
+    // a non-admin Compact does not move the floor.
+    #[test]
+    fn compaction_requires_admin() {
+        let mut c = GroupCrdt::new(id(1));
+        c.merge_op(add(10, 1, 1, 2, ROLE_MEMBER)); // 2 plain member
+        c.merge_op(GroupOp {
+            op_id: oid(50),
+            actor_id: id(2),
+            lamport: 5,
+            created_at: 0,
+            kind: OpKind::Compact { epoch: 1, below: 3 },
+        });
+        assert_eq!(c.epoch(), 0, "non-admin compact ignored");
+    }
+}

--- a/rust/libqaul/src/services/group/crdt.rs
+++ b/rust/libqaul/src/services/group/crdt.rs
@@ -172,6 +172,19 @@ impl GroupCrdt {
         self.ops.len()
     }
 
+    /// All `Add` op_ids currently in the set for `member_id`. Used to
+    /// build the `observed_adds` of a `Remove` so it tombstones every
+    /// add this replica has seen for that member (OR-Set semantics).
+    pub fn add_op_ids_for(&self, member_id: &[u8]) -> Vec<OpId> {
+        self.ops
+            .values()
+            .filter_map(|op| match &op.kind {
+                OpKind::Add { member_id: m, .. } if m.as_slice() == member_id => Some(op.op_id),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Merge one op into the set. Idempotent (dedup by `op_id`) and
     /// order-independent. Returns `true` if the op was newly stored.
     ///

--- a/rust/libqaul/src/services/group/crdt_store.rs
+++ b/rust/libqaul/src/services/group/crdt_store.rs
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Open Community Project Association https://ocpa.ch
+// This software is published under the AGPLv3 license.
+
+//! # Group CRDT op-set persistence
+//!
+//! Stores the grow-only set of signed `GroupOp`s per group in the
+//! per-account `group_ops` sled tree and rebuilds a [`GroupCrdt`] from
+//! it on demand.
+//!
+//! Ops are stored as their encoded `qaul.net.group.GroupOp` bytes,
+//! keyed by `group_id ++ op_id`. **Signature verification happens once,
+//! on receive, before [`save_op`]** (the network handler resolves the
+//! actor's public key and calls [`crdt_wire::verify_and_decode`]); ops
+//! loaded back from the local store are trusted and only structurally
+//! decoded.
+
+use prost::Message;
+
+use super::crdt::{GroupCrdt, OpId};
+use super::crdt_wire::{self, proto_net};
+use super::storage::GroupAccountDb;
+
+/// Storage key for one op: `group_id ++ op_id`.
+fn op_key(group_id: &[u8], op_id: &[u8]) -> Vec<u8> {
+    let mut k = Vec::with_capacity(group_id.len() + op_id.len());
+    k.extend_from_slice(group_id);
+    k.extend_from_slice(op_id);
+    k
+}
+
+/// Key range covering every op of one group.
+fn group_range(group_id: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let first = op_key(group_id, &[0u8; 16]);
+    let last = op_key(group_id, &[0xffu8; 16]);
+    (first, last)
+}
+
+/// Persist an already-verified `GroupOp` into the op set. Idempotent:
+/// re-storing the same `(group_id, op_id)` overwrites identical bytes.
+pub fn save_op(db: &GroupAccountDb, group_id: &[u8], op: &proto_net::GroupOp) {
+    if op.op_id.len() != 16 {
+        log::warn!("refusing to store group op with non-16-byte op_id");
+        return;
+    }
+    let key = op_key(group_id, &op.op_id);
+    let bytes = op.encode_to_vec();
+    if let Err(e) = db.ops.insert(key, bytes) {
+        log::error!("group op store insert: {}", e);
+        return;
+    }
+    if let Err(e) = db.ops.flush() {
+        log::error!("group op store flush: {}", e);
+    }
+}
+
+/// Rebuild the [`GroupCrdt`] for a group from its persisted op set.
+///
+/// `founder` is the group creator (bootstrap admin). Stored ops are
+/// decoded structurally and folded in; they were signature-verified
+/// before storage, so no public-key lookup is needed here. Ops that no
+/// longer decode (corruption / forward-incompatible) are skipped.
+pub fn load_crdt(db: &GroupAccountDb, group_id: &[u8], founder: Vec<u8>) -> GroupCrdt {
+    let mut crdt = GroupCrdt::new(founder);
+    let (first, last) = group_range(group_id);
+    for item in db.ops.range(first..last) {
+        let (_k, bytes) = match item {
+            Ok(kv) => kv,
+            Err(e) => {
+                log::error!("group op store iter: {}", e);
+                continue;
+            }
+        };
+        let proto = match proto_net::GroupOp::decode(&bytes[..]) {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!("group op decode (stored): {}", e);
+                continue;
+            }
+        };
+        if let Some(core) = crdt_wire::decode_trusted(&proto) {
+            crdt.merge_op(core);
+        }
+    }
+    crdt
+}
+
+/// Whether an op with `op_id` is already stored for `group_id`.
+pub fn has_op(db: &GroupAccountDb, group_id: &[u8], op_id: &OpId) -> bool {
+    db.ops
+        .get(op_key(group_id, op_id))
+        .map(|v| v.is_some())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::crdt::{OpKind, ROLE_ADMIN, ROLE_MEMBER};
+    use libp2p::identity::Keypair;
+
+    fn test_db() -> GroupAccountDb {
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        GroupAccountDb {
+            groups: db.open_tree("groups").unwrap(),
+            invited: db.open_tree("invited").unwrap(),
+            ops: db.open_tree("group_ops").unwrap(),
+        }
+    }
+
+    fn oid(b: u8) -> OpId {
+        let mut o = [0u8; 16];
+        o[0] = b;
+        o
+    }
+
+    // ops saved for a group are reloaded and folded into the same view.
+    #[test]
+    fn save_load_round_trip() {
+        let db = test_db();
+        let founder_keys = Keypair::generate_ed25519();
+        let founder = founder_keys.public().to_peer_id().to_bytes();
+        let group = b"group-1".to_vec();
+        let member = vec![2u8; 4];
+
+        // founder signs an Add(member) op and we persist it
+        let op = crdt_wire::sign_op(
+            &founder_keys,
+            &group,
+            oid(1),
+            1,
+            0,
+            &OpKind::Add { member_id: member.clone(), role: ROLE_MEMBER },
+        )
+        .unwrap();
+        save_op(&db, &group, &op);
+        assert!(has_op(&db, &group, &oid(1)));
+
+        // reload and derive the view
+        let crdt = load_crdt(&db, &group, founder.clone());
+        let view = crdt.view();
+        assert!(view.is_member(&member), "saved add survives reload");
+        assert!(view.is_admin(&founder));
+        assert_eq!(crdt.op_count(), 1);
+    }
+
+    // ops are isolated per group.
+    #[test]
+    fn per_group_isolation() {
+        let db = test_db();
+        let keys = Keypair::generate_ed25519();
+        let founder = keys.public().to_peer_id().to_bytes();
+        let g1 = b"g1".to_vec();
+        let g2 = b"g2".to_vec();
+
+        let op = crdt_wire::sign_op(
+            &keys,
+            &g1,
+            oid(1),
+            1,
+            0,
+            &OpKind::Add { member_id: vec![9; 4], role: ROLE_ADMIN },
+        )
+        .unwrap();
+        save_op(&db, &g1, &op);
+
+        // g1 has the op; g2 does not
+        assert_eq!(load_crdt(&db, &g1, founder.clone()).op_count(), 1);
+        assert_eq!(load_crdt(&db, &g2, founder).op_count(), 0);
+    }
+
+    // a full add → remove sequence reloads to the converged view.
+    #[test]
+    fn sequence_reloads_converged() {
+        let db = test_db();
+        let keys = Keypair::generate_ed25519();
+        let founder = keys.public().to_peer_id().to_bytes();
+        let group = b"g".to_vec();
+        let member = vec![3u8; 4];
+
+        let add = crdt_wire::sign_op(&keys, &group, oid(1), 1, 0,
+            &OpKind::Add { member_id: member.clone(), role: ROLE_MEMBER }).unwrap();
+        save_op(&db, &group, &add);
+        let remove = crdt_wire::sign_op(&keys, &group, oid(2), 2, 0,
+            &OpKind::Remove { member_id: member.clone(), observed_adds: vec![oid(1)] }).unwrap();
+        save_op(&db, &group, &remove);
+
+        let view = load_crdt(&db, &group, founder).view();
+        assert!(!view.is_member(&member), "remove applied after reload");
+    }
+}

--- a/rust/libqaul/src/services/group/crdt_wire.rs
+++ b/rust/libqaul/src/services/group/crdt_wire.rs
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 Open Community Project Association https://ocpa.ch
+// This software is published under the AGPLv3 license.
+
+//! # Group CRDT wire codec: signing & verification
+//!
+//! Bridges the proto-free [`crdt`](super::crdt) core and the
+//! `qaul.net.group.GroupOp` wire message. A `GroupOp` is signed by the
+//! actor's identity (Ed25519) key over the deterministic protobuf
+//! encoding of the message with its `signature` field empty; verifiers
+//! resolve the actor's public key from its `actor_id` (a PeerId is a
+//! hash of the key) and check both the signature and that `actor_id`
+//! matches that key.
+//!
+//! The router-side public-key lookup is intentionally kept out of this
+//! module: [`verify_and_decode`] takes the resolved `PublicKey`, so the
+//! sign/verify logic is unit-testable without the wider stack. The
+//! integration layer resolves the key (e.g. via `Users::get_pub_key`).
+
+use libp2p::identity::{Keypair, PublicKey};
+use libp2p::PeerId;
+use prost::Message;
+
+use super::crdt::{GroupOp, OpId, OpKind};
+
+/// Import the generated group protobuf types.
+pub use qaul_proto::qaul_net_group as proto_net;
+
+/// Build and sign a `GroupOp` wire message from core fields.
+///
+/// `keys` is the actor's identity keypair; `actor_id` is derived from
+/// it. The signature covers the encoded message with `signature` empty.
+/// Returns `None` if signing fails.
+pub fn sign_op(
+    keys: &Keypair,
+    group_id: &[u8],
+    op_id: OpId,
+    lamport: u64,
+    created_at: u64,
+    kind: &OpKind,
+) -> Option<proto_net::GroupOp> {
+    let actor_id = keys.public().to_peer_id().to_bytes();
+    let mut msg = proto_net::GroupOp {
+        group_id: group_id.to_vec(),
+        op_id: op_id.to_vec(),
+        actor_id,
+        lamport,
+        created_at,
+        op: Some(kind_to_proto(kind)),
+        signature: Vec::new(),
+    };
+
+    // sign the canonical (signature-empty) encoding
+    let unsigned = msg.encode_to_vec();
+    match keys.sign(&unsigned) {
+        Ok(sig) => {
+            msg.signature = sig;
+            Some(msg)
+        }
+        Err(e) => {
+            log::error!("group op signing failed: {}", e);
+            None
+        }
+    }
+}
+
+/// Verify a wire `GroupOp` against `actor_pubkey` and, on success,
+/// decode it into a core [`GroupOp`].
+///
+/// Checks: (1) the signature verifies over the signature-empty
+/// encoding, (2) `actor_id` is a valid PeerId equal to the PeerId of
+/// `actor_pubkey`, (3) `op_id` is exactly 16 bytes, (4) the `op` oneof
+/// is present and well-formed. Returns `None` on any failure.
+pub fn verify_and_decode(
+    op: &proto_net::GroupOp,
+    actor_pubkey: &PublicKey,
+) -> Option<GroupOp> {
+    // 1. actor_id must be the PeerId of the supplied key
+    let actor_peer = PeerId::from_bytes(&op.actor_id).ok()?;
+    if actor_peer != actor_pubkey.to_peer_id() {
+        log::warn!("group op actor_id does not match supplied public key");
+        return None;
+    }
+
+    // 2. re-encode with an empty signature and verify
+    let mut unsigned = op.clone();
+    unsigned.signature = Vec::new();
+    let unsigned_bytes = unsigned.encode_to_vec();
+    if !actor_pubkey.verify(&unsigned_bytes, &op.signature) {
+        log::warn!("group op signature verification failed");
+        return None;
+    }
+
+    // 3. op_id must be 16 bytes
+    let op_id: OpId = op.op_id.as_slice().try_into().ok()?;
+
+    // 4. decode the op kind
+    let kind = proto_to_kind(op.op.as_ref()?)?;
+
+    Some(GroupOp {
+        op_id,
+        actor_id: op.actor_id.clone(),
+        lamport: op.lamport,
+        created_at: op.created_at,
+        kind,
+    })
+}
+
+/// Convert a core [`OpKind`] into the proto oneof.
+fn kind_to_proto(kind: &OpKind) -> proto_net::group_op::Op {
+    match kind {
+        OpKind::Add { member_id, role } => {
+            proto_net::group_op::Op::Add(proto_net::AddMemberOp {
+                member_id: member_id.clone(),
+                role: *role,
+            })
+        }
+        OpKind::Remove {
+            member_id,
+            observed_adds,
+        } => proto_net::group_op::Op::Remove(proto_net::RemoveMemberOp {
+            member_id: member_id.clone(),
+            observed_adds: observed_adds.iter().map(|o| o.to_vec()).collect(),
+        }),
+        OpKind::UpdateMetadata { name, avatar } => {
+            proto_net::group_op::Op::Meta(proto_net::UpdateMetadataOp {
+                name: name.clone(),
+                avatar: avatar.clone(),
+            })
+        }
+        OpKind::Compact { epoch, below } => {
+            proto_net::group_op::Op::Compact(proto_net::CompactOp {
+                epoch: *epoch,
+                below: *below,
+            })
+        }
+    }
+}
+
+/// Convert a proto oneof into a core [`OpKind`], rejecting malformed
+/// op_ids in a `Remove`'s `observed_adds`.
+fn proto_to_kind(op: &proto_net::group_op::Op) -> Option<OpKind> {
+    match op {
+        proto_net::group_op::Op::Add(a) => Some(OpKind::Add {
+            member_id: a.member_id.clone(),
+            role: a.role,
+        }),
+        proto_net::group_op::Op::Remove(r) => {
+            let mut observed = Vec::with_capacity(r.observed_adds.len());
+            for b in &r.observed_adds {
+                // skip malformed op_ids rather than fail the whole op:
+                // a 16-byte tombstone reference is required.
+                let id: OpId = b.as_slice().try_into().ok()?;
+                observed.push(id);
+            }
+            Some(OpKind::Remove {
+                member_id: r.member_id.clone(),
+                observed_adds: observed,
+            })
+        }
+        proto_net::group_op::Op::Meta(m) => Some(OpKind::UpdateMetadata {
+            name: m.name.clone(),
+            avatar: m.avatar.clone(),
+        }),
+        proto_net::group_op::Op::Compact(c) => Some(OpKind::Compact {
+            epoch: c.epoch,
+            below: c.below,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oid(b: u8) -> OpId {
+        let mut o = [0u8; 16];
+        o[0] = b;
+        o
+    }
+
+    // sign → verify round-trips and reconstructs the core op exactly.
+    #[test]
+    fn sign_verify_round_trip() {
+        let keys = Keypair::generate_ed25519();
+        let pubkey = keys.public();
+        let actor_id = pubkey.to_peer_id().to_bytes();
+
+        let kind = OpKind::Add {
+            member_id: vec![2; 4],
+            role: 255,
+        };
+        let wire = sign_op(&keys, b"group-1", oid(7), 42, 1000, &kind).expect("sign");
+        assert!(!wire.signature.is_empty());
+
+        let core = verify_and_decode(&wire, &pubkey).expect("verify");
+        assert_eq!(core.op_id, oid(7));
+        assert_eq!(core.actor_id, actor_id);
+        assert_eq!(core.lamport, 42);
+        assert_eq!(core.created_at, 1000);
+        assert_eq!(core.kind, kind);
+    }
+
+    // every op kind round-trips.
+    #[test]
+    fn all_kinds_round_trip() {
+        let keys = Keypair::generate_ed25519();
+        let pk = keys.public();
+        let kinds = vec![
+            OpKind::Add { member_id: vec![1; 4], role: 0 },
+            OpKind::Remove { member_id: vec![1; 4], observed_adds: vec![oid(1), oid(2)] },
+            OpKind::UpdateMetadata { name: Some("g".into()), avatar: Some(vec![9, 9]) },
+            OpKind::UpdateMetadata { name: None, avatar: None },
+            OpKind::Compact { epoch: 3, below: 100 },
+        ];
+        for (i, k) in kinds.iter().enumerate() {
+            let w = sign_op(&keys, b"g", oid(i as u8), i as u64, 0, k).unwrap();
+            let c = verify_and_decode(&w, &pk).unwrap();
+            assert_eq!(&c.kind, k, "kind {} round-trip", i);
+        }
+    }
+
+    // a tampered field invalidates the signature.
+    #[test]
+    fn tampered_op_rejected() {
+        let keys = Keypair::generate_ed25519();
+        let pk = keys.public();
+        let mut wire = sign_op(
+            &keys,
+            b"g",
+            oid(1),
+            1,
+            0,
+            &OpKind::Add { member_id: vec![2; 4], role: 0 },
+        )
+        .unwrap();
+        // flip the lamport after signing
+        wire.lamport = 999;
+        assert!(verify_and_decode(&wire, &pk).is_none(), "tampered op must fail");
+    }
+
+    // verifying against a different key fails.
+    #[test]
+    fn wrong_key_rejected() {
+        let keys = Keypair::generate_ed25519();
+        let other = Keypair::generate_ed25519().public();
+        let wire = sign_op(
+            &keys,
+            b"g",
+            oid(1),
+            1,
+            0,
+            &OpKind::Add { member_id: vec![2; 4], role: 0 },
+        )
+        .unwrap();
+        // actor_id (from `keys`) won't match `other`'s PeerId
+        assert!(verify_and_decode(&wire, &other).is_none());
+    }
+
+    // an op_id that is not 16 bytes is rejected.
+    #[test]
+    fn bad_op_id_len_rejected() {
+        let keys = Keypair::generate_ed25519();
+        let pk = keys.public();
+        let mut wire = sign_op(
+            &keys,
+            b"g",
+            oid(1),
+            1,
+            0,
+            &OpKind::Add { member_id: vec![2; 4], role: 0 },
+        )
+        .unwrap();
+        // corrupt op_id length then re-sign so the signature is valid
+        // but the op_id is structurally invalid
+        wire.op_id = vec![1, 2, 3];
+        let unsigned = {
+            let mut u = wire.clone();
+            u.signature = Vec::new();
+            u.encode_to_vec()
+        };
+        wire.signature = keys.sign(&unsigned).unwrap();
+        assert!(verify_and_decode(&wire, &pk).is_none(), "non-16-byte op_id rejected");
+    }
+}

--- a/rust/libqaul/src/services/group/crdt_wire.rs
+++ b/rust/libqaul/src/services/group/crdt_wire.rs
@@ -105,6 +105,22 @@ pub fn verify_and_decode(
     })
 }
 
+/// Decode a wire `GroupOp` into a core [`GroupOp`] **without** checking
+/// the signature. Only for ops already verified before storage (see
+/// `crdt_store::load_crdt`); never call this on freshly-received
+/// network data — use [`verify_and_decode`] there.
+pub fn decode_trusted(op: &proto_net::GroupOp) -> Option<GroupOp> {
+    let op_id: OpId = op.op_id.as_slice().try_into().ok()?;
+    let kind = proto_to_kind(op.op.as_ref()?)?;
+    Some(GroupOp {
+        op_id,
+        actor_id: op.actor_id.clone(),
+        lamport: op.lamport,
+        created_at: op.created_at,
+        kind,
+    })
+}
+
 /// Convert a core [`OpKind`] into the proto oneof.
 fn kind_to_proto(kind: &OpKind) -> proto_net::group_op::Op {
     match kind {

--- a/rust/libqaul/src/services/group/manage.rs
+++ b/rust/libqaul/src/services/group/manage.rs
@@ -227,6 +227,8 @@ impl GroupManage {
 
         group.id = group_id.clone();
         group.is_direct_chat = true;
+        // the local creator is the founder (CRDT bootstrap admin)
+        group.founder = account_id.to_bytes();
 
         // save group to data base
         GroupStorage::save_group(state, account_id.to_owned(), group.clone(), GroupSaveReason::Created);
@@ -239,6 +241,8 @@ impl GroupManage {
         let mut group = Group::new();
 
         group.id = uuid::Uuid::new_v4().as_bytes().to_vec();
+        // the local creator is the founder (CRDT bootstrap admin)
+        group.founder = account_id.to_bytes();
 
         group.members.insert(
             account_id.to_bytes(),
@@ -573,6 +577,7 @@ mod tests {
             created_at: 0,
             status: 0,
             revision: 0,
+            founder: Vec::new(),
             members: BTreeMap::new(),
             unread_messages: 0,
             last_message_at,

--- a/rust/libqaul/src/services/group/manage.rs
+++ b/rust/libqaul/src/services/group/manage.rs
@@ -449,8 +449,23 @@ impl GroupManage {
             Some(my_group) => {
                 group = my_group;
 
-                // check if the sent revision is higher then the one we already have
-                // return otherwise
+                // Retire the rev-counter merge for CRDT-managed groups:
+                // membership and metadata are owned by the membership
+                // CRDT (crdt.rs) and maintained by reconcile, so the
+                // legacy revision-gated GroupInfo merge must not clobber
+                // them. (Translating a legacy peer's GroupInfo changes
+                // into CRDT ops for a mixed group is separate future
+                // work; for an all-CRDT group this gossip is redundant.)
+                if !group.founder.is_empty() {
+                    log::trace!(
+                        "on_group_notify: CRDT group {} — ignoring legacy revision merge",
+                        group_id.to_string()
+                    );
+                    return;
+                }
+
+                // (legacy, non-CRDT groups) check if the sent revision
+                // is higher than the one we already have, else return
                 if group.revision >= notify.revision {
                     log::warn!("group update: got a smaller revision");
                     return;

--- a/rust/libqaul/src/services/group/member.rs
+++ b/rust/libqaul/src/services/group/member.rs
@@ -123,6 +123,7 @@ impl Member {
                         created_at: group.created_at,
                         revision: group.revision,
                         members,
+                        founder: group.founder.clone(),
                     }),
                 },
             )),
@@ -320,6 +321,8 @@ impl Member {
         group.created_at = group_info.created_at;
         group.status = super::proto_rpc::GroupStatus::InviteAccepted as i32;
         group.revision = group_info.revision;
+        // learn the founder so this invitee can derive the membership CRDT
+        group.founder = group_info.founder.clone();
 
         let invited = super::GroupInvited {
             sender_id: sender_id.to_bytes(),

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -21,6 +21,7 @@ use crate::rpc::Rpc;
 use crate::utilities::timestamp::Timestamp;
 
 pub mod crdt;
+pub mod crdt_wire;
 pub mod group_id;
 mod manage;
 mod member;
@@ -382,6 +383,17 @@ impl Group {
                 Some(proto_net::group_container::Message::GroupInfo(group_info)) => {
                     log::trace!("group info arrived");
                     manage::GroupManage::on_group_notify(state, *sender_id, *receiver_id, &group_info);
+                }
+                Some(proto_net::group_container::Message::GroupOp(_group_op)) => {
+                    // CRDT membership/metadata op. The receive path
+                    // (verify signature, merge into the op set, re-derive
+                    // the view) is wired in the integration slice; the
+                    // variant is acknowledged here so the new wire shape
+                    // already decodes.
+                    log::trace!(
+                        "received group CRDT op from {} (handler not yet wired)",
+                        sender_id.to_base58()
+                    );
                 }
                 None => {
                     log::error!("group message from {} was empty", sender_id.to_base58())

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -368,7 +368,7 @@ impl Group {
         state: &crate::QaulState,
         account_id: &PeerId,
         group_id: &[u8],
-    ) -> Option<(crdt::GroupView, usize)> {
+    ) -> Option<(crdt::GroupView, usize, u64)> {
         let group = GroupStorage::get_group(state, *account_id, group_id)?;
         if group.founder.is_empty() {
             return None;
@@ -377,7 +377,52 @@ impl Group {
         let crdt = crdt_store::load_crdt(&db, group_id, group.founder.clone());
         let view = crdt.view();
         let count = crdt.op_count();
-        Some((view, count))
+        let epoch = crdt.epoch();
+        Some((view, count, epoch))
+    }
+
+    /// Trigger a CRDT compaction for a group: emit a signed `Compact`
+    /// op raising the epoch and collapsing op history below `below`.
+    /// `below = 0` means "use the current max lamport". Authorization
+    /// (admin-only) is enforced by the CRDT when the op is applied.
+    /// Returns `(epoch, op_count)` after compaction.
+    pub fn crdt_compact(
+        state: &crate::QaulState,
+        account_id: &PeerId,
+        group_id: &[u8],
+        below: u64,
+    ) -> Result<(u64, usize), String> {
+        let group = GroupStorage::get_group(state, *account_id, group_id)
+            .ok_or_else(|| "group not found".to_string())?;
+        if group.founder.is_empty() {
+            return Err("group is not CRDT-managed".to_string());
+        }
+        let db = GroupStorage::get_db_ref(state, *account_id);
+        let crdt = crdt_store::load_crdt(&db, group_id, group.founder.clone());
+
+        // default floor: the current highest lamport (collapse all
+        // history strictly older than the latest op).
+        let floor = if below == 0 {
+            crdt.view().max_lamport
+        } else {
+            below
+        };
+        let next_epoch = crdt.epoch() + 1;
+
+        Self::emit_crdt_op(
+            state,
+            account_id,
+            group_id,
+            crdt::OpKind::Compact {
+                epoch: next_epoch,
+                below: floor,
+            },
+        )
+        .ok_or_else(|| "failed to emit compact op".to_string())?;
+
+        // reload to report the post-compaction state
+        let crdt = crdt_store::load_crdt(&db, group_id, group.founder);
+        Ok((crdt.epoch(), crdt.op_count()))
     }
 
     /// Reconcile the materialized `Group.members` / name from the CRDT,
@@ -963,7 +1008,7 @@ impl Group {
                     }
                     Some(proto_rpc::group::Message::GroupCrdtViewRequest(view_req)) => {
                         let resp = match Self::crdt_view(state, &my_user_id, &view_req.group_id) {
-                            Some((view, op_count)) => proto_rpc::GroupCrdtViewResponse {
+                            Some((view, op_count, epoch)) => proto_rpc::GroupCrdtViewResponse {
                                 group_id: view_req.group_id.clone(),
                                 found: true,
                                 founder: GroupStorage::get_group(state, my_user_id, &view_req.group_id)
@@ -979,6 +1024,7 @@ impl Group {
                                         role: m.role,
                                     })
                                     .collect(),
+                                epoch,
                             },
                             None => proto_rpc::GroupCrdtViewResponse {
                                 group_id: view_req.group_id.clone(),
@@ -988,6 +1034,34 @@ impl Group {
                         };
                         let proto_message = proto_rpc::Group {
                             message: Some(proto_rpc::group::Message::GroupCrdtViewResponse(resp)),
+                        };
+                        Rpc::send_message(
+                            state,
+                            proto_message.encode_to_vec(),
+                            crate::rpc::proto::Modules::Group.into(),
+                            request_id,
+                            Vec::new(),
+                        );
+                    }
+                    Some(proto_rpc::group::Message::GroupCrdtCompactRequest(compact_req)) => {
+                        let (status, message, epoch, op_count) = match Self::crdt_compact(
+                            state,
+                            &my_user_id,
+                            &compact_req.group_id,
+                            compact_req.below,
+                        ) {
+                            Ok((epoch, op_count)) => (true, String::new(), epoch, op_count as u32),
+                            Err(e) => (false, e, 0u64, 0u32),
+                        };
+                        let proto_message = proto_rpc::Group {
+                            message: Some(proto_rpc::group::Message::GroupCrdtCompactResponse(
+                                proto_rpc::GroupCrdtCompactResponse {
+                                    group_id: compact_req.group_id.clone(),
+                                    result: Some(proto_rpc::GroupResult { status, message }),
+                                    epoch,
+                                    op_count,
+                                },
+                            )),
                         };
                         Rpc::send_message(
                             state,

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -81,9 +81,14 @@ pub struct Group {
     /// group status
     ///
     pub status: i32,
-    /// group revision number
+    /// group revision number (LEGACY).
     ///
-    /// this number increases with every revision
+    /// Monotonic counter for the old last-writer-wins membership merge.
+    /// RETIRED for CRDT-managed groups (those with a `founder`): their
+    /// membership/metadata is owned by the membership CRDT and the
+    /// rev-counter merge in `on_group_notify` is skipped. Still used for
+    /// backward-compatible GroupInfo gossip with pre-CRDT peers; kept on
+    /// the wire/struct for that and to avoid breaking stored groups.
     pub revision: u32,
     /// group founder (creator) — bootstrap admin for the membership
     /// CRDT, un-removable, and the only actor who may remove an admin.

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -20,6 +20,7 @@ use crate::node::user_accounts::{UserAccount, UserAccounts};
 use crate::rpc::Rpc;
 use crate::utilities::timestamp::Timestamp;
 
+pub mod crdt;
 pub mod group_id;
 mod manage;
 mod member;

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -459,7 +459,13 @@ impl Group {
         let crdt = crdt_store::load_crdt(&db, group_id, group.founder.clone());
         let view = crdt.view();
 
-        GroupStorage::with_group_mut(state, account_id, group_id, |group| {
+        // A name change must reindex the room's searchable text;
+        // membership-only changes don't.
+        let reason = match &view.name {
+            Some(name) if *name != group.name => GroupSaveReason::Renamed,
+            _ => GroupSaveReason::MembershipChanged,
+        };
+        GroupStorage::with_group_mut(state, account_id, group_id, reason, |group| {
             // 1. drop members the CRDT knows about (has an add for) but
             //    that the view no longer contains (tombstoned).
             let to_drop: Vec<Vec<u8>> = group

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -273,8 +273,9 @@ impl Group {
             &kind,
         )?;
 
-        // persist locally
+        // persist locally + reconcile the materialized membership
         crdt_store::save_op(&db, group_id, &wire);
+        Self::reconcile_group_from_crdt(state, account_id, group_id);
 
         // recipients: every current remote member, plus — for an Add —
         // the member being added (who is not yet in the member list, so
@@ -350,6 +351,9 @@ impl Group {
         let group_id = group_op.group_id.clone();
         let db = GroupStorage::get_db_ref(state, *account_id);
         crdt_store::save_op(&db, &group_id, &group_op);
+        // CRDT is the source of truth: reflect the op into the
+        // materialized Group membership/metadata.
+        Self::reconcile_group_from_crdt(state, account_id, &group_id);
         log::trace!(
             "stored verified group CRDT op for {} from {}",
             bs58::encode(&group_id).into_string(),
@@ -374,6 +378,77 @@ impl Group {
         let view = crdt.view();
         let count = crdt.op_count();
         Some((view, count))
+    }
+
+    /// Reconcile the materialized `Group.members` / name from the CRDT,
+    /// making the CRDT the source of truth for membership.
+    ///
+    /// The CRDT wins for every member it has an opinion about:
+    /// - members present in the derived view are inserted/updated with
+    ///   the view's role (other per-member fields preserved if already
+    ///   present, else defaulted to an activated member joining now);
+    /// - a member the CRDT has at least one `Add` op for but that is
+    ///   *not* in the view was tombstoned by a `Remove`, so it is
+    ///   dropped from `Group.members`;
+    /// - a member the CRDT is entirely silent about (no add op) is left
+    ///   untouched — this preserves members of a mixed/legacy group
+    ///   during the transition and avoids dropping a freshly-invited
+    ///   peer before its add op has arrived.
+    ///
+    /// No-op for groups with no founder recorded (pre-CRDT groups).
+    pub fn reconcile_group_from_crdt(
+        state: &crate::QaulState,
+        account_id: &PeerId,
+        group_id: &[u8],
+    ) {
+        let group = match GroupStorage::get_group(state, *account_id, group_id) {
+            Some(g) if !g.founder.is_empty() => g,
+            _ => return,
+        };
+        let db = GroupStorage::get_db_ref(state, *account_id);
+        let crdt = crdt_store::load_crdt(&db, group_id, group.founder.clone());
+        let view = crdt.view();
+
+        GroupStorage::with_group_mut(state, account_id, group_id, |group| {
+            // 1. drop members the CRDT knows about (has an add for) but
+            //    that the view no longer contains (tombstoned).
+            let to_drop: Vec<Vec<u8>> = group
+                .members
+                .keys()
+                .filter(|id| {
+                    !view.members.contains_key(*id)
+                        && !crdt.add_op_ids_for(id).is_empty()
+                })
+                .cloned()
+                .collect();
+            for id in to_drop {
+                group.members.remove(&id);
+            }
+
+            // 2. insert / update every member the view contains.
+            for (id, m) in &view.members {
+                match group.members.get_mut(id) {
+                    Some(existing) => existing.role = m.role,
+                    None => {
+                        group.members.insert(
+                            id.clone(),
+                            GroupMember {
+                                user_id: id.clone(),
+                                role: m.role,
+                                joined_at: Timestamp::get_timestamp(),
+                                state: proto_rpc::GroupMemberState::Activated as i32,
+                                last_message_index: 0,
+                            },
+                        );
+                    }
+                }
+            }
+
+            // 3. metadata name (LWW) wins when set.
+            if let Some(name) = &view.name {
+                group.name = name.clone();
+            }
+        });
     }
 
     /// Send capsuled group message through messaging service

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -85,6 +85,12 @@ pub struct Group {
     ///
     /// this number increases with every revision
     pub revision: u32,
+    /// group founder (creator) — bootstrap admin for the membership
+    /// CRDT, un-removable, and the only actor who may remove an admin.
+    /// `#[serde(default)]` (empty) for groups stored before this field
+    /// existed; set to the creator's id for groups created since.
+    #[serde(default)]
+    pub founder: Vec<u8>,
     /// members
     pub members: BTreeMap<Vec<u8>, GroupMember>,
     /// how many unread messages are there
@@ -119,6 +125,7 @@ impl Group {
             created_at: Timestamp::get_timestamp(),
             status: 0,
             revision: 0,
+            founder: Vec::new(),
             members: BTreeMap::new(),
             unread_messages: 0,
             last_message_at: 0,
@@ -221,6 +228,154 @@ impl Group {
         }
     }
 
+    // ------------------------------------------------------------------
+    //                     Membership / metadata CRDT
+    // ------------------------------------------------------------------
+
+    /// Emit a signed CRDT op for `group_id`: stamp it with the next
+    /// lamport, sign it with the local identity key, persist it to the
+    /// op set, and broadcast it to the group's remote members.
+    ///
+    /// Additive to the legacy invite/reply path — failures here never
+    /// block the legacy operation. Returns the op_id on success.
+    pub fn emit_crdt_op(
+        state: &crate::QaulState,
+        account_id: &PeerId,
+        group_id: &[u8],
+        kind: crdt::OpKind,
+    ) -> Option<crdt::OpId> {
+        let user_account = UserAccounts::get_by_id(state, *account_id)?;
+        let group = GroupStorage::get_group(state, *account_id, group_id)?;
+        let db = GroupStorage::get_db_ref(state, *account_id);
+
+        // next lamport from the current op set
+        let founder = if group.founder.is_empty() {
+            account_id.to_bytes()
+        } else {
+            group.founder.clone()
+        };
+        let lamport = crdt_store::load_crdt(&db, group_id, founder).next_lamport();
+
+        // fresh random op_id
+        let mut op_id = [0u8; 16];
+        {
+            use rand::Rng;
+            rand::rng().fill(&mut op_id[..]);
+        }
+        let created_at = Timestamp::get_timestamp();
+
+        let wire = crdt_wire::sign_op(
+            &user_account.keys,
+            group_id,
+            op_id,
+            lamport,
+            created_at,
+            &kind,
+        )?;
+
+        // persist locally
+        crdt_store::save_op(&db, group_id, &wire);
+
+        // recipients: every current remote member, plus — for an Add —
+        // the member being added (who is not yet in the member list, so
+        // would otherwise miss the op that adds them).
+        let mut recipients: Vec<Vec<u8>> = group
+            .members
+            .keys()
+            .filter(|id| id.as_slice() != account_id.to_bytes().as_slice())
+            .cloned()
+            .collect();
+        if let crdt::OpKind::Add { member_id, .. } = &kind {
+            if !recipients.iter().any(|r| r == member_id) {
+                recipients.push(member_id.clone());
+            }
+        }
+
+        // send the op (wrapped so it routes to Group::net on receive)
+        let container = proto_net::GroupContainer {
+            message: Some(proto_net::group_container::Message::GroupOp(wire)),
+        };
+        let bytes = container.encode_to_vec();
+        for rid in recipients {
+            if let Ok(peer) = PeerId::from_bytes(&rid) {
+                Self::send_notify_message(state, &user_account, &peer, bytes.clone());
+            }
+        }
+        log::trace!(
+            "emitted group CRDT op for {} (lamport {})",
+            bs58::encode(group_id).into_string(),
+            lamport
+        );
+        Some(op_id)
+    }
+
+    /// Handle an incoming CRDT `GroupOp`: resolve the actor's public key
+    /// (a PeerId is a hash of the key), verify the signature, and
+    /// persist the op to the group's op set. Merge is unconditional —
+    /// authorization is enforced when the view is derived.
+    fn on_crdt_op(
+        state: &crate::QaulState,
+        account_id: &PeerId,
+        sender_id: &PeerId,
+        group_op: proto_net::GroupOp,
+    ) {
+        let actor_peer = match PeerId::from_bytes(&group_op.actor_id) {
+            Ok(p) => p,
+            Err(_) => {
+                log::warn!("group CRDT op from {}: invalid actor_id", sender_id.to_base58());
+                return;
+            }
+        };
+        let pubkey = {
+            let router = state.get_router();
+            crate::router::users::Users::get_pub_key(&router, &actor_peer)
+        };
+        let pubkey = match pubkey {
+            Some(k) => k,
+            None => {
+                log::warn!(
+                    "group CRDT op: unknown public key for actor {}",
+                    actor_peer.to_base58()
+                );
+                return;
+            }
+        };
+        if crdt_wire::verify_and_decode(&group_op, &pubkey).is_none() {
+            log::warn!(
+                "group CRDT op from {}: signature verification failed",
+                sender_id.to_base58()
+            );
+            return;
+        }
+        let group_id = group_op.group_id.clone();
+        let db = GroupStorage::get_db_ref(state, *account_id);
+        crdt_store::save_op(&db, &group_id, &group_op);
+        log::trace!(
+            "stored verified group CRDT op for {} from {}",
+            bs58::encode(&group_id).into_string(),
+            sender_id.to_base58()
+        );
+    }
+
+    /// Derive the converged CRDT view for a group (for inspection /
+    /// the read RPC). `None` if the group is unknown or predates CRDT
+    /// (no founder recorded).
+    pub fn crdt_view(
+        state: &crate::QaulState,
+        account_id: &PeerId,
+        group_id: &[u8],
+    ) -> Option<(crdt::GroupView, usize)> {
+        let group = GroupStorage::get_group(state, *account_id, group_id)?;
+        if group.founder.is_empty() {
+            return None;
+        }
+        let db = GroupStorage::get_db_ref(state, *account_id);
+        let crdt = crdt_store::load_crdt(&db, group_id, group.founder.clone());
+        let view = crdt.view();
+        let count = crdt.op_count();
+        Some((view, count))
+    }
+
     /// Send capsuled group message through messaging service
     #[allow(dead_code)]
     pub fn send_group_message(
@@ -313,6 +468,7 @@ impl Group {
             created_at: group.created_at,
             revision: group.revision,
             members,
+            founder: group.founder.clone(),
         };
 
         let container = proto_net::GroupContainer {
@@ -385,16 +541,8 @@ impl Group {
                     log::trace!("group info arrived");
                     manage::GroupManage::on_group_notify(state, *sender_id, *receiver_id, &group_info);
                 }
-                Some(proto_net::group_container::Message::GroupOp(_group_op)) => {
-                    // CRDT membership/metadata op. The receive path
-                    // (verify signature, merge into the op set, re-derive
-                    // the view) is wired in the integration slice; the
-                    // variant is acknowledged here so the new wire shape
-                    // already decodes.
-                    log::trace!(
-                        "received group CRDT op from {} (handler not yet wired)",
-                        sender_id.to_base58()
-                    );
+                Some(proto_net::group_container::Message::GroupOp(group_op)) => {
+                    Self::on_crdt_op(state, &user.id, sender_id, group_op);
                 }
                 None => {
                     log::error!("group message from {} was empty", sender_id.to_base58())
@@ -487,6 +635,17 @@ impl Group {
                         // post updates
                         if status {
                             Self::post_group_update(state, &my_user_id, &group_rename_req.group_id);
+
+                            // shadow the rename as a CRDT metadata op
+                            Self::emit_crdt_op(
+                                state,
+                                &my_user_id,
+                                &group_rename_req.group_id,
+                                crdt::OpKind::UpdateMetadata {
+                                    name: Some(group_rename_req.group_name.clone()),
+                                    avatar: None,
+                                },
+                            );
                         }
                     }
                     Some(proto_rpc::group::Message::GroupInfoRequest(group_info_req)) => {
@@ -618,6 +777,21 @@ impl Group {
                             request_id,
                             Vec::new(),
                         );
+
+                        // additively shadow the invite as a CRDT op so
+                        // members converge on membership without the
+                        // rev-counter merge. Best-effort.
+                        if status {
+                            Self::emit_crdt_op(
+                                state,
+                                &my_user_id,
+                                &invite_req.group_id,
+                                crdt::OpKind::Add {
+                                    member_id: invite_req.user_id.clone(),
+                                    role: crdt::ROLE_MEMBER,
+                                },
+                            );
+                        }
                     }
                     Some(proto_rpc::group::Message::GroupReplyInviteRequest(reply_req)) => {
                         let mut status = true;
@@ -691,7 +865,62 @@ impl Group {
 
                         if status {
                             Self::post_group_update(state, &my_user_id, &remove_req.group_id);
+
+                            // shadow the removal as a CRDT op tombstoning
+                            // every add we have seen for that member.
+                            let db = GroupStorage::get_db_ref(state, my_user_id);
+                            let founder = GroupStorage::get_group(state, my_user_id, &remove_req.group_id)
+                                .map(|g| g.founder)
+                                .unwrap_or_default();
+                            let founder = if founder.is_empty() { my_user_id.to_bytes() } else { founder };
+                            let observed = crdt_store::load_crdt(&db, &remove_req.group_id, founder)
+                                .add_op_ids_for(&remove_req.user_id);
+                            Self::emit_crdt_op(
+                                state,
+                                &my_user_id,
+                                &remove_req.group_id,
+                                crdt::OpKind::Remove {
+                                    member_id: remove_req.user_id.clone(),
+                                    observed_adds: observed,
+                                },
+                            );
                         }
+                    }
+                    Some(proto_rpc::group::Message::GroupCrdtViewRequest(view_req)) => {
+                        let resp = match Self::crdt_view(state, &my_user_id, &view_req.group_id) {
+                            Some((view, op_count)) => proto_rpc::GroupCrdtViewResponse {
+                                group_id: view_req.group_id.clone(),
+                                found: true,
+                                founder: GroupStorage::get_group(state, my_user_id, &view_req.group_id)
+                                    .map(|g| g.founder)
+                                    .unwrap_or_default(),
+                                name: view.name.clone().unwrap_or_default(),
+                                op_count: op_count as u32,
+                                members: view
+                                    .members
+                                    .iter()
+                                    .map(|(id, m)| proto_rpc::GroupCrdtMember {
+                                        user_id: id.clone(),
+                                        role: m.role,
+                                    })
+                                    .collect(),
+                            },
+                            None => proto_rpc::GroupCrdtViewResponse {
+                                group_id: view_req.group_id.clone(),
+                                found: false,
+                                ..Default::default()
+                            },
+                        };
+                        let proto_message = proto_rpc::Group {
+                            message: Some(proto_rpc::group::Message::GroupCrdtViewResponse(resp)),
+                        };
+                        Rpc::send_message(
+                            state,
+                            proto_message.encode_to_vec(),
+                            crate::rpc::proto::Modules::Group.into(),
+                            request_id,
+                            Vec::new(),
+                        );
                     }
                     _ => {
                         log::error!("Unhandled Protobuf Group chat message");

--- a/rust/libqaul/src/services/group/mod.rs
+++ b/rust/libqaul/src/services/group/mod.rs
@@ -21,6 +21,7 @@ use crate::rpc::Rpc;
 use crate::utilities::timestamp::Timestamp;
 
 pub mod crdt;
+pub mod crdt_store;
 pub mod crdt_wire;
 pub mod group_id;
 mod manage;

--- a/rust/libqaul/src/services/group/storage.rs
+++ b/rust/libqaul/src/services/group/storage.rs
@@ -22,6 +22,12 @@ pub struct GroupAccountDb {
     /// invited DB ref
     /// bincode of `GroupInvited`
     pub invited: sled::Tree,
+    /// group CRDT operation log (membership/metadata).
+    ///
+    /// key: `group_id ++ op_id`
+    /// value: encoded `qaul.net.group.GroupOp` (already signature-
+    /// verified before storage). See `crdt_store.rs`.
+    pub ops: sled::Tree,
 }
 
 /// qaul Chat Conversation Storage
@@ -115,6 +121,7 @@ impl GroupStorageState {
                 return GroupAccountDb {
                     groups: group_account_db.groups.clone(),
                     invited: group_account_db.invited.clone(),
+                    ops: group_account_db.ops.clone(),
                 };
             }
         }
@@ -127,8 +134,9 @@ impl GroupStorageState {
     fn create_groupaccountdb(&self, account_id: PeerId, db: &sled::Db) -> GroupAccountDb {
         let groups: sled::Tree = db.open_tree("groups").unwrap();
         let invited: sled::Tree = db.open_tree("invited").unwrap();
+        let ops: sled::Tree = db.open_tree("group_ops").unwrap();
 
-        let group_account_db = GroupAccountDb { groups, invited };
+        let group_account_db = GroupAccountDb { groups, invited, ops };
 
         let mut group_storage = self.inner.write().unwrap();
         group_storage
@@ -159,6 +167,7 @@ impl GroupStorage {
                 return GroupAccountDb {
                     groups: group_account_db.groups.clone(),
                     invited: group_account_db.invited.clone(),
+                    ops: group_account_db.ops.clone(),
                 };
             }
         }
@@ -170,6 +179,7 @@ impl GroupStorage {
         GroupAccountDb {
             groups: group_account_db.groups.clone(),
             invited: group_account_db.invited.clone(),
+            ops: group_account_db.ops.clone(),
         }
     }
 
@@ -211,8 +221,15 @@ impl GroupStorage {
                 db.open_tree("__fallback_invited").expect("critical: cannot open fallback invited tree")
             }
         };
+        let ops: sled::Tree = match db.open_tree("group_ops") {
+            Ok(tree) => tree,
+            Err(e) => {
+                log::error!("failed to open group_ops tree: {}", e);
+                db.open_tree("__fallback_group_ops").expect("critical: cannot open fallback group_ops tree")
+            }
+        };
 
-        let group_account_db = GroupAccountDb { groups, invited };
+        let group_account_db = GroupAccountDb { groups, invited, ops };
 
         // add account to state (scope the write lock so it is released before search init)
         {


### PR DESCRIPTION
Replaces the `Group::revision` last-writer-wins merge with a signed-op
  CRDT so partitioned members converge deterministically on membership and
  metadata. Implements docs/proposals/Group-State-CRDT.md.
  - Membership = Observed-Remove Set (add-wins); metadata = per-field LWW.
  - Founder is bootstrap admin, un-removable, and the only one who can
    remove an admin. Gated on Capabilities::GROUP_CRDT.
  - CRDT is the source of truth for Group.members; includes compaction GC
    and session-tolerant delivery (queues sends during first-contact
    handshake instead of dropping). Inspect via `qauld-ctl group crdt-view`.