### PR TITLE
Update initials function to handle graphemes

### DIFF
--- a/qaul_ui/packages/utils/lib/utils.dart
+++ b/qaul_ui/packages/utils/lib/utils.dart
@@ -42,11 +42,6 @@ Color colorGenerationStrategy(String first) {
 /// * https://github.com/flutter/flutter/issues/43302
 String initials(String name) {
   assert(name.isNotEmpty, 'name should have at least one character');
-  if (hasEmojis(name)) {
-    final emoji = retrieveFirstEmoji(name);
-    if (emoji != null) return emoji;
-    name = removeEmoji(name);
-  }
   if (name.replaceAll(' ', '').isEmpty) {
     throw ArgumentError.value(
       name,
@@ -61,7 +56,19 @@ String initials(String name) {
           .toUpperCase();
     }
   }
+  if (hasEmojis(name)) {
+    final emoji = _firstEmojiGrapheme(name);
+    if (emoji != null) return emoji;
+    name = removeEmoji(name);
+  }
   return name.characters.first.toUpperCase();
+}
+
+String? _firstEmojiGrapheme(String text) {
+  for (final grapheme in text.characters) {
+    if (hasEmojis(grapheme)) return grapheme;
+  }
+  return null;
 }
 
 /// If [clock] is provided, timestamp is in relation to [clock] (Should only be useful for testing).

--- a/qaul_ui/packages/utils/lib/utils.dart
+++ b/qaul_ui/packages/utils/lib/utils.dart
@@ -34,7 +34,7 @@ Color colorGenerationStrategy(String first) {
 /// Given a string containing values separated by space (" "), yields a string of length 2
 /// containing the first letter of the first and last word, respectively, in uppercase.
 ///
-/// If the provided string has no spaces, returns its first two letters - also uppercase.
+/// If the provided string has no spaces, returns its first grapheme - also uppercase.
 ///
 /// Note: Filters out emojis, so as not to cause malformed UTF-16 issues. See more here:
 /// * https://github.com/dart-lang/sdk/issues/35798
@@ -56,9 +56,12 @@ String initials(String name) {
   }
   if (name.contains(' ')) {
     final ws = name.split(' ').where((e) => e.isNotEmpty).toList();
-    if (ws.length > 1) return '${ws.first[0]}${ws.last[0]}'.toUpperCase();
+    if (ws.length > 1) {
+      return '${ws.first.characters.first}${ws.last.characters.first}'
+          .toUpperCase();
+    }
   }
-  return name.substring(0, 1).toUpperCase();
+  return name.characters.first.toUpperCase();
 }
 
 /// If [clock] is provided, timestamp is in relation to [clock] (Should only be useful for testing).

--- a/qaul_ui/packages/utils/test/utils_test.dart
+++ b/qaul_ui/packages/utils/test/utils_test.dart
@@ -103,6 +103,9 @@ void main() {
       MapEntry('l🤣h😌o🙄😪😓😳ggasdf', '🤣'),
       MapEntry('😌🤣h😌o🙄😪😓😳ggasdf', '😌'),
       MapEntry('😳🤣h😌🙄😪😓😳ggasdf', '😳'),
+      MapEntry('🫠', '🫠'),
+      MapEntry('🫠 user', '🫠U'),
+      MapEntry('👨‍👩‍👧‍👦', '👨‍👩‍👧‍👦'),
     ];
 
     for (final tc in names) {


### PR DESCRIPTION
## Description
Fixed emoji initials rendering for user names.

Some newer or compound emojis were not recognized by the existing emoji regex, causing the initials fallback to split UTF-16 surrogate pairs with substring(0, 1). This produced an invalid replacement character instead of the emoji in avatars and the network overview.

The initials fallback now uses grapheme clusters, so emoji-only names and compound emoji names render as a complete character instead of a question mark/replacement glyph.

## Evidence
Before
<img width="250" alt="Screenshot 2026-07-09 at 11 07 15" src="https://github.com/user-attachments/assets/3b4c792e-0057-4801-b59e-f2185a3141e2" />

After
<img width="250" alt="Screenshot 2026-07-09 at 11 07 29" src="https://github.com/user-attachments/assets/e412c2ed-acd0-4bba-bb83-f5ddc966244c" />
