### PR TITLE
fix: delivery bugs

### DIFF
--- a/rust/libqaul/src/services/chat/file.rs
+++ b/rust/libqaul/src/services/chat/file.rs
@@ -705,6 +705,7 @@ impl ChatFile {
             user_account,
             &group,
             &message_id,
+            file_id,
             timestamp,
             info.encode_to_vec(),
         );
@@ -728,7 +729,7 @@ impl ChatFile {
             message_count: file_info.message_count,
             chunk_size: DEF_PACKAGE_SIZE,
             file_state: FileState::Sending,
-            reception_tracking: BTreeMap::new(),
+            reception_tracking: Self::init_reception_tracking(&group, &user_account.id),
             file_name: file_name.clone(),
             file_description: description.clone(),
             file_extension: extension.clone(),
@@ -803,6 +804,7 @@ impl ChatFile {
                 user_account,
                 &group,
                 &message_id,
+                file_id,
                 timestamp,
                 data.encode_to_vec(),
             );
@@ -856,12 +858,47 @@ impl ChatFile {
         );
     }
 
+    /// Build the initial reception-tracking map for a file we are sending.
+    ///
+    /// One entry per remote group member (ourselves excluded); each starts
+    /// with zero confirmed packages. Without this the map would be empty and
+    /// [`FileHistory::reception_confirmed`] could never advance the file state,
+    /// so a sent file would never be marked confirmed for any recipient.
+    fn init_reception_tracking(
+        group: &Group,
+        self_id: &PeerId,
+    ) -> BTreeMap<Vec<u8>, ReceptionTracking> {
+        let mut tracking = BTreeMap::new();
+        for member in group.members.values() {
+            match PeerId::from_bytes(&member.user_id) {
+                Ok(id) => {
+                    // we don't expect a confirmation from ourselves
+                    if &id == self_id {
+                        continue;
+                    }
+                    // key by the canonical PeerId byte form, matching the key
+                    // computed in `reception_confirmed`
+                    tracking.insert(
+                        id.to_bytes(),
+                        ReceptionTracking {
+                            received: false,
+                            package_count: 0,
+                        },
+                    );
+                }
+                Err(e) => log::error!("init_reception_tracking: invalid member id: {}", e),
+            }
+        }
+        tracking
+    }
+
     /// Pack a FileContainer message and send it to all Group members
     fn send_filecontainer_to_group(
         state: &crate::QaulState,
         user_account: &UserAccount,
         group: &Group,
         message_id: &[u8],
+        file_id: u64,
         timestamp: u64,
         data: Vec<u8>,
     ) {
@@ -882,13 +919,19 @@ impl ChatFile {
         };
         let message_bytes = message.encode_to_vec();
 
+        // The unconfirmed-table entry for a file message is keyed (for
+        // confirmation routing) by the file_id rather than the group
+        // message_id: the `ChatFile` confirmation arm decodes this back into a
+        // u64 file_id to update per-recipient reception tracking. The wire
+        // `CommonMessage` above still carries the real group message_id.
+        let file_id_bytes = file_id.to_be_bytes();
         Group::send_to_remote_members(
             state,
             user_account,
             group,
             &message_bytes,
             MessagingServiceType::ChatFile,
-            message_id,
+            &file_id_bytes,
             "sending file message error",
         );
     }
@@ -1220,5 +1263,115 @@ impl ChatFile {
                 log::error!("{:?}", error);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::group::GroupMember;
+    use libp2p::identity::Keypair;
+
+    fn peer() -> PeerId {
+        Keypair::generate_ed25519().public().to_peer_id()
+    }
+
+    fn member(id: &PeerId) -> GroupMember {
+        GroupMember {
+            user_id: id.to_bytes(),
+            role: 0,
+            joined_at: 0,
+            state: 0,
+            last_message_index: 0,
+        }
+    }
+
+    /// A file we send must track every *remote* group member (and not
+    /// ourselves), so confirmations can be attributed per recipient.
+    ///
+    /// Regression: `reception_tracking` was created empty, so
+    /// `reception_confirmed` always took its `None` branch and a sent file
+    /// could never be marked confirmed.
+    #[test]
+    fn init_reception_tracking_tracks_each_remote_member() {
+        let me = peer();
+        let a = peer();
+        let b = peer();
+
+        let mut group = Group::new();
+        for id in [&me, &a, &b] {
+            group.members.insert(id.to_bytes(), member(id));
+        }
+
+        let tracking = ChatFile::init_reception_tracking(&group, &me);
+
+        assert_eq!(tracking.len(), 2, "should track both remote members");
+        assert!(tracking.contains_key(&a.to_bytes()));
+        assert!(tracking.contains_key(&b.to_bytes()));
+        assert!(
+            !tracking.contains_key(&me.to_bytes()),
+            "must not track ourselves"
+        );
+        for t in tracking.values() {
+            assert_eq!(t.package_count, 0);
+            assert!(!t.received);
+        }
+    }
+
+    /// A file becomes `Confirmed` only once a recipient has confirmed *every*
+    /// chunk, and `ConfirmedByAll` only once *every* recipient has. This is the
+    /// delivery semantics the empty-map bug silently disabled.
+    #[test]
+    fn reception_confirmed_completes_per_member_then_all() {
+        let a = peer();
+        let b = peer();
+
+        let mut tracking = BTreeMap::new();
+        tracking.insert(
+            a.to_bytes(),
+            ReceptionTracking {
+                received: false,
+                package_count: 0,
+            },
+        );
+        tracking.insert(
+            b.to_bytes(),
+            ReceptionTracking {
+                received: false,
+                package_count: 0,
+            },
+        );
+
+        // message_count = 2 -> two confirmations per recipient to complete
+        let mut fh = FileHistory {
+            group_id: Vec::new(),
+            sender_id: Vec::new(),
+            file_id: 1,
+            message_id: vec![9, 9, 9],
+            start_index: 0,
+            message_count: 2,
+            chunk_size: 1,
+            file_state: FileState::Sending,
+            reception_tracking: tracking,
+            file_name: "f".to_string(),
+            file_description: String::new(),
+            file_extension: String::new(),
+            file_size: 1,
+            sent_at: 0,
+            received_at: 0,
+        };
+
+        // A confirms 1 of 2: not complete yet
+        assert!(!fh.reception_confirmed(a));
+        assert!(matches!(fh.file_state, FileState::Sending));
+
+        // A confirms 2 of 2: A is done, but not everyone
+        assert!(fh.reception_confirmed(a));
+        assert!(matches!(fh.file_state, FileState::Confirmed));
+
+        // B confirms both chunks: now confirmed by all recipients
+        assert!(!fh.reception_confirmed(b));
+        assert!(fh.reception_confirmed(b));
+        assert!(matches!(fh.file_state, FileState::ConfirmedByAll));
     }
 }

--- a/rust/libqaul/src/services/crypto/mod.rs
+++ b/rust/libqaul/src/services/crypto/mod.rs
@@ -506,6 +506,7 @@ impl Crypto {
             user_account,
             &remote_id,
             encrypted_message,
+            messaging::MessagingServiceType::Crypto,
             &message_id,
             true,
         )
@@ -905,6 +906,7 @@ impl Crypto {
                                         &user_account,
                                         &remote_id,
                                         encrypted_message,
+                                        messaging::MessagingServiceType::Crypto,
                                         message_id,
                                         true,
                                     ) {
@@ -1043,6 +1045,7 @@ impl Crypto {
             user_account,
             &remote_id,
             encrypted_message,
+            messaging::MessagingServiceType::Crypto,
             &message_id,
             true,
         ) {

--- a/rust/libqaul/src/services/crypto/mod.rs
+++ b/rust/libqaul/src/services/crypto/mod.rs
@@ -159,6 +159,25 @@ impl Crypto {
     ///
     /// The function returns the packed message on success,
     /// or none on failure.
+    ///
+    /// Returns true if the primary session for `remote_id` exists and is
+    /// still completing its handshake (`HalfOutgoing`) — i.e. `encrypt` would
+    /// currently refuse to produce a transport frame for this peer, so the
+    /// caller should queue the plaintext and retry once the session is ready.
+    /// Returns false when there is no session (where `encrypt` instead starts
+    /// a fresh handshake and succeeds) or the session is already usable.
+    pub fn session_pending_handshake(
+        state: &crate::QaulState,
+        user_account: &UserAccount,
+        remote_id: PeerId,
+    ) -> bool {
+        let crypto_account = CryptoStorage::get_db_ref(state, user_account.id.clone());
+        match Self::resolve_primary_state(&crypto_account, remote_id) {
+            Some(session) => matches!(session.state, CryptoProcessState::HalfOutgoing),
+            None => false,
+        }
+    }
+
     pub fn encrypt(
         state: &crate::QaulState,
         data: Vec<u8>,

--- a/rust/libqaul/src/services/crypto/mod.rs
+++ b/rust/libqaul/src/services/crypto/mod.rs
@@ -178,6 +178,21 @@ impl Crypto {
         }
     }
 
+    /// The session_id of the current primary session for `remote_id`, if any.
+    ///
+    /// Retransmit uses this to detect when a stored message's ciphertext was
+    /// encrypted under a session that is no longer current (the peer rotated
+    /// away from it), so it can re-encrypt the plaintext under the live session
+    /// instead of replaying ciphertext the receiver may have already retired.
+    pub fn current_primary_session_id(
+        state: &crate::QaulState,
+        local_user_id: PeerId,
+        remote_id: PeerId,
+    ) -> Option<u32> {
+        let crypto_account = CryptoStorage::get_db_ref(state, local_user_id);
+        Self::resolve_primary_state(&crypto_account, remote_id).map(|s| s.session_id)
+    }
+
     pub fn encrypt(
         state: &crate::QaulState,
         data: Vec<u8>,
@@ -693,7 +708,7 @@ impl Crypto {
 
     /// Extract the `Encrypted.session_id` from an encoded messaging
     /// `Container`, if the container carries an encrypted payload.
-    fn container_session_id(container_bytes: &[u8]) -> Option<u32> {
+    pub(crate) fn container_session_id(container_bytes: &[u8]) -> Option<u32> {
         let container = messaging::proto::Container::decode(container_bytes).ok()?;
         let envelope = container.envelope?;
         let payload = messaging::proto::EnvelopPayload::decode(&envelope.payload[..]).ok()?;

--- a/rust/libqaul/src/services/crypto/sessionmanager.rs
+++ b/rust/libqaul/src/services/crypto/sessionmanager.rs
@@ -226,6 +226,7 @@ impl CryptoSessionManager {
             user_account,
             sender_id,
             encrypted_message,
+            messaging::MessagingServiceType::Crypto,
             &message_id,
             true,
         ) {
@@ -317,6 +318,7 @@ impl CryptoSessionManager {
             user_account,
             sender_id,
             encrypted_message,
+            messaging::MessagingServiceType::Crypto,
             &message_id,
             true,
         ) {

--- a/rust/libqaul/src/services/dtn/mod.rs
+++ b/rust/libqaul/src/services/dtn/mod.rs
@@ -258,32 +258,56 @@ impl DtnModuleState {
     }
 
     /// Process DTN response (instance method).
+    ///
+    /// A custodian receives confirmation that a stored message was
+    /// delivered, so it frees the storage that message occupied and
+    /// drops it from both index trees.
     pub fn on_dtn_response(&self, dtn_response: &super::messaging::proto::DtnResponse) {
         let mut state = self.inner.write().unwrap();
-        if state.db_ref.contains_key(&dtn_response.signature).unwrap() {
-            let entry_bytes = state.db_ref.get(&dtn_response.signature).unwrap().unwrap();
-            let entry: DtnMessageEntry = bincode::deserialize(&entry_bytes).unwrap();
-            if state.used_size > entry.size as u64 {
-                state.used_size = state.used_size + (entry.size as u64);
-            } else {
-                state.used_size = 0;
-            }
-            if state.message_counts > 0 {
-                state.message_counts = state.message_counts - 1;
-            }
 
-            if let Err(_) = state.db_ref.remove(&dtn_response.signature) {
-                log::error!("remove storage node entry error!");
-            } else if let Err(_) = state.db_ref.flush() {
-                log::error!("remove storage node entry flush error!");
+        // look up the stored entry; not finding it (or a bad row) is a
+        // no-op, never a panic
+        let entry_bytes = match state.db_ref.get(&dtn_response.signature) {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return,
+            Err(e) => {
+                log::error!("dtn on_dtn_response db_ref get: {}", e);
+                return;
             }
+        };
+        let entry: DtnMessageEntry = match bincode::deserialize(&entry_bytes) {
+            Ok(e) => e,
+            Err(e) => {
+                log::error!("dtn on_dtn_response entry deserialize: {}", e);
+                return;
+            }
+        };
 
-            if let Err(_) = state.db_ref_id.remove(&entry.org_sig) {
-                log::error!("remove storage node id entry error!");
-            } else if let Err(_) = state.db_ref_id.flush() {
-                log::error!("remove storage node id entry flush error!");
-            }
+        // The message was delivered and is being removed, so FREE its
+        // storage (subtract). Previously this incorrectly *added* the
+        // size, so used_size grew without bound until the node started
+        // rejecting every new message as over-quota.
+        state.used_size = state.used_size.saturating_sub(entry.size as u64);
+        state.message_counts = state.message_counts.saturating_sub(1);
+
+        // remove from both index trees atomically: a crash between two
+        // separate removals would otherwise desync db_ref / db_ref_id
+        // and corrupt dedup state.
+        use sled::Transactional;
+        let sig = dtn_response.signature.clone();
+        let org_sig = entry.org_sig.clone();
+        let res: sled::transaction::TransactionResult<(), ()> =
+            (&state.db_ref, &state.db_ref_id).transaction(|(db_ref, db_ref_id)| {
+                db_ref.remove(sig.as_slice())?;
+                db_ref_id.remove(org_sig.as_slice())?;
+                Ok(())
+            });
+        if let Err(e) = res {
+            log::error!("dtn on_dtn_response tree removal transaction failed: {:?}", e);
+            return;
         }
+        let _ = state.db_ref.flush();
+        let _ = state.db_ref_id.flush();
     }
 
     /// Get DTN storage state (instance method).
@@ -415,10 +439,9 @@ impl Dtn {
         };
 
         if let Ok(signature) = user_account.keys.sign(&envelop.encode_to_vec()) {
-            // save dtn message entry
-            storage_state.message_counts = storage_state.message_counts + 1;
-            storage_state.used_size = new_size;
-
+            // (storage accounting is updated only after the entry is
+            // committed to the index trees, below, so a failed write
+            // can't inflate used_size / message_counts.)
             let message_entry = DtnMessageEntry {
                 org_sig: org_sig.clone(),
                 size: dtn_payload.len() as u32,
@@ -434,31 +457,37 @@ impl Dtn {
                 }
             };
 
-            // NOTE: The following two tree writes (db_ref and db_ref_id) are not
-            // atomic. If a crash occurs between them, the database could end up in
-            // an inconsistent state (e.g. an entry in db_ref without a corresponding
-            // entry in db_ref_id, or vice versa). A sled transaction spanning both
-            // trees would fix this but requires a larger refactor.
-            if let Err(_e) = storage_state
-                .db_ref
-                .insert(signature.clone(), message_entry_bytes)
-            {
-                log::error!("dnt entry storing error!");
-            } else {
-                if let Err(_e) = storage_state.db_ref.flush() {
-                    log::error!("dnt entry flushing error!");
+            // Write both index trees (db_ref and db_ref_id) atomically:
+            // a crash between two separate inserts would leave them
+            // desynced (an entry in one tree without its counterpart),
+            // corrupting dedup/cleanup. A sled transaction commits both
+            // or neither.
+            use sled::Transactional;
+            let sig = signature.clone();
+            let org = org_sig.clone();
+            let res: sled::transaction::TransactionResult<(), ()> = (
+                &storage_state.db_ref,
+                &storage_state.db_ref_id,
+            )
+                .transaction(|(db_ref, db_ref_id)| {
+                    db_ref.insert(sig.as_slice(), message_entry_bytes.as_slice())?;
+                    db_ref_id.insert(org.as_slice(), sig.as_slice())?;
+                    Ok(())
+                });
+            match res {
+                Ok(()) => {
+                    let _ = storage_state.db_ref.flush();
+                    let _ = storage_state.db_ref_id.flush();
+                    // entry is committed — now account for its storage
+                    storage_state.message_counts = storage_state.message_counts + 1;
+                    storage_state.used_size = new_size;
                 }
-            }
-
-            // save message id
-            if let Err(_e) = storage_state
-                .db_ref_id
-                .insert(org_sig.clone(), signature.clone())
-            {
-                log::error!("dtn id db storing error!");
-            } else {
-                if let Err(_e) = storage_state.db_ref_id.flush() {
-                    log::error!("dtn id db flushing error!");
+                Err(e) => {
+                    log::error!("dtn entry store transaction failed: {:?}", e);
+                    return (
+                        super::messaging::proto::dtn_response::ResponseType::Rejected as i32,
+                        super::messaging::proto::dtn_response::Reason::None as i32,
+                    );
                 }
             }
 
@@ -479,42 +508,6 @@ impl Dtn {
             super::messaging::proto::dtn_response::ResponseType::Accepted as i32,
             super::messaging::proto::dtn_response::Reason::None as i32,
         )
-    }
-
-    /// this function is called when receive DTN response
-    pub fn on_dtn_response(state: &crate::QaulState, dtn_response: &super::messaging::proto::DtnResponse) {
-        let mut state = state.services.dtn.inner.write().unwrap();
-        if let Ok(Some(entry_bytes)) = state.db_ref.get(&dtn_response.signature) {
-            // update storage node state
-            let entry: DtnMessageEntry = match bincode::deserialize(&entry_bytes) {
-                Ok(e) => e,
-                Err(e) => {
-                    log::error!("DTN: failed to deserialize entry: {}", e);
-                    return;
-                }
-            };
-            state.used_size = state.used_size.saturating_sub(entry.size as u64);
-            state.message_counts = state.message_counts.saturating_sub(1);
-
-            // NOTE: The following two tree removals (db_ref and db_ref_id) are not
-            // atomic. A crash between them could leave stale entries in one tree.
-            // A sled transaction spanning both trees would fix this.
-            if let Err(_) = state.db_ref.remove(&dtn_response.signature) {
-                log::error!("remove storage node entry error!");
-            } else {
-                if let Err(_) = state.db_ref.flush() {
-                    log::error!("remove storage node entry flush error!");
-                }
-            }
-
-            if let Err(_) = state.db_ref_id.remove(&entry.org_sig) {
-                log::error!("remove storage node id entry error!");
-            } else {
-                if let Err(_) = state.db_ref_id.flush() {
-                    log::error!("remove storage node id entry flush error!");
-                }
-            }
-        }
     }
 
     /// process DTN messages from network
@@ -1700,6 +1693,69 @@ mod tests {
     use libp2p::identity::Keypair;
     use prost::Message;
     use std::collections::HashMap;
+
+    // A delivered DTN message must FREE the storage it occupied (the
+    // accounting previously *added* the size, so used_size grew without
+    // bound until the custodian rejected everything as over-quota), and
+    // both index trees must be cleared together (atomic removal).
+    #[test]
+    fn dtn_response_frees_storage_and_clears_both_trees() {
+        let dtn = DtnModuleState::new();
+        let sig = vec![1u8; 16];
+        let org_sig = vec![2u8; 16];
+        let entry = DtnMessageEntry {
+            org_sig: org_sig.clone(),
+            size: 500,
+        };
+
+        // simulate one stored message occupying 500 bytes
+        {
+            let st = dtn.inner.write().unwrap();
+            st.db_ref
+                .insert(sig.as_slice(), bincode::serialize(&entry).unwrap())
+                .unwrap();
+            st.db_ref_id
+                .insert(org_sig.as_slice(), sig.as_slice())
+                .unwrap();
+        }
+        {
+            let mut st = dtn.inner.write().unwrap();
+            st.used_size = 500;
+            st.message_counts = 1;
+        }
+
+        // delivery confirmation for that message
+        let resp = proto::DtnResponse {
+            signature: sig.clone(),
+            ..Default::default()
+        };
+        dtn.on_dtn_response(&resp);
+
+        let st = dtn.inner.read().unwrap();
+        assert_eq!(st.used_size, 0, "delivered message must free its storage");
+        assert_eq!(st.message_counts, 0);
+        assert!(
+            !st.db_ref.contains_key(sig.as_slice()).unwrap(),
+            "entry removed from db_ref"
+        );
+        assert!(
+            !st.db_ref_id.contains_key(org_sig.as_slice()).unwrap(),
+            "entry removed from db_ref_id (atomic with db_ref)"
+        );
+    }
+
+    // An unknown / already-delivered signature is a harmless no-op
+    // (never a panic), even on a corrupted row.
+    #[test]
+    fn dtn_response_unknown_signature_is_noop() {
+        let dtn = DtnModuleState::new();
+        let resp = proto::DtnResponse {
+            signature: vec![9u8; 16],
+            ..Default::default()
+        };
+        dtn.on_dtn_response(&resp); // must not panic
+        assert_eq!(dtn.inner.read().unwrap().used_size, 0);
+    }
 
     /// Create a random PeerId from a fresh Ed25519 keypair.
     fn random_peer() -> PeerId {

--- a/rust/libqaul/src/services/messaging/mod.rs
+++ b/rust/libqaul/src/services/messaging/mod.rs
@@ -117,12 +117,42 @@ pub struct PendingPlaintext {
     pub queued_at: u64,
 }
 
+/// Plaintext of a sent, not-yet-confirmed message, kept so a retransmit can
+/// RE-ENCRYPT it under the peer's current session when the originally-sent
+/// ciphertext can no longer be decrypted by the receiver (the peer session
+/// rotated and the old one was retired).
+///
+/// Persisted (unlike [`PendingPlaintext`], which is in-memory) so that
+/// re-encryption survives a restart-triggered cold re-key — the dominant
+/// rotation trigger. Stored on the sender's own device only; the same message
+/// content already lives in the local chat database, so this is not a new
+/// plaintext-at-rest exposure. Removed once the message is confirmed.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OutboundPlaintext {
+    /// local sending user id (PeerId bytes)
+    pub user_id: Vec<u8>,
+    /// remote receiver id (PeerId bytes)
+    pub receiver_id: Vec<u8>,
+    /// plaintext message bytes to (re-)encrypt and send
+    pub data: Vec<u8>,
+    /// service type for the unconfirmed entry
+    pub message_type: MessagingServiceType,
+    /// message id for the unconfirmed entry
+    pub message_id: Vec<u8>,
+}
+
 /// Unconfirmed Messages Structure
 pub struct UnConfirmedMessages {
     /// signature => UnConfirmedMessage
     ///
     /// value: bincode of `UnConfirmedMessage`
     pub unconfirmed: sled::Tree,
+    /// signature => bincode of [`OutboundPlaintext`]
+    ///
+    /// Sender-side plaintext for sent-but-unconfirmed messages, so retransmit
+    /// can re-encrypt across a session rotation. Kept in lock-step with
+    /// `unconfirmed` (same signature key, same write lock).
+    pub outbound_plaintext: sled::Tree,
 }
 
 /// Qaul Messaging Structure
@@ -156,12 +186,14 @@ impl MessagingState {
     pub fn new() -> Self {
         let db = sled::Config::new().temporary(true).open().unwrap();
         let unconfirmed_tree = db.open_tree("unconfirmed").unwrap();
+        let outbound_plaintext_tree = db.open_tree("outbound_plaintext").unwrap();
         Self {
             messaging: RwLock::new(Messaging {
                 to_send: VecDeque::new(),
             }),
             unconfirmed: RwLock::new(UnConfirmedMessages {
                 unconfirmed: unconfirmed_tree,
+                outbound_plaintext: outbound_plaintext_tree,
             }),
             pending_plaintext: RwLock::new(Vec::new()),
             _db: RwLock::new(db),
@@ -177,12 +209,14 @@ impl MessagingState {
     /// Create a MessagingState backed by a production sled database.
     pub fn from_production(db: sled::Db) -> Self {
         let unconfirmed_tree = db.open_tree("unconfirmed").unwrap();
+        let outbound_plaintext_tree = db.open_tree("outbound_plaintext").unwrap();
         Self {
             messaging: RwLock::new(Messaging {
                 to_send: VecDeque::new(),
             }),
             unconfirmed: RwLock::new(UnConfirmedMessages {
                 unconfirmed: unconfirmed_tree,
+                outbound_plaintext: outbound_plaintext_tree,
             }),
             pending_plaintext: RwLock::new(Vec::new()),
             _db: RwLock::new(db),
@@ -200,9 +234,11 @@ impl MessagingState {
     /// production-backed ones. Called from `Messaging::init()`.
     pub fn init_production(&self, db: sled::Db) {
         let unconfirmed_tree = db.open_tree("unconfirmed").unwrap();
+        let outbound_plaintext_tree = db.open_tree("outbound_plaintext").unwrap();
         {
             let mut unconfirmed = self.unconfirmed.write().unwrap();
             unconfirmed.unconfirmed = unconfirmed_tree;
+            unconfirmed.outbound_plaintext = outbound_plaintext_tree;
         }
         {
             let mut db_lock = self._db.write().unwrap();
@@ -305,6 +341,8 @@ impl MessagingState {
                 log::error!("{}", e);
             }
         }
+        // the message is confirmed: drop its retransmit plaintext too
+        let _ = unconfirmed.outbound_plaintext.remove(signature);
     }
 
     pub(crate) fn on_scheduled_message(&self, signature: &[u8]) {
@@ -349,6 +387,43 @@ impl MessagingState {
                 log::error!("pending_plaintext lock poisoned: {}", e);
                 Vec::new()
             }
+        }
+    }
+
+    /// Persist the plaintext of a sent-but-unconfirmed message, keyed by its
+    /// signature, so a retransmit can re-encrypt it across a session rotation
+    /// (see [`OutboundPlaintext`]). Stored in the same tree-group as the
+    /// unconfirmed entry; removed when the message is confirmed or expires.
+    ///
+    /// Callers must NOT already hold the `unconfirmed` lock (this acquires it).
+    pub fn save_outbound_plaintext(&self, signature: &[u8], item: OutboundPlaintext) {
+        let bytes = match bincode::serialize(&item) {
+            Ok(b) => b,
+            Err(e) => {
+                log::error!("failed to serialize outbound plaintext: {}", e);
+                return;
+            }
+        };
+        let unconfirmed = match self.unconfirmed.write() {
+            Ok(u) => u,
+            Err(e) => {
+                log::error!("unconfirmed lock poisoned: {}", e);
+                return;
+            }
+        };
+        if let Err(e) = unconfirmed.outbound_plaintext.insert(signature, bytes) {
+            log::error!("failed to store outbound plaintext: {}", e);
+        } else {
+            let _ = unconfirmed.outbound_plaintext.flush();
+        }
+    }
+
+    /// Load the stored retransmit plaintext for a message signature, if any.
+    pub fn get_outbound_plaintext(&self, signature: &[u8]) -> Option<OutboundPlaintext> {
+        let unconfirmed = self.unconfirmed.read().ok()?;
+        match unconfirmed.outbound_plaintext.get(signature) {
+            Ok(Some(bytes)) => bincode::deserialize(&bytes).ok(),
+            _ => None,
         }
     }
 
@@ -488,6 +563,9 @@ impl Messaging {
             }
         }
 
+        // the message is confirmed: drop its retransmit plaintext too
+        let _ = unconfirmed.outbound_plaintext.remove(signature);
+
         // Release the unconfirmed-table lock before the rotation hook,
         // which takes its own read lock on the same table.
         drop(unconfirmed);
@@ -542,6 +620,17 @@ impl Messaging {
             return Ok(Vec::new());
         }
 
+        // Keep a copy of the plaintext for confirmable messages so a
+        // retransmit can re-encrypt it if the peer session rotates (and the old
+        // one is retired) before the message is confirmed — see
+        // `OutboundPlaintext`. Cloned only for confirmable messages, so
+        // confirmations and one-shot messages don't pay the cost.
+        let retry_plaintext = if message_needs_confirmation {
+            Some(data.clone())
+        } else {
+            None
+        };
+
         // encrypt data
         let encrypted_message: proto::Encrypted;
         let encryption_result = Crypto::encrypt(state, data, user_account.to_owned(), receiver.clone());
@@ -553,15 +642,34 @@ impl Messaging {
             None => return Err("Encryption error occurred".to_string()),
         }
 
-        return Self::pack_and_send_encrypted_data(
+        let result = Self::pack_and_send_encrypted_data(
             state,
             user_account,
             receiver,
             encrypted_message,
-            message_type,
+            message_type.clone(),
             message_id,
             message_needs_confirmation,
         );
+
+        // On success, persist the plaintext keyed by the message signature, so a
+        // retransmit can re-encrypt it under the current session if the original
+        // one rotates away before confirmation. Only this path stores it; crypto
+        // handshake frames call pack_and_send_encrypted_data directly and are
+        // intentionally excluded. Removed when the message is confirmed.
+        if let (Ok(signature), Some(plaintext)) = (&result, retry_plaintext) {
+            state.services.messaging.save_outbound_plaintext(
+                signature,
+                OutboundPlaintext {
+                    user_id: user_account.id.to_bytes(),
+                    receiver_id: receiver.to_bytes(),
+                    data: plaintext,
+                    message_type,
+                    message_id: message_id.to_vec(),
+                },
+            );
+        }
+        result
     }
 
     /// pack, sign and schedule encrypted message data
@@ -988,5 +1096,33 @@ mod tests {
         let remaining = ms.take_pending_plaintext();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].queued_at, 5_000_000);
+    }
+
+    /// A confirmable message's plaintext is persisted (so a retransmit can
+    /// re-encrypt it across a session rotation) and removed once the message
+    /// is confirmed — otherwise the store would grow without bound.
+    #[test]
+    fn outbound_plaintext_stored_and_cleared_on_confirm() {
+        let ms = MessagingState::new();
+        let sig = b"sig-1".to_vec();
+        ms.save_outbound_plaintext(
+            &sig,
+            OutboundPlaintext {
+                user_id: vec![1],
+                receiver_id: vec![2],
+                data: vec![3, 4, 5],
+                message_type: MessagingServiceType::Chat,
+                message_id: vec![6],
+            },
+        );
+        let got = ms.get_outbound_plaintext(&sig).expect("stored");
+        assert_eq!(got.data, vec![3, 4, 5]);
+
+        // confirming the message must drop its retransmit plaintext
+        ms.on_confirmed_message(&sig);
+        assert!(
+            ms.get_outbound_plaintext(&sig).is_none(),
+            "plaintext must be cleared once the message is confirmed"
+        );
     }
 }

--- a/rust/libqaul/src/services/messaging/mod.rs
+++ b/rust/libqaul/src/services/messaging/mod.rs
@@ -620,13 +620,16 @@ impl Messaging {
                 envelope: Some(envelope),
             };
 
-            state.services.messaging.save_unconfirmed_message(
-                MessagingServiceType::DtnStored,
-                &[],
-                target_id,
-                &container,
-                true,
-            );
+            // NOTE: V2 routed messages are deliberately NOT tracked in the
+            // messaging unconfirmed table. Reliable delivery and cleanup are
+            // owned by the V2 custody store (`db_ref_routed_v2`, keyed by the
+            // stable end-to-end `original_signature`): retried by
+            // `process_retransmit_v2` and cleared by `on_dtn_response_v2`.
+            // A messaging unconfirmed entry here would be keyed by this hop's
+            // wrapper-envelope `signature`, which the end-to-end `DtnResponse`
+            // (carrying `original_signature`) can never match — so it would
+            // never be confirmed, never expire (retransmit skips DTN entries),
+            // and leak permanently, one entry per V2 message sent.
 
             state.services.messaging.schedule_message(
                 target_id.clone(),

--- a/rust/libqaul/src/services/messaging/mod.rs
+++ b/rust/libqaul/src/services/messaging/mod.rs
@@ -442,7 +442,7 @@ impl Messaging {
         user_account: &UserAccount,
         receiver: &PeerId,
         data: Vec<u8>,
-        _message_type: MessagingServiceType,
+        message_type: MessagingServiceType,
         message_id: &[u8],
         message_needs_confirmation: bool,
     ) -> Result<Vec<u8>, String> {
@@ -464,6 +464,7 @@ impl Messaging {
             user_account,
             receiver,
             encrypted_message,
+            message_type,
             message_id,
             message_needs_confirmation,
         );
@@ -478,6 +479,7 @@ impl Messaging {
         user_account: &UserAccount,
         receiver: &PeerId,
         encrypted_message: proto::Encrypted,
+        message_type: MessagingServiceType,
         message_id: &[u8],
         message_needs_confirmation: bool,
     ) -> Result<Vec<u8>, String> {
@@ -518,7 +520,7 @@ impl Messaging {
             // in common message case, save into unconfirmed table
             if message_needs_confirmation {
                 state.services.messaging.save_unconfirmed_message(
-                    MessagingServiceType::Chat,
+                    message_type,
                     message_id,
                     receiver,
                     &container,

--- a/rust/libqaul/src/services/messaging/mod.rs
+++ b/rust/libqaul/src/services/messaging/mod.rs
@@ -90,6 +90,33 @@ pub enum MessagingServiceType {
     Rtc,
 }
 
+/// An outbound message whose plaintext is held in memory because it could
+/// not be encrypted yet: the peer session was still completing its KK
+/// handshake (`HalfOutgoing`), so `Crypto::encrypt` refuses to produce a
+/// transport frame. The retransmit tick re-attempts it once the session
+/// reaches `Transport`.
+///
+/// Held in RAM only — deliberately never persisted — so plaintext is not
+/// written at rest; a restart simply drops anything still pending (no worse
+/// than today, where such messages were dropped outright).
+#[derive(Clone)]
+pub struct PendingPlaintext {
+    /// local sending user id (PeerId bytes)
+    pub user_id: Vec<u8>,
+    /// remote receiver id (PeerId bytes)
+    pub receiver_id: Vec<u8>,
+    /// plaintext message bytes to encrypt and send
+    pub data: Vec<u8>,
+    /// service type for the eventual unconfirmed entry
+    pub message_type: MessagingServiceType,
+    /// message id for the eventual unconfirmed entry
+    pub message_id: Vec<u8>,
+    /// whether the message expects a delivery confirmation
+    pub needs_confirmation: bool,
+    /// timestamp (ms) when first queued, used for bounded expiry
+    pub queued_at: u64,
+}
+
 /// Unconfirmed Messages Structure
 pub struct UnConfirmedMessages {
     /// signature => UnConfirmedMessage
@@ -112,6 +139,10 @@ pub struct MessagingState {
     pub messaging: RwLock<Messaging>,
     /// Unconfirmed messages tracking.
     pub unconfirmed: RwLock<UnConfirmedMessages>,
+    /// In-memory queue of outbound plaintext awaiting a usable peer session
+    /// (messages queued while a KK handshake is still in progress). Not
+    /// persisted; see [`PendingPlaintext`].
+    pub pending_plaintext: RwLock<Vec<PendingPlaintext>>,
     /// Sled database backing (kept alive for tree references).
     /// Wrapped in RwLock so `init_production` can swap it after construction.
     _db: RwLock<sled::Db>,
@@ -132,6 +163,7 @@ impl MessagingState {
             unconfirmed: RwLock::new(UnConfirmedMessages {
                 unconfirmed: unconfirmed_tree,
             }),
+            pending_plaintext: RwLock::new(Vec::new()),
             _db: RwLock::new(db),
             #[cfg(emulate)]
             network_emul: RwLock::new(network_emul::NetworkEmulatorStat {
@@ -152,6 +184,7 @@ impl MessagingState {
             unconfirmed: RwLock::new(UnConfirmedMessages {
                 unconfirmed: unconfirmed_tree,
             }),
+            pending_plaintext: RwLock::new(Vec::new()),
             _db: RwLock::new(db),
             #[cfg(emulate)]
             network_emul: RwLock::new(network_emul::NetworkEmulatorStat {
@@ -280,6 +313,43 @@ impl MessagingState {
 
     pub fn on_scheduled_as_dtn_message(&self, signature: &[u8]) {
         self.mark_unconfirmed(signature, |msg| msg.scheduled_dtn = true);
+    }
+
+    /// Queue an outbound message whose peer session is still mid-handshake,
+    /// to be re-attempted by the retransmit tick once the session is ready.
+    pub fn enqueue_pending_plaintext(&self, item: PendingPlaintext) {
+        match self.pending_plaintext.write() {
+            Ok(mut q) => q.push(item),
+            Err(e) => log::error!("pending_plaintext lock poisoned: {}", e),
+        }
+    }
+
+    /// Drop pending items older than `max_age_ms`. Returns the number dropped.
+    /// Bounds the queue so a peer that never completes its handshake cannot
+    /// make it grow without limit.
+    pub fn prune_expired_pending(&self, now: u64, max_age_ms: u64) -> usize {
+        match self.pending_plaintext.write() {
+            Ok(mut q) => {
+                let before = q.len();
+                q.retain(|p| now.saturating_sub(p.queued_at) <= max_age_ms);
+                before - q.len()
+            }
+            Err(e) => {
+                log::error!("pending_plaintext lock poisoned: {}", e);
+                0
+            }
+        }
+    }
+
+    /// Take (drain) all pending plaintext items.
+    pub fn take_pending_plaintext(&self) -> Vec<PendingPlaintext> {
+        match self.pending_plaintext.write() {
+            Ok(mut q) => std::mem::take(&mut *q),
+            Err(e) => {
+                log::error!("pending_plaintext lock poisoned: {}", e);
+                Vec::new()
+            }
+        }
     }
 
     /// Shared helper: load an unconfirmed message, apply a mutation, persist it back.
@@ -447,6 +517,30 @@ impl Messaging {
         message_needs_confirmation: bool,
     ) -> Result<Vec<u8>, String> {
         log::trace!("pack_and_send_message to {}", receiver.to_base58());
+
+        // If the peer session is still completing its KK handshake, encryption
+        // would fail and the message would be dropped. Instead, queue the
+        // plaintext in memory; the retransmit tick re-sends it once the session
+        // reaches Transport. Probing before encrypt avoids cloning `data` on
+        // the common (already-established) path — file chunks can be tens of KB.
+        if Crypto::session_pending_handshake(state, user_account, receiver.clone()) {
+            state.services.messaging.enqueue_pending_plaintext(PendingPlaintext {
+                user_id: user_account.id.to_bytes(),
+                receiver_id: receiver.to_bytes(),
+                data,
+                message_type,
+                message_id: message_id.to_vec(),
+                needs_confirmation: message_needs_confirmation,
+                queued_at: Timestamp::get_timestamp(),
+            });
+            log::debug!(
+                "queued outbound message for {} (peer handshake in progress)",
+                receiver.to_base58()
+            );
+            // Accepted (queued for retry); there is no signature yet. Callers
+            // branch only on Err vs Ok, so an empty signature is harmless.
+            return Ok(Vec::new());
+        }
 
         // encrypt data
         let encrypted_message: proto::Encrypted;
@@ -842,5 +936,57 @@ impl Messaging {
             }
             Err(e) => log::error!("Messaging container decoding error: {}", e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending(queued_at: u64) -> PendingPlaintext {
+        PendingPlaintext {
+            user_id: vec![1],
+            receiver_id: vec![2],
+            data: vec![3, 4, 5],
+            message_type: MessagingServiceType::Chat,
+            message_id: vec![6],
+            needs_confirmation: true,
+            queued_at,
+        }
+    }
+
+    /// A message that cannot be encrypted yet (peer mid-handshake) is held in
+    /// the in-memory queue rather than dropped, and survives until taken.
+    /// Regression: such messages were lost (encrypt returned None and the send
+    /// path returned Err before queuing anything).
+    #[test]
+    fn pending_plaintext_is_queued_and_drained() {
+        let ms = MessagingState::new();
+        ms.enqueue_pending_plaintext(pending(1000));
+        ms.enqueue_pending_plaintext(pending(2000));
+
+        let drained = ms.take_pending_plaintext();
+        assert_eq!(drained.len(), 2);
+        // draining empties the queue
+        assert!(ms.take_pending_plaintext().is_empty());
+    }
+
+    /// The queue is bounded: items stuck longer than the max age are dropped,
+    /// so a peer that never completes its handshake can't grow it without
+    /// limit. Fresher items are retained.
+    #[test]
+    fn pending_plaintext_expires_when_too_old() {
+        let ms = MessagingState::new();
+        ms.enqueue_pending_plaintext(pending(1000)); // old
+        ms.enqueue_pending_plaintext(pending(5_000_000)); // fresh
+
+        // now = 5_001_000, max age = 1h: the 1000-stamped item is ~5_000_000ms
+        // old (> 1h) and dropped; the 5_000_000-stamped item is ~1s old, kept.
+        let dropped = ms.prune_expired_pending(5_001_000, 3_600_000);
+        assert_eq!(dropped, 1);
+
+        let remaining = ms.take_pending_plaintext();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].queued_at, 5_000_000);
     }
 }

--- a/rust/libqaul/src/services/messaging/retransmit.rs
+++ b/rust/libqaul/src/services/messaging/retransmit.rs
@@ -9,6 +9,7 @@ use libp2p::PeerId;
 use prost::Message;
 
 use super::UnConfirmedMessage;
+use crate::node::user_accounts::UserAccounts;
 use crate::services::dtn;
 use crate::utilities::qaul_id::QaulId;
 use crate::utilities::timestamp::Timestamp;
@@ -145,7 +146,97 @@ impl MessagingRetransmit {
             }
         }
 
+        // Release the unconfirmed lock before the re-entrant sends below:
+        // flush_pending_plaintext calls back into the messaging send path,
+        // which itself takes the unconfirmed (and messaging) locks.
+        drop(unconfirmed);
+
+        // Re-send any messages that were queued while a peer session was
+        // still completing its handshake.
+        Self::flush_pending_plaintext(state);
+
         // Process V2 DTN routed messages
         dtn::Dtn::process_retransmit_v2(state);
+    }
+
+    /// Re-attempt sending messages that were queued because their peer
+    /// session was mid-handshake (see [`super::PendingPlaintext`]).
+    ///
+    /// Items whose session is still not ready are kept (preserving their
+    /// original queue time so they can still expire); items older than 1h are
+    /// dropped so the queue stays bounded even if a peer never completes its
+    /// handshake.
+    fn flush_pending_plaintext(state: &crate::QaulState) {
+        // Bound the queue first (drops anything stuck for over an hour).
+        let now = Timestamp::get_timestamp();
+        let dropped = state
+            .services
+            .messaging
+            .prune_expired_pending(now, 3_600_000);
+        if dropped > 0 {
+            log::warn!("retransmit: dropped {} expired pending message(s)", dropped);
+        }
+
+        let items = state.services.messaging.take_pending_plaintext();
+        if items.is_empty() {
+            return;
+        }
+
+        let mut keep = Vec::new();
+        for item in items {
+            let receiver = match PeerId::from_bytes(&item.receiver_id) {
+                Ok(r) => r,
+                Err(e) => {
+                    log::error!("pending flush: invalid receiver id: {}", e);
+                    continue;
+                }
+            };
+            let user_id = match PeerId::from_bytes(&item.user_id) {
+                Ok(u) => u,
+                Err(e) => {
+                    log::error!("pending flush: invalid user id: {}", e);
+                    continue;
+                }
+            };
+            let user_account = match UserAccounts::get_by_id(state, user_id) {
+                Some(ua) => ua,
+                None => {
+                    log::error!("pending flush: sending user account no longer exists");
+                    continue;
+                }
+            };
+
+            // Still mid-handshake? Keep it and try again next tick.
+            if crate::services::crypto::Crypto::session_pending_handshake(
+                state,
+                &user_account,
+                receiver,
+            ) {
+                keep.push(item);
+                continue;
+            }
+
+            // Session is ready (or absent, which starts a fresh handshake):
+            // send for real. On success the message enters the normal
+            // unconfirmed-table flow.
+            if let Err(e) = super::Messaging::pack_and_send_message(
+                state,
+                &user_account,
+                &receiver,
+                item.data,
+                item.message_type,
+                &item.message_id,
+                item.needs_confirmation,
+            ) {
+                log::error!("pending flush send failed: {}", e);
+            }
+        }
+
+        // Re-queue items still waiting on a handshake.
+        if !keep.is_empty() {
+            if let Ok(mut q) = state.services.messaging.pending_plaintext.write() {
+                q.extend(keep);
+            }
+        }
     }
 }

--- a/rust/libqaul/src/services/messaging/retransmit.rs
+++ b/rust/libqaul/src/services/messaging/retransmit.rs
@@ -47,6 +47,11 @@ impl MessagingRetransmit {
         let rs = state.get_router();
         let online_users = rs.routing_table.get_online_users();
 
+        // Messages whose peer session rotated away from the one their stored
+        // ciphertext used: collected here and re-encrypted after the unconfirmed
+        // lock is released (re-encryption re-enters the messaging send path).
+        let mut to_reencrypt: Vec<super::OutboundPlaintext> = Vec::new();
+
         let mut updated = false;
         let cur_time = Timestamp::get_timestamp();
         for entry in unconfirmed.unconfirmed.iter() {
@@ -79,6 +84,7 @@ impl MessagingRetransmit {
                     if let Err(_e) = unconfirmed.unconfirmed.remove(&signature) {
                         log::error!("removing expired unconfirmed message error!");
                     }
+                    let _ = unconfirmed.outbound_plaintext.remove(&signature);
                     updated = true;
                     continue;
                 }
@@ -105,6 +111,40 @@ impl MessagingRetransmit {
                                 }
                             };
 
+                            // If this message's session has rotated away from the
+                            // one its stored ciphertext used (the receiver may
+                            // have retired that session), re-encrypt the kept
+                            // plaintext under the live session instead of
+                            // replaying ciphertext the peer can no longer decrypt.
+                            // The actual resend is deferred until the unconfirmed
+                            // lock is released, below.
+                            if let Ok(Some(pt_bytes)) =
+                                unconfirmed.outbound_plaintext.get(&signature)
+                            {
+                                if let Ok(pt) =
+                                    bincode::deserialize::<super::OutboundPlaintext>(&pt_bytes)
+                                {
+                                    let cur = PeerId::from_bytes(&pt.user_id).ok().and_then(|u| {
+                                        crate::services::crypto::Crypto::current_primary_session_id(
+                                            state, u, receiver,
+                                        )
+                                    });
+                                    let sent =
+                                        crate::services::crypto::Crypto::container_session_id(
+                                            &unconfirmed_message.container,
+                                        );
+                                    if let (Some(c), Some(s)) = (cur, sent) {
+                                        if c != s {
+                                            let _ = unconfirmed.unconfirmed.remove(&signature);
+                                            let _ = unconfirmed.outbound_plaintext.remove(&signature);
+                                            updated = true;
+                                            to_reencrypt.push(pt);
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+
                             log::trace!(
                                 "retrans message, signature: {}",
                                 bs58::encode(&container.signature).into_string()
@@ -129,6 +169,7 @@ impl MessagingRetransmit {
                                 if let Err(_e) = unconfirmed.unconfirmed.remove(&signature) {
                                     log::error!("removing expired unconfirmed message error!");
                                 }
+                                let _ = unconfirmed.outbound_plaintext.remove(&signature);
                                 updated = true;
                             } else {
                                 unconfirmed_message.retry = new_retry;
@@ -153,6 +194,51 @@ impl MessagingRetransmit {
         if updated {
             if let Err(_e) = unconfirmed.unconfirmed.flush() {
                 log::error!("updating unconfirmed table error!");
+            }
+            let _ = unconfirmed.outbound_plaintext.flush();
+        }
+
+        // Release the unconfirmed lock before re-encrypting: pack_and_send_message
+        // re-acquires it. Re-send each rotated-away message under the peer's
+        // current session (this creates a fresh unconfirmed entry + plaintext
+        // under the new signature; the stale ones were already removed above).
+        drop(unconfirmed);
+        for pt in to_reencrypt {
+            let receiver = match PeerId::from_bytes(&pt.receiver_id) {
+                Ok(r) => r,
+                Err(e) => {
+                    log::error!("re-encrypt: invalid receiver id: {}", e);
+                    continue;
+                }
+            };
+            let user_id = match PeerId::from_bytes(&pt.user_id) {
+                Ok(u) => u,
+                Err(e) => {
+                    log::error!("re-encrypt: invalid user id: {}", e);
+                    continue;
+                }
+            };
+            let user_account = match UserAccounts::get_by_id(state, user_id) {
+                Some(ua) => ua,
+                None => {
+                    log::error!("re-encrypt: sending user account no longer exists");
+                    continue;
+                }
+            };
+            log::debug!(
+                "retransmit: re-encrypting message for {} under current session",
+                receiver.to_base58()
+            );
+            if let Err(e) = super::Messaging::pack_and_send_message(
+                state,
+                &user_account,
+                &receiver,
+                pt.data,
+                pt.message_type,
+                &pt.message_id,
+                true,
+            ) {
+                log::error!("retransmit re-encrypt resend failed: {}", e);
             }
         }
     }

--- a/rust/libqaul/src/services/messaging/retransmit.rs
+++ b/rust/libqaul/src/services/messaging/retransmit.rs
@@ -20,6 +20,16 @@ pub struct MessagingRetransmit {}
 impl MessagingRetransmit {
     /// process retransmission
     pub fn process(state: &crate::QaulState) {
+        // These run on every tick regardless of the unconfirmed table, because
+        // they use separate stores and the unconfirmed-table early-return below
+        // must not skip them:
+        //  - messages queued while a peer session was completing its handshake
+        //    (pending_plaintext); after the handshake completes the unconfirmed
+        //    table may well be empty, so this must not be gated on it.
+        //  - V2 routed DTN messages, tracked in the DTN custody store.
+        Self::flush_pending_plaintext(state);
+        dtn::Dtn::process_retransmit_v2(state);
+
         // get unconfirmed table
         let unconfirmed = match state.services.messaging.unconfirmed.write() {
             Ok(u) => u,
@@ -145,18 +155,6 @@ impl MessagingRetransmit {
                 log::error!("updating unconfirmed table error!");
             }
         }
-
-        // Release the unconfirmed lock before the re-entrant sends below:
-        // flush_pending_plaintext calls back into the messaging send path,
-        // which itself takes the unconfirmed (and messaging) locks.
-        drop(unconfirmed);
-
-        // Re-send any messages that were queued while a peer session was
-        // still completing its handshake.
-        Self::flush_pending_plaintext(state);
-
-        // Process V2 DTN routed messages
-        dtn::Dtn::process_retransmit_v2(state);
     }
 
     /// Re-attempt sending messages that were queued because their peer

--- a/rust/qaul-sim/src/integration.rs
+++ b/rust/qaul-sim/src/integration.rs
@@ -36,6 +36,7 @@ mod tests {
             debug: DebugOption::default(),
             routing: RoutingOptions::default(),
             handshake_extras: HandshakeExtras::default(),
+            crypto_rotation: CryptoRotation::default(),
         }
     }
 


### PR DESCRIPTION
- DTN V1 quota inverted — delivering a message added its size to used_size instead of subtracting, so storage grew until the node rejected everything as over-quota.
  - DTN V1 non-atomic index writes — the two dedup index trees were updated separately; a crash between them desynced/corrupted them. Now one sled transaction.
  - File confirmations never recorded — three stacked defects: the send path dropped message_type (file confirms mis-routed as chat), the ChatFile confirm arm decoded the wrong id, and
  reception_tracking was never populated. File state now advances Sending → Confirmed → ConfirmedByAll.
  - DTN V2 unconfirmed leak — each routed send left a retry entry keyed by the per-hop wrapper signature, which the end-to-end response (keyed by original_signature) could never clear or expire
  — one permanent leak per message. Removed; V2 retry/cleanup is owned by the custody store.
  - Messages dropped during a peer handshake — while a KK session was still completing (HalfOutgoing), outbound messages were dropped instead of retried. Now queued in memory and re-sent once
  the session is ready.
  - Retransmit skipped flush/V2 when the unconfirmed table was empty — an early-return bypassed the handshake-queue flush and V2 retransmit. (Caught by qauld-ctl: 1/3 → 3/3 messages delivered.)
  - Retransmit replayed stale ciphertext across session rotation — a message unconfirmed across a rotation became undeliverable once the receiver retired the old session. Now re-encrypts the
  message under the live session from a persisted sender-side plaintext store (survives restart; removed on confirm/expiry).

  Also repairs a pre-existing broken cargo test build on main so the regression tests can run.