### PR TITLE
Enhance user invitation dialog layout with SafeArea and im…

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
@@ -166,53 +166,58 @@ class _InviteUsersToGroupDialogState
     return SearchUserDecorator(
       title: AppLocalizations.of(context)!.inviteUser,
       builder: (_, users) {
-        return Stack(
-          children: [
-            ListView.separated(
-              padding: const EdgeInsets.fromLTRB(8, 8, 8, 40),
-              itemCount: users.length,
-              separatorBuilder: (_, _) => const Divider(height: 12.0),
-              itemBuilder: (context, i) {
-                final usr = users[i];
-                return QaulListTile.user(
-                  usr,
-                  onTap: () {
-                    if (selected.contains(usr)) {
-                      setState(() => selected.remove(usr));
-                      return;
-                    }
-                    setState(() => selected.add(usr));
-                  },
-                  trailingIcon: Checkbox(
-                    value: selected.contains(usr),
-                    onChanged: (ok) {
-                      if (ok ?? false) {
-                        setState(() => selected.add(usr));
+        return SafeArea(
+          top: false,
+          left: false,
+          right: false,
+          child: Stack(
+            children: [
+              ListView.separated(
+                padding: const EdgeInsets.fromLTRB(8, 8, 8, 72),
+                itemCount: users.length,
+                separatorBuilder: (_, _) => const Divider(height: 12.0),
+                itemBuilder: (context, i) {
+                  final usr = users[i];
+                  return QaulListTile.user(
+                    usr,
+                    onTap: () {
+                      if (selected.contains(usr)) {
+                        setState(() => selected.remove(usr));
                         return;
                       }
-                      setState(() => selected.remove(usr));
+                      setState(() => selected.add(usr));
                     },
-                  ),
-                );
-              },
-            ),
-            Positioned.directional(
-              textDirection: Directionality.of(context),
-              end: 12,
-              bottom: 8,
-              child: QaulButton(
-                backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                onPressed: () async {
-                  final worker = ref.read(qaulWorkerProvider);
-                  for (final user in selected) {
-                    worker.inviteUserToGroup(user, widget.room);
-                  }
-                  Navigator.pop(context);
+                    trailingIcon: Checkbox(
+                      value: selected.contains(usr),
+                      onChanged: (ok) {
+                        if (ok ?? false) {
+                          setState(() => selected.add(usr));
+                          return;
+                        }
+                        setState(() => selected.remove(usr));
+                      },
+                    ),
+                  );
                 },
-                label: l10n.invite,
               ),
-            ),
-          ],
+              Positioned.directional(
+                textDirection: Directionality.of(context),
+                end: 12,
+                bottom: 8,
+                child: QaulButton(
+                  backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+                  onPressed: () async {
+                    final worker = ref.read(qaulWorkerProvider);
+                    for (final user in selected) {
+                      worker.inviteUserToGroup(user, widget.room);
+                    }
+                    Navigator.pop(context);
+                  },
+                  label: l10n.invite,
+                ),
+              ),
+            ],
+          ),
         );
       },
     );


### PR DESCRIPTION
## Description
Fixed the group invite screen so the Invite button respects the device safe area.
The invite action is now wrapped in the screen’s bottom safe area, preventing it from being hidden behind Android system navigation bars while still adapting correctly on gesture-navigation devices.

## Evidence
Before
<img width="250" alt="Screenshot 2026-07-09 at 10 41 54" src="https://github.com/user-attachments/assets/4f317cbc-16fc-4435-bc66-d91cd621b59c" />

After
<img width="250" alt="Screenshot 2026-07-09 at 10 40 51" src="https://github.com/user-attachments/assets/887ea1a1-abb3-495f-b33b-704cf424175b" />
