### PR TITLE
Adjust group chat refresh state

### DIFF
--- a/qaul_ui/lib/stores/group_store.dart
+++ b/qaul_ui/lib/stores/group_store.dart
@@ -24,6 +24,13 @@ class ChatRoomsStore extends Notifier<void> {
     final result = await worker.getAllChatRooms(offset: offset, limit: limit);
     if (!ref.mounted || result == null) return null;
     _chatRoomsPagination = result.pagination;
+    final state = ref.read(chatRoomsProvider.notifier);
+    final pagination = result.pagination;
+    if (pagination != null && pagination.offset > 0) {
+      state.append(result.rooms);
+    } else {
+      state.mergeOrderedFromBackend(result.rooms);
+    }
     await _resolveMissingUsersForRooms(result.rooms);
     if (!ref.mounted) return null;
     return PaginatedChatRooms(
@@ -43,6 +50,24 @@ class ChatRoomsStore extends Notifier<void> {
     );
     if (!ref.mounted || result == null) return null;
     _groupInvitesPagination = result.pagination;
+    final inviteState = ref.read(groupInvitesProvider.notifier);
+    final pagination = result.pagination;
+    if (pagination != null && pagination.offset > 0) {
+      inviteState.append(result.invites);
+    } else {
+      for (final invite in result.invites) {
+        if (!inviteState.contains(invite)) {
+          inviteState.add(invite);
+        } else {
+          inviteState.update(invite);
+        }
+      }
+      final isCompleteList =
+          pagination == null || (pagination.offset == 0 && !pagination.hasMore);
+      if (isCompleteList) {
+        inviteState.retainAll(result.invites);
+      }
+    }
     final rooms = result.invites.map((i) => i.groupDetails).toList();
     await _resolveMissingUsersForRooms(rooms);
     if (!ref.mounted) return null;

--- a/qaul_ui/packages/qaul_rpc/lib/src/internal/chat_conversation_state.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/internal/chat_conversation_state.dart
@@ -1,0 +1,38 @@
+import 'package:collection/collection.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../generated/services/chat/chat.pb.dart';
+import '../models/models.dart';
+
+const _byteListEquality = ListEquality<int>();
+
+void applyChatConversationList(
+  Ref ref,
+  ChatConversationList conversation,
+) {
+  final state = ref.read(chatRoomsProvider.notifier);
+  final room = ref.read(chatRoomsProvider).firstWhereOrNull(
+        (r) => _byteListEquality.equals(
+          r.conversationId,
+          conversation.groupId,
+        ),
+      );
+  final currentOpenRoom = ref.read(currentOpenChatRoom.notifier);
+
+  final openRoom = currentOpenRoom.state;
+  final isOpenRoom = openRoom != null &&
+      _byteListEquality.equals(openRoom.conversationId, conversation.groupId);
+
+  final source = room ?? (isOpenRoom ? openRoom : null);
+  if (source == null) return;
+
+  final merged = source.copyWithMessages(conversation);
+
+  if (room != null) {
+    state.replacePreservingOrder(merged);
+  }
+
+  if (isOpenRoom) {
+    currentOpenRoom.state = merged;
+  }
+}

--- a/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/libqaul_worker.dart
@@ -26,6 +26,7 @@ import 'generated/services/chat/chatfile_rpc.pb.dart';
 import 'generated/services/dtn/dtn_rpc.pb.dart';
 import 'generated/services/feed/feed.pb.dart';
 import 'generated/services/group/group_rpc.pb.dart';
+import 'internal/chat_conversation_state.dart';
 import 'internal/file_history.dart';
 import 'libqaul/libqaul.dart';
 import 'rpc_translators/abstract_rpc_module_translator.dart';
@@ -469,6 +470,7 @@ class LibqaulWorker {
         return null;
       },
     );
+    if (result != null) applyChatConversationList(_ref, result);
     return result;
   }
 

--- a/qaul_ui/test/chat_conversation_state_test.dart
+++ b/qaul_ui/test/chat_conversation_state_test.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_rpc/src/generated/services/chat/chat.pb.dart';
+import 'package:qaul_rpc/src/internal/chat_conversation_state.dart';
+
+final _conversationApplierProvider =
+    NotifierProvider<_ConversationApplier, void>(_ConversationApplier.new);
+
+class _ConversationApplier extends Notifier<void> {
+  @override
+  void build() {}
+
+  void apply(ChatConversationList conversation) {
+    applyChatConversationList(ref, conversation);
+  }
+}
+
+void main() {
+  final conversationId = Uint8List.fromList('group-1'.codeUnits);
+
+  ChatRoom room(String name) =>
+      ChatRoom(conversationId: conversationId, name: name, isDirectChat: false);
+
+  ChatConversationList conversation(int index) => ChatConversationList(
+    groupId: conversationId,
+    messageList: [
+      ChatMessage(
+        index: Int64(index),
+        senderId: Uint8List.fromList('sender'.codeUnits),
+        messageId: Uint8List.fromList('message-$index'.codeUnits),
+      ),
+    ],
+  );
+
+  test('applies fetched messages to chatRoomsProvider and open room', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final storedRoom = room('Stored group');
+    final openRoom = room('Open group');
+    container.read(chatRoomsProvider.notifier).add(storedRoom);
+    container.read(currentOpenChatRoom.notifier).state = openRoom;
+
+    container
+        .read(_conversationApplierProvider.notifier)
+        .apply(conversation(7));
+
+    final updatedStoredRoom = container.read(chatRoomsProvider).single;
+    final updatedOpenRoom = container.read(currentOpenChatRoom)!;
+
+    expect(updatedStoredRoom.idBase58, storedRoom.idBase58);
+    expect(updatedStoredRoom.messages, hasLength(1));
+    expect(updatedStoredRoom.lastMessageIndex, 7);
+    expect(updatedOpenRoom.idBase58, openRoom.idBase58);
+    expect(updatedOpenRoom.messages, hasLength(1));
+    expect(updatedOpenRoom.lastMessageIndex, 7);
+  });
+}

--- a/qaul_ui/test/group_store_test.dart
+++ b/qaul_ui/test/group_store_test.dart
@@ -1,0 +1,93 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/stores/stores.dart';
+
+import 'chat_tab/chat_tab_test.dart';
+
+class _GroupStoreWorker extends StubLibqaulWorker {
+  _GroupStoreWorker(super.ref, {required this.rooms, this.invites = const []});
+
+  final List<ChatRoom> rooms;
+  final List<GroupInvite> invites;
+
+  @override
+  Future<PaginatedChatRooms?> getAllChatRooms({int? offset, int? limit}) async {
+    return PaginatedChatRooms(rooms: rooms);
+  }
+
+  @override
+  Future<PaginatedGroupInvites?> getGroupInvitesReceived({
+    int? offset,
+    int? limit,
+  }) async {
+    return PaginatedGroupInvites(invites: invites);
+  }
+}
+
+ChatRoom _room(String id, String name) {
+  return ChatRoom(
+    conversationId: Uint8List.fromList(id.codeUnits),
+    name: name,
+    isDirectChat: false,
+  );
+}
+
+ProviderContainer _container(
+  _GroupStoreWorker Function(Ref ref) workerBuilder,
+) {
+  return ProviderContainer(
+    overrides: [qaulWorkerProvider.overrideWith(workerBuilder)],
+  );
+}
+
+void main() {
+  group('ChatRoomsStore', () {
+    test('publishes fetched chat rooms to chatRoomsProvider', () async {
+      final backendRoom = _room('group-1', 'New group');
+      final container = _container(
+        (ref) => _GroupStoreWorker(ref, rooms: [backendRoom]),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(chatRoomsProvider), isEmpty);
+
+      final rooms = await container
+          .read(chatRoomsStoreProvider.notifier)
+          .refreshChatRooms();
+
+      expect(rooms, hasLength(1));
+      expect(rooms.single.idBase58, backendRoom.idBase58);
+      expect(container.read(chatRoomsProvider), hasLength(1));
+      expect(
+        container.read(chatRoomsProvider).single.idBase58,
+        backendRoom.idBase58,
+      );
+    });
+
+    test('publishes fetched group invites to groupInvitesProvider', () async {
+      final group = _room('group-2', 'Invited group');
+      final invite = GroupInvite(
+        senderId: Uint8List.fromList('sender'.codeUnits),
+        receivedAt: DateTime(2026, 1, 1),
+        groupDetails: group,
+      );
+      final container = _container(
+        (ref) => _GroupStoreWorker(ref, rooms: const [], invites: [invite]),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(groupInvitesProvider), isEmpty);
+
+      final invites = await container
+          .read(chatRoomsStoreProvider.notifier)
+          .refreshGroupInvites();
+
+      expect(invites, hasLength(1));
+      expect(invites.single, invite);
+      expect(container.read(groupInvitesProvider), [invite]);
+    });
+  });
+}


### PR DESCRIPTION
## Description
Fix chat/group state updates after RPC request responses.

After the request/response flow started resolving `_sendRequest` before translator side effects ran, fetched chat rooms, group invites, and conversation messages were no longer being written back into Riverpod state. That made group creation appear to fail and made newly fetched/sent messages invisible until switching branches or reloading from another code path.

This PR restores those state updates in the request-driven paths and adds focused tests for group room/invite publishing and conversation message state application.