### PR TITLE
Implement notification count increment logic

### DIFF
--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -113,6 +113,16 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
     );
   }
 
+  @override
+  int notificationCountIncrement(ChatRoom value) {
+    final cached = _chats.firstWhereOrNull(
+      (c) => c.roomIdBase58 == value.idBase58,
+    );
+    final previousUnreadCount = cached?.unreadCount ?? 0;
+    final delta = value.unreadCount - previousUnreadCount;
+    return delta > 0 ? delta : 1;
+  }
+
   bool _lastMessageIsFromLocalUser(ChatRoom r1) =>
       localUser.id.equals(r1.lastMessageSenderId ?? []);
 

--- a/qaul_ui/lib/providers/notification_controller/notification_controller.dart
+++ b/qaul_ui/lib/providers/notification_controller/notification_controller.dart
@@ -27,9 +27,8 @@ class NotificationController<T> {
 
   @protected
   @visibleForOverriding
-  MapEntry<dynamic, void Function(T?, T)>
-      get strategy =>
-          throw UnimplementedError('Must be implemented by child class');
+  MapEntry<dynamic, void Function(T?, T)> get strategy =>
+      throw UnimplementedError('Must be implemented by child class');
 
   @protected
   @visibleForOverriding
@@ -67,9 +66,11 @@ mixin DataProcessingStrategy<T> on NotificationController<List<T>> {
 
     while (queue.isNotEmpty) {
       final entry = queue.removeFirst();
+      final countIncrement = notificationCountIncrement(entry);
       final message = process(entry);
       if (message == null) continue;
-      newNotificationCount.value = (newNotificationCount.value ?? 0) + 1;
+      newNotificationCount.value =
+          (newNotificationCount.value ?? 0) + countIncrement;
       LocalNotifications.instance.displayNotification(message);
       await Future.delayed(const Duration(milliseconds: 500));
     }
@@ -82,6 +83,9 @@ mixin DataProcessingStrategy<T> on NotificationController<List<T>> {
 
   @visibleForOverriding
   LocalNotification? process(T value);
+
+  @visibleForOverriding
+  int notificationCountIncrement(T value) => 1;
 
   @visibleForOverriding
   void close();

--- a/qaul_ui/packages/qaul_components/lib/design_components/shell/qaul_navbar.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/shell/qaul_navbar.dart
@@ -103,7 +103,8 @@ const double _kNavBarMenuVisualSplashRadius = 8.0;
 /// Circular tap/hover target for the overflow menu ([InkWell] inside [SizedBox]).
 const double _kNavBarMenuHitDiameter = 40.0;
 const double _kNavBarBadgeFontSize = 10.0;
-const double _kNavBarBadgePositionOffset = 8.0;
+const double _kNavBarBadgeSize = 16.0;
+const double _kNavBarBadgePositionOffset = 4.0;
 
 // iOS SafeArea reports the full notch/Dynamic Island inset, but the vertical
 // rail only needs a fraction of that because its content is already inset by
@@ -763,13 +764,21 @@ class _NavBarItem extends StatelessWidget {
         // Let taps pass through the count pill to the tab [InkWell] below.
         ignorePointer: true,
         showBadge: true,
-        badgeStyle: const BadgeStyle(badgeColor: Colors.lightBlue),
-        badgeContent: Text(
-          '$badgeCount',
-          style: const TextStyle(
-            fontSize: _kNavBarBadgeFontSize,
-            color: Colors.white,
-            fontWeight: FontWeight.w800,
+        badgeStyle: const BadgeStyle(
+          badgeColor: Colors.lightBlue,
+          padding: EdgeInsets.zero,
+        ),
+        badgeContent: SizedBox.square(
+          dimension: _kNavBarBadgeSize,
+          child: Center(
+            child: Text(
+              '$badgeCount',
+              style: const TextStyle(
+                fontSize: _kNavBarBadgeFontSize,
+                color: Colors.white,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
           ),
         ),
         position: BadgePosition.bottomEnd(

--- a/qaul_ui/packages/qaul_components/test/qaul_navbar_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_navbar_test.dart
@@ -1,3 +1,4 @@
+import 'package:badges/badges.dart' as badges;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qaul_components/qaul_components.dart';
@@ -34,9 +35,18 @@ void main() {
     });
 
     test('returns correct paths for all tab types with icons', () {
-      expect(navBarTabIconPath(TabType.public, false), 'assets/icons/public-outlined.svg');
-      expect(navBarTabIconPath(TabType.users, false), 'assets/icons/people-outlined.svg');
-      expect(navBarTabIconPath(TabType.network, false), 'assets/icons/network-outlined.svg');
+      expect(
+        navBarTabIconPath(TabType.public, false),
+        'assets/icons/public-outlined.svg',
+      );
+      expect(
+        navBarTabIconPath(TabType.users, false),
+        'assets/icons/people-outlined.svg',
+      );
+      expect(
+        navBarTabIconPath(TabType.network, false),
+        'assets/icons/network-outlined.svg',
+      );
     });
   });
 
@@ -46,7 +56,12 @@ void main() {
       final (selected, icon, active) = navBarColors(theme);
       expect(selected, const Color(0xFF333333));
       expect(icon, theme.iconTheme.color ?? Colors.white);
-      expect(active, theme.navigationBarTheme.surfaceTintColor ?? theme.iconTheme.color ?? Colors.white);
+      expect(
+        active,
+        theme.navigationBarTheme.surfaceTintColor ??
+            theme.iconTheme.color ??
+            Colors.white,
+      );
     });
 
     test('returns light theme colors for Brightness.light', () {
@@ -67,11 +82,46 @@ void main() {
     });
 
     test('throws for account tab', () {
-      expect(
-        () => navBarTabIconSize(TabType.account),
-        throwsStateError,
-      );
+      expect(() => navBarTabIconSize(TabType.account), throwsStateError);
     });
   });
 
+  group('QaulNavBar notification badge', () {
+    testWidgets('uses 16px badge positioned 4px from bottom/end', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: QaulNavBar(
+              vertical: false,
+              selectedTab: TabType.chat,
+              onTabSelected: (_) {},
+              onOverflowSelected: (_) {},
+              overflowMenuLabels: const {},
+              tabTooltips: const {
+                TabType.account: 'Account',
+                TabType.public: 'Public',
+                TabType.users: 'Users',
+                TabType.chat: 'Chat',
+                TabType.network: 'Network',
+              },
+              chatNotificationCount: 5,
+            ),
+          ),
+        ),
+      );
+
+      final badge = tester.widget<badges.Badge>(find.byType(badges.Badge));
+      expect(badge.position?.bottom, 4);
+      expect(badge.position?.end, 4);
+      expect(badge.badgeStyle.padding, EdgeInsets.zero);
+
+      final badgeContent = badge.badgeContent;
+      expect(badgeContent, isA<SizedBox>());
+      final box = badgeContent as SizedBox;
+      expect(box.width, 16);
+      expect(box.height, 16);
+    });
+  });
 }

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -98,7 +98,9 @@ class StubLibqaulWorker implements LibqaulWorker {
 
     return PaginatedUsers(
       users: page.users
-          .where((user) => user.name.toLowerCase().contains(query.toLowerCase()))
+          .where(
+            (user) => user.name.toLowerCase().contains(query.toLowerCase()),
+          )
           .toList(),
       pagination: page.pagination,
     );
@@ -289,6 +291,9 @@ class NullChatNotificationController implements ChatNotificationController {
   LocalNotification? process(ChatRoom value) {
     throw UnimplementedError();
   }
+
+  @override
+  int notificationCountIncrement(ChatRoom value) => 1;
 
   @override
   Ref get ref => throw UnimplementedError();

--- a/qaul_ui/test/chat_user_resolution_test.dart
+++ b/qaul_ui/test/chat_user_resolution_test.dart
@@ -16,15 +16,16 @@ class _NoopWorker implements LibqaulWorker {
   final Ref ref;
 
   @override
-  Future<PaginatedChatRooms?> getAllChatRooms({int? offset, int? limit}) async =>
-      PaginatedChatRooms(rooms: []);
+  Future<PaginatedChatRooms?> getAllChatRooms({
+    int? offset,
+    int? limit,
+  }) async => PaginatedChatRooms(rooms: []);
 
   @override
   Future<PaginatedGroupInvites?> getGroupInvitesReceived({
     int? offset,
     int? limit,
-  }) async =>
-      PaginatedGroupInvites(invites: []);
+  }) async => PaginatedGroupInvites(invites: []);
 
   @override
   Future<bool> get initialized => Future.value(true);
@@ -58,7 +59,7 @@ class _NoopChatNotificationController implements ChatNotificationController {
 
   @override
   MapEntry<dynamic, void Function(List<ChatRoom>?, List<ChatRoom>)>
-      get strategy => const MapEntry(null, _noopStrategy);
+  get strategy => const MapEntry(null, _noopStrategy);
 
   static void _noopStrategy(List<ChatRoom>? _, List<ChatRoom> _) {}
 
@@ -81,6 +82,9 @@ class _NoopChatNotificationController implements ChatNotificationController {
   LocalNotification? process(ChatRoom value) => null;
 
   @override
+  int notificationCountIncrement(ChatRoom value) => 1;
+
+  @override
   void removeNotifications() {}
 
   @override
@@ -90,10 +94,14 @@ class _NoopChatNotificationController implements ChatNotificationController {
 class _DirectRoomNotifier extends ChatRoomListNotifier {
   @override
   List<ChatRoom> build() {
-    final defaultUser =
-        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
-    final otherUser =
-        User(name: 'Peer', id: Uint8List.fromList('peer-user'.codeUnits));
+    final defaultUser = User(
+      name: 'Default',
+      id: Uint8List.fromList('default-user'.codeUnits),
+    );
+    final otherUser = User(
+      name: 'Peer',
+      id: Uint8List.fromList('peer-user'.codeUnits),
+    );
     return [
       ChatRoom(
         conversationId: Uint8List.fromList('dm-room'.codeUnits),
@@ -111,15 +119,15 @@ class _DirectRoomNotifier extends ChatRoomListNotifier {
 class _GroupRoomWithUnknownEventNotifier extends ChatRoomListNotifier {
   @override
   List<ChatRoom> build() {
-    final defaultUser =
-        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
+    final defaultUser = User(
+      name: 'Default',
+      id: Uint8List.fromList('default-user'.codeUnits),
+    );
     return [
       ChatRoom(
         conversationId: Uint8List.fromList('group-room'.codeUnits),
         isDirectChat: false,
-        members: [
-          ChatRoomUser(defaultUser, joinedAt: DateTime(2024)),
-        ],
+        members: [ChatRoomUser(defaultUser, joinedAt: DateTime(2024))],
         name: 'Group',
         lastMessagePreview: GroupEventContent(
           userId: Uint8List.fromList('unknown-user'.codeUnits),
@@ -135,40 +143,51 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets('direct room renders using member fallback when users store is empty',
-      (tester) async {
-    final defaultUser =
-        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
+  testWidgets(
+    'direct room renders using member fallback when users store is empty',
+    (tester) async {
+      final defaultUser = User(
+        name: 'Default',
+        id: Uint8List.fromList('default-user'.codeUnits),
+      );
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          defaultUserProvider.overrideWith((_) => defaultUser),
-          chatNotificationControllerProvider
-              .overrideWithValue(_NoopChatNotificationController()),
-          chatRoomsProvider.overrideWith(_DirectRoomNotifier.new),
-          qaulWorkerProvider.overrideWith((ref) => _NoopWorker(ref)),
-        ],
-        child: materialAppWithLocalizations(BaseTab.chat()),
-      ),
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            defaultUserProvider.overrideWith((_) => defaultUser),
+            chatNotificationControllerProvider.overrideWithValue(
+              _NoopChatNotificationController(),
+            ),
+            chatRoomsProvider.overrideWith(_DirectRoomNotifier.new),
+            qaulWorkerProvider.overrideWith((ref) => _NoopWorker(ref)),
+          ],
+          child: materialAppWithLocalizations(BaseTab.chat()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Peer'), findsOneWidget);
+    },
+  );
+
+  testWidgets('group event with missing user shows unknown fallback', (
+    tester,
+  ) async {
+    final defaultUser = User(
+      name: 'Default',
+      id: Uint8List.fromList('default-user'.codeUnits),
     );
-    await tester.pumpAndSettle();
-
-    expect(find.text('Peer'), findsOneWidget);
-  });
-
-  testWidgets('group event with missing user shows unknown fallback',
-      (tester) async {
-    final defaultUser =
-        User(name: 'Default', id: Uint8List.fromList('default-user'.codeUnits));
 
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           defaultUserProvider.overrideWith((_) => defaultUser),
-          chatNotificationControllerProvider
-              .overrideWithValue(_NoopChatNotificationController()),
-          chatRoomsProvider.overrideWith(_GroupRoomWithUnknownEventNotifier.new),
+          chatNotificationControllerProvider.overrideWithValue(
+            _NoopChatNotificationController(),
+          ),
+          chatRoomsProvider.overrideWith(
+            _GroupRoomWithUnknownEventNotifier.new,
+          ),
           qaulWorkerProvider.overrideWith((ref) => _NoopWorker(ref)),
         ],
         child: materialAppWithLocalizations(BaseTab.chat()),

--- a/qaul_ui/test/providers/chat_notification_controller_test.dart
+++ b/qaul_ui/test/providers/chat_notification_controller_test.dart
@@ -20,12 +20,12 @@ void main() {
   final localUserId = Uint8List.fromList('localUser'.codeUnits);
 
   ChatRoom makeRoom({required int unreadCount}) => ChatRoom(
-        conversationId: roomId,
-        name: 'Test Room',
-        unreadCount: unreadCount,
-        lastMessagePreview: const TextMessageContent('hello'),
-        lastMessageSenderId: otherUserId,
-      );
+    conversationId: roomId,
+    name: 'Test Room',
+    unreadCount: unreadCount,
+    lastMessagePreview: const TextMessageContent('hello'),
+    lastMessageSenderId: otherUserId,
+  );
 
   late ProviderContainer container;
   late ChatNotificationController controller;
@@ -41,12 +41,14 @@ void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
 
-    container = ProviderContainer(overrides: [
-      defaultUserProvider.overrideWith(
-        (_) => User(name: 'Local', id: localUserId),
-      ),
-      qaulWorkerProvider.overrideWithValue(_StubWorker()),
-    ]);
+    container = ProviderContainer(
+      overrides: [
+        defaultUserProvider.overrideWith(
+          (_) => User(name: 'Local', id: localUserId),
+        ),
+        qaulWorkerProvider.overrideWithValue(_StubWorker()),
+      ],
+    );
 
     controller = container.read(chatNotificationControllerProvider);
     await controller.initialize();
@@ -55,8 +57,7 @@ void main() {
   tearDown(() => container.dispose());
 
   group('ChatNotificationController cache vs unreadCount', () {
-    test(
-        'after reading messages (unreadCount drops to 0), '
+    test('after reading messages (unreadCount drops to 0), '
         'a new message (unreadCount back to 1) is detected', () {
       // 1. New room arrives with unreadCount: 1 — should be detected.
       var entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 1)]);
@@ -93,26 +94,42 @@ void main() {
 
       // One new message.
       entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 1)]);
-      expect(entries, isNotEmpty,
-          reason: 'cache updated to 0, so 1 > 0 is a new message');
+      expect(
+        entries,
+        isNotEmpty,
+        reason: 'cache updated to 0, so 1 > 0 is a new message',
+      );
     });
 
-    test('monotonically increasing unreadCount still works (regression guard)',
-        () {
-      var entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 1)]);
-      expect(entries, isNotEmpty);
-      for (final e in entries) {
-        controller.process(e);
-      }
+    test(
+      'monotonically increasing unreadCount still works (regression guard)',
+      () {
+        var entries = controller.entriesToBeProcessed([
+          makeRoom(unreadCount: 1),
+        ]);
+        expect(entries, isNotEmpty);
+        for (final e in entries) {
+          controller.process(e);
+        }
 
-      entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 2)]);
-      expect(entries, isNotEmpty);
-      for (final e in entries) {
-        controller.process(e);
-      }
+        entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 2)]);
+        expect(entries, isNotEmpty);
+        for (final e in entries) {
+          controller.process(e);
+        }
 
-      entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 3)]);
-      expect(entries, isNotEmpty);
+        entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 3)]);
+        expect(entries, isNotEmpty);
+      },
+    );
+
+    test('notification counter increment follows unreadCount delta', () {
+      final firstRoom = makeRoom(unreadCount: 2);
+      expect(controller.notificationCountIncrement(firstRoom), 2);
+      controller.process(firstRoom);
+
+      final updatedRoom = makeRoom(unreadCount: 5);
+      expect(controller.notificationCountIncrement(updatedRoom), 3);
     });
 
     test('same unreadCount on consecutive calls does not re-trigger', () {
@@ -122,12 +139,14 @@ void main() {
       }
 
       entries = controller.entriesToBeProcessed([makeRoom(unreadCount: 1)]);
-      expect(entries, isEmpty,
-          reason: 'same unreadCount should not re-trigger');
+      expect(
+        entries,
+        isEmpty,
+        reason: 'same unreadCount should not re-trigger',
+      );
     });
 
-    test(
-        'unreadCount drop is persisted so a restart '
+    test('unreadCount drop is persisted so a restart '
         'does not revert to stale high watermark', () async {
       // 1. First message arrives — detected and processed.
       final room = makeRoom(unreadCount: 1);
@@ -147,19 +166,24 @@ void main() {
       // 3. Simulate app restart: new container, fresh controller loading
       //    from the same SharedPreferences.
       container.dispose();
-      container = ProviderContainer(overrides: [
-        defaultUserProvider.overrideWith(
-          (_) => User(name: 'Local', id: localUserId),
-        ),
-        qaulWorkerProvider.overrideWithValue(_StubWorker()),
-      ]);
-      final freshController =
-          container.read(chatNotificationControllerProvider);
+      container = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith(
+            (_) => User(name: 'Local', id: localUserId),
+          ),
+          qaulWorkerProvider.overrideWithValue(_StubWorker()),
+        ],
+      );
+      final freshController = container.read(
+        chatNotificationControllerProvider,
+      );
       await freshController.initialize();
 
       // 4. New message arrives (unreadCount: 1). The fresh controller must
       //    detect it, not silently swallow it due to a stale cached count.
-      entries = freshController.entriesToBeProcessed([makeRoom(unreadCount: 1)]);
+      entries = freshController.entriesToBeProcessed([
+        makeRoom(unreadCount: 1),
+      ]);
       expect(
         entries,
         isNotEmpty,
@@ -175,8 +199,10 @@ void main() {
 /// Only [getAllChatRooms] is called during [initialize].
 class _StubWorker implements LibqaulWorker {
   @override
-  Future<PaginatedChatRooms?> getAllChatRooms({int? offset, int? limit}) async =>
-      PaginatedChatRooms(rooms: []);
+  Future<PaginatedChatRooms?> getAllChatRooms({
+    int? offset,
+    int? limit,
+  }) async => PaginatedChatRooms(rooms: []);
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>


### PR DESCRIPTION
## Description
Fix chat notification badge placement and count.

The bottom navigation chat badge was rendered with the wrong size and offset. This PR updates it to the expected 16x16 badge with 4px bottom/right spacing.

It also applies a small notification count fix: when unread counts increase, the bottom navigation badge now increments by the unread-count delta instead of always adding one per room update. This better matches the chat overview counter without reworking the temporary derived-notification architecture.

## Evidence
<img width="250" alt="image" src="https://github.com/user-attachments/assets/a44634a0-55b5-40f1-a684-287db7f015fb" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b35e2f4c-3b7f-43fc-b8d9-ca8cf5d88a3a" />
