### PR TITLE
Improve chat bubble layout and text scaling

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
@@ -485,7 +485,7 @@ class _ComposerPill extends StatelessWidget {
     final text = controller.text;
     if (text.contains('\n') || text.contains('\r')) return true;
 
-    final inlineActionsWidth =
+    const inlineActionsWidth =
         _kPlusCircleSize +
         _kTextActionSpacing +
         _kActionButtonMinSize +

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/group_chat_messages.dart
@@ -59,10 +59,7 @@ class ChatMessageRenderer {
     if (display == null) return const SizedBox.shrink();
 
     if (mode == ChatRenderMode.group && !presentation.isPrimary) {
-      return GroupTextMessageItem(
-        presentation: presentation,
-        clock: clock,
-      );
+      return GroupTextMessageItem(presentation: presentation, clock: clock);
     }
 
     return DirectTextMessageItem(
@@ -140,8 +137,9 @@ class GroupTextMessageItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final display = presentation.bubbleDisplay!;
     final sender = presentation.sender;
-    final senderNameColor =
-        sender == null ? null : colorGenerationStrategy(sender.idBase58);
+    final senderNameColor = sender == null
+        ? null
+        : colorGenerationStrategy(sender.idBase58);
     final bubbleMessage = presentation.meta.showSenderName && sender != null
         ? display.message.copyWith(
             senderDisplayName: sender.name,
@@ -181,8 +179,10 @@ class GroupMessageShell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final senderNameColor =
-        sender == null ? null : colorGenerationStrategy(sender!.idBase58);
+    final textScaler = chatBubbleTextScaler(context);
+    final senderNameColor = sender == null
+        ? null
+        : colorGenerationStrategy(sender!.idBase58);
     return Padding(
       padding: EdgeInsetsDirectional.only(top: marginTop),
       child: Row(
@@ -211,6 +211,7 @@ class GroupMessageShell extends StatelessWidget {
                       style: kGroupSenderNameTextStyle.copyWith(
                         color: senderNameColor,
                       ),
+                      textScaler: textScaler,
                     ),
                   ),
                 child,
@@ -231,6 +232,7 @@ class GroupSenderAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final background = colorGenerationStrategy(sender.idBase58);
+    final textScaler = chatBubbleTextScaler(context);
 
     return SizedBox(
       width: 28,
@@ -251,6 +253,7 @@ class GroupSenderAvatar extends StatelessWidget {
                 height: 1.2,
                 letterSpacing: 0,
               ),
+              textScaler: textScaler,
             ),
           ),
           if (sender.isConnected)

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
@@ -22,6 +22,13 @@ enum ChatRenderMode { direct, group }
 // ---------------------------------------------------------------------------
 
 const double kChatBubbleWidthBreakpoint = 500.0;
+const double kChatBubbleMaxTextScaleFactor = 1.3;
+
+TextScaler chatBubbleTextScaler(BuildContext context) {
+  return MediaQuery.textScalerOf(
+    context,
+  ).clamp(maxScaleFactor: kChatBubbleMaxTextScaleFactor);
+}
 
 class ChatBubbleStyle {
   static const maxBubbleWidthMobile = 272.0;
@@ -192,7 +199,7 @@ class QaulChatBubble extends StatelessWidget {
 
   final bool showTimestamp;
 
-  Widget? _buildStatusIcon(Color textColor) {
+  Widget? _buildStatusIcon(Color textColor, double iconSize) {
     switch (message.status) {
       case MessageStatus.notSent:
         return null;
@@ -200,14 +207,14 @@ class QaulChatBubble extends StatelessWidget {
       case MessageStatus.sent:
         return Icon(
           Icons.check,
-          size: 14,
+          size: iconSize,
           color: textColor.withValues(alpha: 0.8),
         );
 
       case MessageStatus.read:
         return Icon(
           Icons.done_all,
-          size: 14,
+          size: iconSize,
           color: textColor.withValues(alpha: 0.9),
         );
     }
@@ -248,7 +255,9 @@ class QaulChatBubble extends StatelessWidget {
     );
 
     final timeLabel = formatQaulChatBubbleTime(message, clock);
-    final statusIcon = _buildStatusIcon(textColor);
+    final textScaler = chatBubbleTextScaler(context);
+    final statusIconSize = textScaler.scale(14);
+    final statusIcon = _buildStatusIcon(textColor, statusIconSize);
 
     return Align(
       alignment: isPrimary ? Alignment.centerRight : Alignment.centerLeft,
@@ -283,13 +292,14 @@ class QaulChatBubble extends StatelessWidget {
                       style: ChatBubbleStyle.timeStyle,
                     ),
                     textDirection: TextDirection.ltr,
+                    textScaler: textScaler,
                   );
                   timeLabelPainter.layout();
                   var timeBlockWidth =
                       timeLabelPainter.width +
                       ChatBubbleStyle.gapBetweenTimeAndStatusIcon;
                   if (isPrimary && statusIcon != null) {
-                    timeBlockWidth += 14.0;
+                    timeBlockWidth += statusIconSize;
                   }
                   final maxMessageWidth =
                       (constraints.maxWidth - gap - timeBlockWidth).clamp(
@@ -300,10 +310,11 @@ class QaulChatBubble extends StatelessWidget {
                   final painter = TextPainter(
                     text: messageSpan,
                     textDirection: TextDirection.ltr,
+                    textScaler: textScaler,
                   );
                   painter.layout(maxWidth: maxMessageWidth);
                   final lineHeight =
-                      ChatBubbleStyle.textStyle.fontSize! *
+                      textScaler.scale(ChatBubbleStyle.textStyle.fontSize!) *
                       (ChatBubbleStyle.textStyle.height ?? 1.2);
                   final fitsOnOneLine = painter.height <= lineHeight * 1.1;
 
@@ -311,7 +322,11 @@ class QaulChatBubble extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      Text(timeLabel, style: ChatBubbleStyle.timeStyle),
+                      Text(
+                        timeLabel,
+                        style: ChatBubbleStyle.timeStyle,
+                        textScaler: textScaler,
+                      ),
                       const SizedBox(
                         width: ChatBubbleStyle.gapBetweenTimeAndStatusIcon,
                       ),
@@ -324,6 +339,7 @@ class QaulChatBubble extends StatelessWidget {
                     messageContent = RichText(
                       textAlign: TextAlign.left,
                       textWidthBasis: TextWidthBasis.longestLine,
+                      textScaler: textScaler,
                       text: messageSpan,
                     );
                   } else if (fitsOnOneLine) {
@@ -335,6 +351,7 @@ class QaulChatBubble extends StatelessWidget {
                           child: RichText(
                             textAlign: TextAlign.left,
                             textWidthBasis: TextWidthBasis.longestLine,
+                            textScaler: textScaler,
                             text: messageSpan,
                           ),
                         ),
@@ -352,6 +369,7 @@ class QaulChatBubble extends StatelessWidget {
                         RichText(
                           textAlign: TextAlign.left,
                           textWidthBasis: TextWidthBasis.longestLine,
+                          textScaler: textScaler,
                           text: messageSpan,
                         ),
                         Padding(
@@ -376,9 +394,11 @@ class QaulChatBubble extends StatelessWidget {
                         child: Text(
                           message.senderDisplayName!,
                           style: kGroupSenderNameTextStyle.copyWith(
-                            color: message.senderDisplayNameColor ??
+                            color:
+                                message.senderDisplayNameColor ??
                                 Colors.white.withValues(alpha: 0.85),
                           ),
+                          textScaler: textScaler,
                         ),
                       ),
                       messageContent,
@@ -428,7 +448,10 @@ class QaulChatBubbleDisplayItem {
 // Public helpers
 // ---------------------------------------------------------------------------
 
-bool directChatBubblesShareMinute(QaulChatBubbleMessage a, QaulChatBubbleMessage b) {
+bool directChatBubblesShareMinute(
+  QaulChatBubbleMessage a,
+  QaulChatBubbleMessage b,
+) {
   if (a.messageType != b.messageType) return false;
 
   if (a.senderIdBase58 != null &&
@@ -467,7 +490,10 @@ List<TailEdge> tailEdgesForPrimary(bool hasPreviousLinked, bool hasNextLinked) {
   return const [TailEdge.topEnd];
 }
 
-List<TailEdge> tailEdgesForSecondary(bool hasPreviousLinked, bool hasNextLinked) {
+List<TailEdge> tailEdgesForSecondary(
+  bool hasPreviousLinked,
+  bool hasNextLinked,
+) {
   if (!hasPreviousLinked && !hasNextLinked) {
     return const [TailEdge.bottomStart];
   }

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -53,8 +53,10 @@ void main() {
       expect(items, hasLength(3));
 
       expect(items[0].message.edges, const [TailEdge.bottomEnd]);
-      expect(items[1].message.edges,
-          const [TailEdge.topEnd, TailEdge.bottomEnd]);
+      expect(items[1].message.edges, const [
+        TailEdge.topEnd,
+        TailEdge.bottomEnd,
+      ]);
       expect(items[2].message.edges, const [TailEdge.topEnd]);
 
       expect(items[0].showTimestamp, isFalse);
@@ -116,56 +118,58 @@ void main() {
     });
 
     test(
-        'group layout: edges/timestamps match direct; 4px vertical only for same '
-            'participant streak, 12px when switching me vs others', () {
-      final base = DateTime(2026, 4, 19, 19, 23);
+      'group layout: edges/timestamps match direct; 4px vertical only for same '
+      'participant streak, 12px when switching me vs others',
+      () {
+        final base = DateTime(2026, 4, 19, 19, 23);
 
-      final messages = [
-        QaulChatBubbleMessage(
-          content: 'primary',
-          sentAt: base,
-          receivedAt: base,
-          status: MessageStatus.sent,
-          messageType: MessageType.primary,
-          edges: const [],
-        ),
-        QaulChatBubbleMessage(
-          content: 'primary later',
-          sentAt: base.add(const Duration(minutes: 1)),
-          receivedAt: base.add(const Duration(minutes: 1)),
-          status: MessageStatus.sent,
-          messageType: MessageType.primary,
-          edges: const [],
-        ),
-        QaulChatBubbleMessage(
-          content: 'secondary same minute as second',
-          sentAt: base.add(const Duration(minutes: 1)),
-          receivedAt: base.add(const Duration(minutes: 1)),
-          status: MessageStatus.sent,
-          messageType: MessageType.secondary,
-          edges: const [],
-        ),
-      ];
+        final messages = [
+          QaulChatBubbleMessage(
+            content: 'primary',
+            sentAt: base,
+            receivedAt: base,
+            status: MessageStatus.sent,
+            messageType: MessageType.primary,
+            edges: const [],
+          ),
+          QaulChatBubbleMessage(
+            content: 'primary later',
+            sentAt: base.add(const Duration(minutes: 1)),
+            receivedAt: base.add(const Duration(minutes: 1)),
+            status: MessageStatus.sent,
+            messageType: MessageType.primary,
+            edges: const [],
+          ),
+          QaulChatBubbleMessage(
+            content: 'secondary same minute as second',
+            sentAt: base.add(const Duration(minutes: 1)),
+            receivedAt: base.add(const Duration(minutes: 1)),
+            status: MessageStatus.sent,
+            messageType: MessageType.secondary,
+            edges: const [],
+          ),
+        ];
 
-      final directItems = computeChatBubbleDisplayItems(
-        messages,
-        layoutMode: ChatRenderMode.direct,
-      );
-      final groupItems = computeChatBubbleDisplayItems(
-        messages,
-        layoutMode: ChatRenderMode.group,
-      );
+        final directItems = computeChatBubbleDisplayItems(
+          messages,
+          layoutMode: ChatRenderMode.direct,
+        );
+        final groupItems = computeChatBubbleDisplayItems(
+          messages,
+          layoutMode: ChatRenderMode.group,
+        );
 
-      for (var i = 0; i < 3; i++) {
-        expect(groupItems[i].message.edges, directItems[i].message.edges);
-        expect(groupItems[i].showTimestamp, directItems[i].showTimestamp);
-      }
+        for (var i = 0; i < 3; i++) {
+          expect(groupItems[i].message.edges, directItems[i].message.edges);
+          expect(groupItems[i].showTimestamp, directItems[i].showTimestamp);
+        }
 
-      expect(directItems[1].marginTop, kChatBubbleSeparatedGap);
-      expect(directItems[2].marginTop, kChatBubbleSeparatedGap);
-      expect(groupItems[1].marginTop, kChatBubbleLinkedGap);
-      expect(groupItems[2].marginTop, kChatBubbleSeparatedGap);
-    });
+        expect(directItems[1].marginTop, kChatBubbleSeparatedGap);
+        expect(directItems[2].marginTop, kChatBubbleSeparatedGap);
+        expect(groupItems[1].marginTop, kChatBubbleLinkedGap);
+        expect(groupItems[2].marginTop, kChatBubbleSeparatedGap);
+      },
+    );
   });
 
   group('formatQaulChatBubbleTime', () {
@@ -185,8 +189,9 @@ void main() {
   });
 
   group('QaulChatBubble timestamp formatting', () {
-    testWidgets('shows minutes when sent less than an hour before clock',
-        (tester) async {
+    testWidgets('shows minutes when sent less than an hour before clock', (
+      tester,
+    ) async {
       final clock = DateTime(2026, 6, 1, 12, 0);
       final fiveMinutesAgo = clock.subtract(const Duration(minutes: 5));
 
@@ -214,106 +219,113 @@ void main() {
       expect(find.text('5 min'), findsOneWidget);
     });
 
-    testWidgets('shows absolute time when sent more than an hour before clock',
-        (tester) async {
-      final clock = DateTime(2026, 6, 1, 12, 0);
-      final ninetyMinutesAgo = clock.subtract(const Duration(minutes: 90));
+    testWidgets(
+      'shows absolute time when sent more than an hour before clock',
+      (tester) async {
+        final clock = DateTime(2026, 6, 1, 12, 0);
+        final ninetyMinutesAgo = clock.subtract(const Duration(minutes: 90));
 
-      final message = QaulChatBubbleMessage(
-        content: 'older message',
-        sentAt: ninetyMinutesAgo,
-        receivedAt: ninetyMinutesAgo,
-        status: MessageStatus.sent,
-        messageType: MessageType.primary,
-        edges: const [],
-      );
+        final message = QaulChatBubbleMessage(
+          content: 'older message',
+          sentAt: ninetyMinutesAgo,
+          receivedAt: ninetyMinutesAgo,
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: QaulChatBubble(
-              message: message,
-              clock: clock,
-              showTimestamp: true,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: QaulChatBubble(
+                message: message,
+                clock: clock,
+                showTimestamp: true,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      final timestampText =
-          tester.widget<Text>(_findTimestampText(tester).first);
-      final label = timestampText.data ?? '';
-      expect(label.contains('min'), isFalse);
-      expect(label.contains(':'), isTrue);
-    });
+        final timestampText = tester.widget<Text>(
+          _findTimestampText(tester).first,
+        );
+        final label = timestampText.data ?? '';
+        expect(label.contains('min'), isFalse);
+        expect(label.contains(':'), isTrue);
+      },
+    );
 
     testWidgets(
-        'sender (primary) read message shows sent time + days when received later',
-        (tester) async {
-      final clock = DateTime(2026, 4, 21, 16, 0);
-      final sentAt = DateTime(2026, 4, 19, 14, 50);
-      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+      'sender (primary) read message shows sent time + days when received later',
+      (tester) async {
+        final clock = DateTime(2026, 4, 21, 16, 0);
+        final sentAt = DateTime(2026, 4, 19, 14, 50);
+        final receivedAt = DateTime(2026, 4, 20, 15, 50);
 
-      final message = QaulChatBubbleMessage(
-        content: 'hello',
-        sentAt: sentAt,
-        receivedAt: receivedAt,
-        status: MessageStatus.read,
-        messageType: MessageType.primary,
-        edges: const [],
-      );
+        final message = QaulChatBubbleMessage(
+          content: 'hello',
+          sentAt: sentAt,
+          receivedAt: receivedAt,
+          status: MessageStatus.read,
+          messageType: MessageType.primary,
+          edges: const [],
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: QaulChatBubble(
-              message: message,
-              clock: clock,
-              showTimestamp: true,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: QaulChatBubble(
+                message: message,
+                clock: clock,
+                showTimestamp: true,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      final timestampText =
-          tester.widget<Text>(_findTimestampText(tester).first);
-      final label = timestampText.data ?? '';
-      expect(label.contains('+ 1 day'), isTrue);
-    });
+        final timestampText = tester.widget<Text>(
+          _findTimestampText(tester).first,
+        );
+        final label = timestampText.data ?? '';
+        expect(label.contains('+ 1 day'), isTrue);
+      },
+    );
 
     testWidgets(
-        'receiver (secondary) read message shows received time + days ago',
-        (tester) async {
-      final clock = DateTime(2026, 4, 21, 16, 0);
-      final sentAt = DateTime(2026, 4, 19, 14, 50);
-      final receivedAt = DateTime(2026, 4, 20, 15, 50);
+      'receiver (secondary) read message shows received time + days ago',
+      (tester) async {
+        final clock = DateTime(2026, 4, 21, 16, 0);
+        final sentAt = DateTime(2026, 4, 19, 14, 50);
+        final receivedAt = DateTime(2026, 4, 20, 15, 50);
 
-      final message = QaulChatBubbleMessage(
-        content: 'hello',
-        sentAt: sentAt,
-        receivedAt: receivedAt,
-        status: MessageStatus.read,
-        messageType: MessageType.secondary,
-        edges: const [],
-      );
+        final message = QaulChatBubbleMessage(
+          content: 'hello',
+          sentAt: sentAt,
+          receivedAt: receivedAt,
+          status: MessageStatus.read,
+          messageType: MessageType.secondary,
+          edges: const [],
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: QaulChatBubble(
-              message: message,
-              clock: clock,
-              showTimestamp: true,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: QaulChatBubble(
+                message: message,
+                clock: clock,
+                showTimestamp: true,
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      final timestampText =
-          tester.widget<Text>(_findTimestampText(tester).first);
-      final label = timestampText.data ?? '';
-      expect(label.contains('1 day ago'), isTrue);
-    });
+        final timestampText = tester.widget<Text>(
+          _findTimestampText(tester).first,
+        );
+        final label = timestampText.data ?? '';
+        expect(label.contains('1 day ago'), isTrue);
+      },
+    );
 
     testWidgets('read message same day has no days suffix', (tester) async {
       final clock = DateTime(2026, 4, 19, 18, 0);
@@ -341,8 +353,9 @@ void main() {
         ),
       );
 
-      final timestampText =
-          tester.widget<Text>(_findTimestampText(tester).first);
+      final timestampText = tester.widget<Text>(
+        _findTimestampText(tester).first,
+      );
       final label = timestampText.data ?? '';
       expect(label.contains('+ '), isFalse);
       expect(label.contains(' ago'), isFalse);
@@ -374,8 +387,9 @@ void main() {
         ),
       );
 
-      final timestampText =
-          tester.widget<Text>(_findTimestampText(tester).first);
+      final timestampText = tester.widget<Text>(
+        _findTimestampText(tester).first,
+      );
       final label = timestampText.data ?? '';
       expect(label.contains('+ 1 day'), isFalse);
       expect(label.contains(' ago'), isFalse);
@@ -409,6 +423,51 @@ void main() {
       final rich = tester.widget<RichText>(find.byType(RichText).first);
       final text = rich.text.toPlainText();
       expect(text, 'line one\nline two');
+    });
+
+    testWidgets('scales message and timestamp text with chat bubble cap', (
+      tester,
+    ) async {
+      final clock = DateTime(2026, 1, 1, 12, 0);
+      final message = QaulChatBubbleMessage(
+        content: 'scaled message',
+        sentAt: clock,
+        receivedAt: clock,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: Material(
+              child: QaulChatBubble(
+                message: message,
+                clock: clock,
+                showTimestamp: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText).first);
+      final timestampText = tester.widget<Text>(find.text('Now'));
+
+      expect(
+        rich.textScaler.scale(ChatBubbleStyle.textStyle.fontSize!),
+        moreOrLessEquals(
+          ChatBubbleStyle.textStyle.fontSize! * kChatBubbleMaxTextScaleFactor,
+        ),
+      );
+      expect(
+        timestampText.textScaler!.scale(ChatBubbleStyle.timeStyle.fontSize!),
+        moreOrLessEquals(
+          ChatBubbleStyle.timeStyle.fontSize! * kChatBubbleMaxTextScaleFactor,
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
## Description
I tested the current main branch and could not reproduce the reported issue.

On my Android test device, chat message text and timestamps looked correct, and Android font/accessibility scaling was also being applied as expected in the app. I did not find evidence that the reported behavior is currently broken on main.

That said, I added a small safeguard in the chat bubble component: message text, timestamps, sender labels, and the bubble layout measurements now use the same capped text scaler. This should prevent future regressions where one text element scales and another does not, while still keeping the layout within the designer’s intended bounds.

## Evidence

Android Emulator (main):
<img width="250" alt="Screenshot 2026-07-07 at 14 34 09" src="https://github.com/user-attachments/assets/3b58c1e2-9fad-46b5-9479-0bee01f36867" />
<img width="250" alt="Screenshot_20260707_142025" src="https://github.com/user-attachments/assets/b803fb0e-0db1-4d1d-80d3-68cf1c104cd0" />

Android Emulator (fix branch):
<img width="250" alt="Screenshot_20260707_143903" src="https://github.com/user-attachments/assets/f248ec7b-84bb-4b2e-9552-ba092b26a1cc" />
<img width="250" alt="Screenshot_20260707_143809" src="https://github.com/user-attachments/assets/15325eed-f81f-4b01-8239-aca7ffe8c28c" />

Android Device (Redmi 9i)
<img width="250" alt="1783449143540" src="https://github.com/user-attachments/assets/d625b450-4ebe-4ade-b3b1-ca453528de75" />

<img width="250" alt="1783449143453" src="https://github.com/user-attachments/assets/25ac9999-938c-40ff-beec-059682cca33e" />

Scalled Text
<img width="250" alt="Screenshot_2026-07-07-15-47-40-732_net qaul qaul_app" src="https://github.com/user-attachments/assets/5b92a0e5-bad4-4b88-a983-d298edac6763" />
