### PR TITLE
Add user details navigation in chat screen and fix color

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -275,11 +275,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     final l10n = AppLocalizations.of(context)!;
     final directPeer = _directChatPeer(room);
+    final chatBackgroundColor = QaulColorSheet(
+      Theme.of(context).brightness,
+    ).background;
     _chatRenderMode = resolveChatRenderMode(room);
 
     return Scaffold(
+      backgroundColor: chatBackgroundColor,
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
+        backgroundColor: chatBackgroundColor,
         leading: IconButtonFactory(onPressed: closeChat),
         title: Row(
           mainAxisSize: MainAxisSize.min,
@@ -555,7 +560,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 directPeer?.idBase58 ?? otherUser?.idBase58 ?? room.idBase58,
               ),
             ],
-            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+            backgroundColor: chatBackgroundColor,
             messageInsetsVertical: 0,
             messageInsetsHorizontal: 0,
             dateDividerTextStyle: const TextStyle(

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -37,6 +37,7 @@ import '../../../../../../stores/stores.dart';
 import '../../../../../providers/providers.dart';
 import '../../../../../utils.dart';
 import '../../../../../widgets/widgets.dart';
+import '../../../user_details_screen.dart';
 import '../../tab.dart';
 import 'conditional/conditional.dart';
 
@@ -208,6 +209,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
   }
 
+  void _openUserDetails(User user) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => UserDetailsScreen(user: user)),
+    );
+  }
+
   void _scheduleUpdateCurrentOpenChat() =>
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ref.read(currentOpenChatRoom.notifier).state = room;
@@ -276,9 +284,19 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         title: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            (_chatRenderMode == ChatRenderMode.group)
+            _chatRenderMode == ChatRenderMode.group
                 ? QaulAvatar.groupSmall()
-                : QaulAvatar.small(user: directPeer),
+                : Semantics(
+                    button: directPeer != null,
+                    label: directPeer?.name,
+                    child: InkResponse(
+                      onTap: directPeer == null
+                          ? null
+                          : () => _openUserDetails(directPeer),
+                      radius: 24,
+                      child: QaulAvatar.small(user: directPeer),
+                    ),
+                  ),
             const SizedBox(width: 12),
             Expanded(
               child: Text(


### PR DESCRIPTION
## Description
- Fixed the chat header interaction and dark-mode chat background styling.
- Clicking the direct-chat user avatar now opens the user details screen.
- The interaction is limited to the user avatar only, with proper tap feedback and semantics.
- The chat screen background, chat list background, and chat header background now use the shared qaul background color, which is #000000 in dark mode.

## Evidence
<img width="266" height="589" alt="Screenshot 2026-07-09 at 09 12 53" src="https://github.com/user-attachments/assets/7170d58e-1cad-42da-bead-9e28a1ae9ecb" />

