### PR TITLE
Add group invite to notificatino count

### DIFF
--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -23,6 +23,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
   @override
   Future<void> initialize() async {
     await super.initialize();
+    ref.listen(groupInvitesProvider, _executeGroupInvites);
     if (preferences.containsKey(cacheKey)) {
       _chats.addAll(
         preferences.getStringList(cacheKey)!.map((e) {
@@ -34,6 +35,24 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
     _log.config(
       'Initialized:\n\t· User: ${localUser.name}\n\t· Cached chats: $_chats',
     );
+  }
+
+  void _executeGroupInvites(
+    List<GroupInvite>? previous,
+    List<GroupInvite> current,
+  ) {
+    final previousInvites = previous ?? const <GroupInvite>[];
+    final newInvites = current.where((invite) {
+      return !previousInvites.contains(invite);
+    }).toList();
+    if (newInvites.isEmpty ||
+        currentVisibleHomeTab == TabType.chat ||
+        !UserPrefsHelper.instance.chatNotificationsEnabled) {
+      return;
+    }
+
+    newNotificationCount.value =
+        (newNotificationCount.value ?? 0) + newInvites.length;
   }
 
   @override

--- a/qaul_ui/test/providers/chat_notification_controller_test.dart
+++ b/qaul_ui/test/providers/chat_notification_controller_test.dart
@@ -16,6 +16,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final roomId = Uint8List.fromList('room1'.codeUnits);
+  final inviteRoomId = Uint8List.fromList('inviteRoom'.codeUnits);
   final otherUserId = Uint8List.fromList('otherUser'.codeUnits);
   final localUserId = Uint8List.fromList('localUser'.codeUnits);
 
@@ -25,6 +26,16 @@ void main() {
     unreadCount: unreadCount,
     lastMessagePreview: const TextMessageContent('hello'),
     lastMessageSenderId: otherUserId,
+  );
+
+  GroupInvite makeInvite() => GroupInvite(
+    senderId: otherUserId,
+    receivedAt: DateTime(2026, 1, 1),
+    groupDetails: ChatRoom(
+      conversationId: inviteRoomId,
+      name: 'Invited Room',
+      isDirectChat: false,
+    ),
   );
 
   late ProviderContainer container;
@@ -191,6 +202,22 @@ void main() {
             'after restart, cache should reflect unreadCount 0 '
             'so the 0→1 transition is detected',
       );
+    });
+
+    test('new group invite increments notification counter', () {
+      expect(controller.newNotificationCount.value, isNull);
+
+      container.read(groupInvitesProvider.notifier).add(makeInvite());
+
+      expect(controller.newNotificationCount.value, 1);
+    });
+
+    test('new group invite does not increment counter on chat tab', () {
+      container.read(homeScreenControllerProvider.notifier).goToTab(TabType.chat);
+
+      container.read(groupInvitesProvider.notifier).add(makeInvite());
+
+      expect(controller.newNotificationCount.value, isNull);
     });
   });
 }


### PR DESCRIPTION
## Description
Fixed the chat tab notification badge so newly received group invites are counted as new chat activity.

The chat notification controller now listens for new group invites in addition to unread chat room updates, increments the main tab bar chat counter for new invites, and keeps the existing behavior of not counting while the user is already on the chat tab. Added regression tests for both cases.

## Evidence
https://github.com/user-attachments/assets/8ced8d65-17b0-4e3a-a4c7-f14d7dd118f5

