### PR TITLE
Unfocus input when navigating out of public tab

### DIFF
--- a/qaul_ui/lib/decorators/qaul_navbar_decorator.dart
+++ b/qaul_ui/lib/decorators/qaul_navbar_decorator.dart
@@ -119,6 +119,7 @@ class _ConnectedNavBarState extends ConsumerState<_ConnectedNavBar> {
           handleNavBarOverflowSelected(context, option),
       selectedTab: currentTab,
       onTabSelected: (tab) {
+        FocusManager.instance.primaryFocus?.unfocus();
         tabController.goToTab(tab);
         if (tab == TabType.public) {
           publicController.removeNotifications();

--- a/qaul_ui/lib/screens/home/tabs/public_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/public_tab.dart
@@ -103,6 +103,14 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(homeScreenControllerProvider, (previous, next) {
+      if (previous != TabType.public || next == TabType.public) return;
+      FocusManager.instance.primaryFocus?.unfocus();
+      widget.disablePageViewScroll.value = false;
+      final navigator = Navigator.of(context);
+      if (navigator.canPop()) navigator.pop();
+    });
+
     ref.listen(feedMessageStoreProvider, (_, _) {
       final pagination = ref.read(feedMessageStoreProvider.notifier).pagination;
       if (pagination != null && !pagination.hasMore) {


### PR DESCRIPTION
## Description
Fixed the public composer keyboard getting stuck after switching tabs.
- Dismisses the active keyboard focus when selecting another navigation tab.
- Closes the public composer bottom sheet when leaving the Public tab.
- Resets the Public tab page-scroll lock after the composer is dismissed.

## Evidence
https://github.com/user-attachments/assets/4e9ff2b0-05f8-4f1c-9bcb-67daf41dc907

