### PR TITLE
Adjust spacing chat margins

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -652,6 +652,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       child,
       message,
       clustersWithNext: presentation.meta.nonTextClustersWithNext,
+      topSpacing:
+          _chatRenderMode == ChatRenderMode.group && !presentation.isPrimary
+          ? 0
+          : presentation.meta.topSpacing,
     );
     return ChatMessageRenderer.wrapNonText(
       child: nonTextBubble,
@@ -664,29 +668,33 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     Widget child,
     types.Message message, {
     required bool clustersWithNext,
+    required double topSpacing,
   }) {
     const radius = 20.0;
     return Builder(
       builder: (context) {
-        return Bubble(
-          elevation: 0,
-          nipRadius: 0,
-          nipWidth: 0.1,
-          nipHeight: radius,
-          radius: const Radius.circular(radius),
-          padding: EdgeInsets.zero,
-          margin: const EdgeInsets.symmetric(horizontal: 4),
-          color: user.toInternalUser().id != message.author.id
-              ? Colors.grey.shade200
-              : Colors.lightBlue.shade700,
-          nip: clustersWithNext
-              ? BubbleNip.no
-              : user.toInternalUser().id != message.author.id
-                  ? BubbleNip.leftBottom
-                  : BubbleNip.rightBottom,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(20),
-            child: child,
+        return Padding(
+          padding: EdgeInsets.only(top: topSpacing),
+          child: Bubble(
+            elevation: 0,
+            nipRadius: 0,
+            nipWidth: 0.1,
+            nipHeight: radius,
+            radius: const Radius.circular(radius),
+            padding: EdgeInsets.zero,
+            margin: const EdgeInsets.symmetric(horizontal: 4),
+            color: user.toInternalUser().id != message.author.id
+                ? Colors.grey.shade200
+                : Colors.lightBlue.shade700,
+            nip: clustersWithNext
+                ? BubbleNip.no
+                : user.toInternalUser().id != message.author.id
+                ? BubbleNip.leftBottom
+                : BubbleNip.rightBottom,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(20),
+              child: child,
+            ),
           ),
         );
       },

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
@@ -73,6 +73,7 @@ ChatTimelineProjection? buildChatTimelineProjection({
 }) {
   final domainMessages = room.messages?.sorted();
   if (domainMessages == null) return null;
+  final chronologicalMessages = domainMessages.reversed.toList(growable: false);
 
   // Only group rooms disambiguate colliding display names.
   final duplicateNotifications = renderMode == ChatRenderMode.group
@@ -96,20 +97,10 @@ ChatTimelineProjection? buildChatTimelineProjection({
 
   for (final m in domainMessages) {
     final author = resolveAuthor(m, l10n);
-    final internal = m.toInternalMessage(
-      author,
-      ref,
-      l10n: l10n,
-      room: room,
-    );
+    final internal = m.toInternalMessage(author, ref, l10n: l10n, room: room);
 
     if (m.content is TextMessageContent && internal is types.TextMessage) {
-      internalMessages.add(
-        internal.copyWith(
-          status: null,
-          showStatus: false,
-        ),
-      );
+      internalMessages.add(internal.copyWith(status: null, showStatus: false));
       textMessages.add(m);
     } else {
       internalMessages.add(internal);
@@ -137,9 +128,9 @@ ChatTimelineProjection? buildChatTimelineProjection({
         status: m.status == MessageState.sent
             ? MessageStatus.sent
             : (m.status == MessageState.confirmed ||
-                    m.status == MessageState.confirmedByAll
-                ? MessageStatus.read
-                : MessageStatus.notSent),
+                      m.status == MessageState.confirmedByAll
+                  ? MessageStatus.read
+                  : MessageStatus.notSent),
         messageType: isMe ? MessageType.primary : MessageType.secondary,
         edges: const [],
         senderIdBase58: m.senderIdBase58,
@@ -154,15 +145,15 @@ ChatTimelineProjection? buildChatTimelineProjection({
   }
 
   final ascendingRows = <ChatTimelinePresentationRow>[
-    for (final m in domainMessages)
+    for (final m in chronologicalMessages)
       ChatTimelinePresentationRow(
         messageIdBase58: m.messageIdBase58,
         senderIdBase58: m.senderIdBase58,
         sentAt: m.sentAt,
         isText: m.content is TextMessageContent,
         isOutgoing: m.senderId.equals(signedInUser.id),
-        qaulBubbleBaseWithoutLayout:
-            bubbleBaseById[m.messageIdBase58]?.copyWith(edges: const []),
+        qaulBubbleBaseWithoutLayout: bubbleBaseById[m.messageIdBase58]
+            ?.copyWith(edges: const []),
       ),
   ];
 
@@ -174,7 +165,8 @@ ChatTimelineProjection? buildChatTimelineProjection({
   final presentations = <String, MessagePresentation>{};
   for (final m in domainMessages) {
     final slice = computed[m.messageIdBase58]!;
-    final incomingGroup = renderMode == ChatRenderMode.group && !slice.isPrimary;
+    final incomingGroup =
+        renderMode == ChatRenderMode.group && !slice.isPrimary;
 
     QaulGroupMessageSender? groupSender;
     if (incomingGroup) {

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/compute_message_presentation.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/compute_message_presentation.dart
@@ -38,39 +38,40 @@ bool _linksByMinute(
       b.qaulBubbleBaseWithoutLayout!,
     );
 
+bool _isMediaTextBoundary(
+  ChatTimelinePresentationRow a,
+  ChatTimelinePresentationRow b,
+) => a.isText != b.isText;
+
+bool _sameVisualStreakSameDay(
+  ChatTimelinePresentationRow a,
+  ChatTimelinePresentationRow b,
+) => !_isMediaTextBoundary(a, b) && _sameStreakSameDay(a, b);
+
 Map<String, MessagePresentationComputation> computeChatMessagePresentation({
   required List<ChatTimelinePresentationRow> ascendingTimeline,
   required ChatRenderMode layoutMode,
 }) {
-  final textRows = ascendingTimeline
-      .where(
-        (r) => r.isText && r.qaulBubbleBaseWithoutLayout != null,
-      )
-      .toList();
-
   MessagePresentationComputation buildTextComputation(
     ChatTimelinePresentationRow row,
-    int textIndexInSequence,
     int timelineIndex,
   ) {
     final bubble = row.qaulBubbleBaseWithoutLayout!;
-    final prevTimeline =
-        timelineIndex > 0 ? ascendingTimeline[timelineIndex - 1] : null;
+    final prevTimeline = timelineIndex > 0
+        ? ascendingTimeline[timelineIndex - 1]
+        : null;
     final nextTimeline = timelineIndex < ascendingTimeline.length - 1
         ? ascendingTimeline[timelineIndex + 1]
         : null;
 
-    final prevTextRow = textIndexInSequence > 0
-        ? textRows[textIndexInSequence - 1]
-        : null;
-    final nextTextRow = textIndexInSequence < textRows.length - 1
-        ? textRows[textIndexInSequence + 1]
-        : null;
-
     final linksToPrevious =
-        prevTextRow != null && _linksByMinute(prevTextRow, row);
+        prevTimeline != null &&
+        prevTimeline.isText &&
+        _linksByMinute(prevTimeline, row);
     final linksToNext =
-        nextTextRow != null && _linksByMinute(row, nextTextRow);
+        nextTimeline != null &&
+        nextTimeline.isText &&
+        _linksByMinute(row, nextTimeline);
 
     final isPrimary = row.isOutgoing;
 
@@ -81,8 +82,10 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
     final double topSpacing;
     if (prevTimeline == null) {
       topSpacing = 0;
+    } else if (_isMediaTextBoundary(prevTimeline, row)) {
+      topSpacing = kChatMediaTextGap;
     } else if (layoutMode == ChatRenderMode.group) {
-      topSpacing = _sameStreakSameDay(prevTimeline, row)
+      topSpacing = _sameVisualStreakSameDay(prevTimeline, row)
           ? kChatBubbleLinkedGap
           : kChatBubbleSeparatedGap;
     } else if (linksToPrevious) {
@@ -98,15 +101,15 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
 
     if (layoutMode == ChatRenderMode.group && row.isGroupIncomingEligible) {
       showSenderName =
-          prevTimeline == null || !_sameStreakSameDay(prevTimeline, row);
+          prevTimeline == null || !_sameVisualStreakSameDay(prevTimeline, row);
 
       final continuesAfter =
-          nextTimeline != null && _sameStreakSameDay(row, nextTimeline);
+          nextTimeline != null && _sameVisualStreakSameDay(row, nextTimeline);
       showAvatar = !continuesAfter;
     }
 
     final nonTextClustersWithNext =
-        nextTimeline != null && _sameStreakSameDay(row, nextTimeline);
+        nextTimeline != null && _sameVisualStreakSameDay(row, nextTimeline);
 
     final meta = MessagePresentationMeta(
       linksToPrevious: linksToPrevious,
@@ -138,8 +141,9 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
     ChatTimelinePresentationRow row,
     int timelineIndex,
   ) {
-    final prevTimeline =
-        timelineIndex > 0 ? ascendingTimeline[timelineIndex - 1] : null;
+    final prevTimeline = timelineIndex > 0
+        ? ascendingTimeline[timelineIndex - 1]
+        : null;
     final nextTimeline = timelineIndex < ascendingTimeline.length - 1
         ? ascendingTimeline[timelineIndex + 1]
         : null;
@@ -157,14 +161,19 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
       showAvatar = !continuesAfter;
 
       if (prevTimeline != null) {
-        topSpacing = _sameStreakSameDay(prevTimeline, row)
+        topSpacing = _isMediaTextBoundary(prevTimeline, row)
+            ? kChatMediaTextGap
+            : _sameVisualStreakSameDay(prevTimeline, row)
             ? kChatBubbleLinkedGap
             : kChatBubbleSeparatedGap;
       }
+    } else if (prevTimeline != null &&
+        _isMediaTextBoundary(prevTimeline, row)) {
+      topSpacing = kChatMediaTextGap;
     }
 
     final nonTextClustersWithNext =
-        nextTimeline != null && _sameStreakSameDay(row, nextTimeline);
+        nextTimeline != null && _sameVisualStreakSameDay(row, nextTimeline);
 
     final meta = MessagePresentationMeta(
       linksToPrevious: false,
@@ -185,14 +194,11 @@ Map<String, MessagePresentationComputation> computeChatMessagePresentation({
   }
 
   final map = <String, MessagePresentationComputation>{};
-  var textSeen = 0;
 
   for (var i = 0; i < ascendingTimeline.length; i++) {
     final row = ascendingTimeline[i];
     if (row.isText && row.qaulBubbleBaseWithoutLayout != null) {
-      map[row.messageIdBase58] =
-          buildTextComputation(row, textSeen, i);
-      textSeen++;
+      map[row.messageIdBase58] = buildTextComputation(row, i);
     } else {
       map[row.messageIdBase58] = emptyNonText(row, i);
     }

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/group_chat_messages.dart
@@ -65,7 +65,7 @@ class ChatMessageRenderer {
     return DirectTextMessageItem(
       presentation: presentation,
       clock: clock,
-      horizontalGutter: mode == ChatRenderMode.direct,
+      horizontalGutter: true,
     );
   }
 
@@ -101,7 +101,7 @@ class DirectTextMessageItem extends StatelessWidget {
 
   /// When true, applies a 16px gutter on the trailing edge for primary
   /// (outgoing) bubbles and on the leading edge for secondary (incoming).
-  /// Set to false for group-mode outgoing bubbles, which render flush.
+  /// Set to false only for layouts that intentionally render flush.
   final bool horizontalGutter;
 
   @override
@@ -184,7 +184,7 @@ class GroupMessageShell extends StatelessWidget {
         ? null
         : colorGenerationStrategy(sender!.idBase58);
     return Padding(
-      padding: EdgeInsetsDirectional.only(top: marginTop),
+      padding: EdgeInsetsDirectional.only(top: marginTop, start: 12),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
@@ -422,6 +422,8 @@ const double kChatBubbleLinkedGap = 4.0;
 
 const double kChatBubbleSeparatedGap = 12.0;
 
+const double kChatMediaTextGap = 8.0;
+
 const double kGroupChatBubbleSeparatedGap = 4.0;
 
 const TextStyle kGroupSenderNameTextStyle = TextStyle(

--- a/qaul_ui/packages/qaul_components/test/compute_message_presentation_test.dart
+++ b/qaul_ui/packages/qaul_components/test/compute_message_presentation_test.dart
@@ -3,107 +3,118 @@ import 'package:qaul_components/qaul_components.dart';
 
 void main() {
   group('computeChatMessagePresentation', () {
-    test('group texts: same sender same day stays 4px even when minutes differ',
-        () {
-      final t1 = DateTime(2026, 4, 19, 8, 9);
-      final t2 = DateTime(2026, 4, 19, 23, 39);
-      final m0 = QaulChatBubbleMessage(
-        content: 'a',
-        sentAt: t1,
-        receivedAt: t1,
-        status: MessageStatus.sent,
-        messageType: MessageType.secondary,
-        edges: const [],
-        senderIdBase58: 'tm',
-      );
-      final m1 = QaulChatBubbleMessage(
-        content: 'b',
-        sentAt: t2,
-        receivedAt: t2,
-        status: MessageStatus.sent,
-        messageType: MessageType.secondary,
-        edges: const [],
-        senderIdBase58: 'tm',
-      );
-      final timeline = <ChatTimelinePresentationRow>[
-        ChatTimelinePresentationRow(
-          messageIdBase58: 'id-0',
-          senderIdBase58: 'tm',
+    test(
+      'group texts: same sender same day stays 4px even when minutes differ',
+      () {
+        final t1 = DateTime(2026, 4, 19, 8, 9);
+        final t2 = DateTime(2026, 4, 19, 23, 39);
+        final m0 = QaulChatBubbleMessage(
+          content: 'a',
           sentAt: t1,
-          isText: true,
-          isOutgoing: false,
-          qaulBubbleBaseWithoutLayout: m0,
-        ),
-        ChatTimelinePresentationRow(
-          messageIdBase58: 'id-1',
+          receivedAt: t1,
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
           senderIdBase58: 'tm',
+        );
+        final m1 = QaulChatBubbleMessage(
+          content: 'b',
           sentAt: t2,
-          isText: true,
-          isOutgoing: false,
-          qaulBubbleBaseWithoutLayout: m1,
-        ),
-      ];
-
-      final out = computeChatMessagePresentation(
-        ascendingTimeline: timeline,
-        layoutMode: ChatRenderMode.group,
-      );
-
-      expect(out['id-1']!.meta.linksToPrevious, isFalse,
-          reason: 'different calendar minutes → unlinked tails');
-      expect(out['id-1']!.meta.topSpacing, kChatBubbleLinkedGap,
-          reason: 'same streak (sender + calendar day) → compact gap');
-    });
-
-    test('group incoming: name at streak start, avatar at streak end same day', () {
-      final base = DateTime(2026, 4, 19, 21, 19);
-      final m0 = QaulChatBubbleMessage(
-        content: 'a',
-        sentAt: base,
-        receivedAt: base,
-        status: MessageStatus.sent,
-        messageType: MessageType.secondary,
-        edges: const [],
-        senderIdBase58: 'tm',
-      );
-      final m1 = QaulChatBubbleMessage(
-        content: 'b',
-        sentAt: base,
-        receivedAt: base,
-        status: MessageStatus.sent,
-        messageType: MessageType.secondary,
-        edges: const [],
-        senderIdBase58: 'tm',
-      );
-      final timeline = <ChatTimelinePresentationRow>[
-        ChatTimelinePresentationRow(
-          messageIdBase58: 'id-0',
+          receivedAt: t2,
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
           senderIdBase58: 'tm',
+        );
+        final timeline = <ChatTimelinePresentationRow>[
+          ChatTimelinePresentationRow(
+            messageIdBase58: 'id-0',
+            senderIdBase58: 'tm',
+            sentAt: t1,
+            isText: true,
+            isOutgoing: false,
+            qaulBubbleBaseWithoutLayout: m0,
+          ),
+          ChatTimelinePresentationRow(
+            messageIdBase58: 'id-1',
+            senderIdBase58: 'tm',
+            sentAt: t2,
+            isText: true,
+            isOutgoing: false,
+            qaulBubbleBaseWithoutLayout: m1,
+          ),
+        ];
+
+        final out = computeChatMessagePresentation(
+          ascendingTimeline: timeline,
+          layoutMode: ChatRenderMode.group,
+        );
+
+        expect(
+          out['id-1']!.meta.linksToPrevious,
+          isFalse,
+          reason: 'different calendar minutes → unlinked tails',
+        );
+        expect(
+          out['id-1']!.meta.topSpacing,
+          kChatBubbleLinkedGap,
+          reason: 'same streak (sender + calendar day) → compact gap',
+        );
+      },
+    );
+
+    test(
+      'group incoming: name at streak start, avatar at streak end same day',
+      () {
+        final base = DateTime(2026, 4, 19, 21, 19);
+        final m0 = QaulChatBubbleMessage(
+          content: 'a',
           sentAt: base,
-          isText: true,
-          isOutgoing: false,
-          qaulBubbleBaseWithoutLayout: m0,
-        ),
-        ChatTimelinePresentationRow(
-          messageIdBase58: 'id-1',
+          receivedAt: base,
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
           senderIdBase58: 'tm',
+        );
+        final m1 = QaulChatBubbleMessage(
+          content: 'b',
           sentAt: base,
-          isText: true,
-          isOutgoing: false,
-          qaulBubbleBaseWithoutLayout: m1,
-        ),
-      ];
+          receivedAt: base,
+          status: MessageStatus.sent,
+          messageType: MessageType.secondary,
+          edges: const [],
+          senderIdBase58: 'tm',
+        );
+        final timeline = <ChatTimelinePresentationRow>[
+          ChatTimelinePresentationRow(
+            messageIdBase58: 'id-0',
+            senderIdBase58: 'tm',
+            sentAt: base,
+            isText: true,
+            isOutgoing: false,
+            qaulBubbleBaseWithoutLayout: m0,
+          ),
+          ChatTimelinePresentationRow(
+            messageIdBase58: 'id-1',
+            senderIdBase58: 'tm',
+            sentAt: base,
+            isText: true,
+            isOutgoing: false,
+            qaulBubbleBaseWithoutLayout: m1,
+          ),
+        ];
 
-      final out = computeChatMessagePresentation(
-        ascendingTimeline: timeline,
-        layoutMode: ChatRenderMode.group,
-      );
+        final out = computeChatMessagePresentation(
+          ascendingTimeline: timeline,
+          layoutMode: ChatRenderMode.group,
+        );
 
-      expect(out['id-0']!.meta.showSenderName, isTrue);
-      expect(out['id-0']!.meta.showAvatar, isFalse);
-      expect(out['id-1']!.meta.showSenderName, isFalse);
-      expect(out['id-1']!.meta.showAvatar, isTrue);
-    });
+        expect(out['id-0']!.meta.showSenderName, isTrue);
+        expect(out['id-0']!.meta.showAvatar, isFalse);
+        expect(out['id-1']!.meta.showSenderName, isFalse);
+        expect(out['id-1']!.meta.showAvatar, isTrue);
+      },
+    );
 
     test('group incoming: new local calendar day restarts streak', () {
       final d0 = DateTime(2026, 4, 19, 23, 0);
@@ -155,10 +166,10 @@ void main() {
       expect(out['id-1']!.meta.showAvatar, isTrue);
     });
 
-    test('non-text sandwiched between same sender does not break streak', () {
+    test('non-text sandwiched between same sender breaks the text bubble', () {
       final t0 = DateTime(2026, 4, 19, 10, 0);
-      final tMid = DateTime(2026, 4, 19, 10, 1);
-      final t2 = DateTime(2026, 4, 19, 10, 2);
+      final tMid = DateTime(2026, 4, 19, 10, 0);
+      final t2 = DateTime(2026, 4, 19, 10, 0);
       final text0 = QaulChatBubbleMessage(
         content: 'a',
         sentAt: t0,
@@ -209,29 +220,31 @@ void main() {
       );
 
       expect(out['id-0']!.meta.showSenderName, isTrue);
-      expect(out['id-0']!.meta.showAvatar, isFalse);
-      expect(out['id-1']!.meta.showSenderName, isFalse);
+      expect(out['id-0']!.meta.showAvatar, isTrue);
+      expect(out['id-0']!.meta.linksToNext, isFalse);
+      expect(out['id-media']!.meta.topSpacing, kChatMediaTextGap);
+      expect(out['id-media']!.meta.nonTextClustersWithNext, isFalse);
+      expect(out['id-1']!.meta.showSenderName, isTrue);
       expect(out['id-1']!.meta.showAvatar, isTrue);
+      expect(out['id-1']!.meta.linksToPrevious, isFalse);
+      expect(out['id-1']!.meta.topSpacing, kChatMediaTextGap);
     });
 
-    test('direct: same clock minute on different calendar days does not link',
-        () {
-      // Same wall-clock minute, but a day apart → must not cluster/link.
-      final d1 = DateTime(2026, 5, 8, 11, 38);
-      final d2 = DateTime(2026, 5, 9, 11, 38);
-      final m0 = QaulChatBubbleMessage(
+    test('direct media uses 8px spacing around neighboring text', () {
+      final base = DateTime(2026, 4, 19, 10, 0);
+      final text0 = QaulChatBubbleMessage(
         content: 'a',
-        sentAt: d1,
-        receivedAt: d1,
+        sentAt: base,
+        receivedAt: base,
         status: MessageStatus.sent,
         messageType: MessageType.primary,
         edges: const [],
         senderIdBase58: 'me',
       );
-      final m1 = QaulChatBubbleMessage(
+      final text1 = QaulChatBubbleMessage(
         content: 'b',
-        sentAt: d2,
-        receivedAt: d2,
+        sentAt: base,
+        receivedAt: base,
         status: MessageStatus.sent,
         messageType: MessageType.primary,
         edges: const [],
@@ -241,18 +254,25 @@ void main() {
         ChatTimelinePresentationRow(
           messageIdBase58: 'id-0',
           senderIdBase58: 'me',
-          sentAt: d1,
+          sentAt: base,
           isText: true,
           isOutgoing: true,
-          qaulBubbleBaseWithoutLayout: m0,
+          qaulBubbleBaseWithoutLayout: text0,
+        ),
+        ChatTimelinePresentationRow(
+          messageIdBase58: 'id-media',
+          senderIdBase58: 'me',
+          sentAt: base,
+          isText: false,
+          isOutgoing: true,
         ),
         ChatTimelinePresentationRow(
           messageIdBase58: 'id-1',
           senderIdBase58: 'me',
-          sentAt: d2,
+          sentAt: base,
           isText: true,
           isOutgoing: true,
-          qaulBubbleBaseWithoutLayout: m1,
+          qaulBubbleBaseWithoutLayout: text1,
         ),
       ];
 
@@ -261,12 +281,77 @@ void main() {
         layoutMode: ChatRenderMode.direct,
       );
 
-      expect(out['id-0']!.meta.linksToNext, isFalse,
-          reason: 'a day boundary breaks the minute cluster');
-      expect(out['id-1']!.meta.linksToPrevious, isFalse,
-          reason: 'a day boundary breaks the minute cluster');
-      expect(out['id-1']!.meta.topSpacing, kChatBubbleSeparatedGap,
-          reason: 'cross-day neighbors get the separated gap');
+      expect(out['id-0']!.meta.linksToNext, isFalse);
+      expect(out['id-media']!.meta.topSpacing, kChatMediaTextGap);
+      expect(out['id-media']!.meta.nonTextClustersWithNext, isFalse);
+      expect(out['id-1']!.meta.linksToPrevious, isFalse);
+      expect(out['id-1']!.meta.topSpacing, kChatMediaTextGap);
     });
+
+    test(
+      'direct: same clock minute on different calendar days does not link',
+      () {
+        // Same wall-clock minute, but a day apart → must not cluster/link.
+        final d1 = DateTime(2026, 5, 8, 11, 38);
+        final d2 = DateTime(2026, 5, 9, 11, 38);
+        final m0 = QaulChatBubbleMessage(
+          content: 'a',
+          sentAt: d1,
+          receivedAt: d1,
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+          senderIdBase58: 'me',
+        );
+        final m1 = QaulChatBubbleMessage(
+          content: 'b',
+          sentAt: d2,
+          receivedAt: d2,
+          status: MessageStatus.sent,
+          messageType: MessageType.primary,
+          edges: const [],
+          senderIdBase58: 'me',
+        );
+        final timeline = <ChatTimelinePresentationRow>[
+          ChatTimelinePresentationRow(
+            messageIdBase58: 'id-0',
+            senderIdBase58: 'me',
+            sentAt: d1,
+            isText: true,
+            isOutgoing: true,
+            qaulBubbleBaseWithoutLayout: m0,
+          ),
+          ChatTimelinePresentationRow(
+            messageIdBase58: 'id-1',
+            senderIdBase58: 'me',
+            sentAt: d2,
+            isText: true,
+            isOutgoing: true,
+            qaulBubbleBaseWithoutLayout: m1,
+          ),
+        ];
+
+        final out = computeChatMessagePresentation(
+          ascendingTimeline: timeline,
+          layoutMode: ChatRenderMode.direct,
+        );
+
+        expect(
+          out['id-0']!.meta.linksToNext,
+          isFalse,
+          reason: 'a day boundary breaks the minute cluster',
+        );
+        expect(
+          out['id-1']!.meta.linksToPrevious,
+          isFalse,
+          reason: 'a day boundary breaks the minute cluster',
+        );
+        expect(
+          out['id-1']!.meta.topSpacing,
+          kChatBubbleSeparatedGap,
+          reason: 'cross-day neighbors get the separated gap',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description
Fix media spacing in chat message groups.

Images/files were not participating in the same spacing and grouping logic as text bubbles. When media appeared between text messages, the surrounding text could still render as if it belonged to one continuous bubble group, causing missing spacing and incorrect visual grouping.

This PR adds an 8px media/text gap and makes media break the chat bubble group for both sent and received messages, without changing the existing text bubble rules.

## Evidence
<img width="250" alt="image" src="https://github.com/user-attachments/assets/f9faa950-b694-4146-b8c2-65dc0274ddaa" />
