### PR TITLE
Foward Recipient Selector

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/forward_recipient_selector.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/forward_recipient_selector.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+
+enum ForwardRecipientKind { public, user, group }
+
+@immutable
+class ForwardRecipient {
+  const ForwardRecipient({
+    required this.id,
+    required this.displayName,
+    required this.kind,
+    this.initials,
+    this.avatarColor,
+    this.isOnline = false,
+  });
+
+  final String id;
+  final String displayName;
+  final ForwardRecipientKind kind;
+  final String? initials;
+  final Color? avatarColor;
+  final bool isOnline;
+}
+
+enum ForwardSearchFilter { user, group, id, chat, trustedVerified }
+
+/// Recipient selection state used before forwarding a message.
+///
+/// Selection is intentionally single-recipient. The host receives changes via
+/// [onRecipientSelected] and can replace this component with a multi-select
+/// implementation later without coupling it to a contact data source.
+class ForwardRecipientSelector extends StatefulWidget {
+  const ForwardRecipientSelector({
+    super.key,
+    required this.recipients,
+    required this.onRecipientSelected,
+    required this.onSearchChanged,
+    required this.onCancel,
+    this.initialSelectedRecipientId,
+    this.initialSearchOpen = false,
+    this.onSearchFilterSelected,
+    this.title = 'Forward message to:',
+  });
+
+  final List<ForwardRecipient> recipients;
+  final ValueChanged<ForwardRecipient> onRecipientSelected;
+  final ValueChanged<String> onSearchChanged;
+  final VoidCallback onCancel;
+  final ValueChanged<ForwardSearchFilter>? onSearchFilterSelected;
+  final String? initialSelectedRecipientId;
+  final bool initialSearchOpen;
+  final String title;
+
+  @override
+  State<ForwardRecipientSelector> createState() =>
+      _ForwardRecipientSelectorState();
+}
+
+class _ForwardRecipientSelectorState extends State<ForwardRecipientSelector> {
+  late String? _selectedRecipientId = widget.initialSelectedRecipientId;
+  late bool _searchOpen = widget.initialSearchOpen;
+  final _searchController = TextEditingController();
+
+  @override
+  void didUpdateWidget(covariant ForwardRecipientSelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialSelectedRecipientId !=
+        widget.initialSelectedRecipientId) {
+      _selectedRecipientId = widget.initialSelectedRecipientId;
+    }
+    if (oldWidget.initialSearchOpen != widget.initialSearchOpen) {
+      _searchOpen = widget.initialSearchOpen;
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final publicRecipients = _ofKind(ForwardRecipientKind.public);
+    final users = _ofKind(ForwardRecipientKind.user);
+    final groups = _ofKind(ForwardRecipientKind.group);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: 'Back',
+          onPressed: widget.onCancel,
+          icon: const Icon(Icons.arrow_back),
+        ),
+        title: Text(widget.title),
+      ),
+      body: Stack(
+        children: [
+          ListView(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+            children: [
+              if (publicRecipients.isNotEmpty) ...[
+                _section(context, 'Public', publicRecipients),
+                const Divider(height: 28),
+              ],
+              _section(context, 'Users / Contacts', users, searchable: true),
+              const Divider(height: 28),
+              _section(context, 'Groups', groups, searchable: true),
+            ],
+          ),
+          if (_searchOpen) _buildSearchOverlay(context),
+        ],
+      ),
+    );
+  }
+
+  List<ForwardRecipient> _ofKind(ForwardRecipientKind kind) =>
+      widget.recipients.where((recipient) => recipient.kind == kind).toList();
+
+  Widget _section(
+    BuildContext context,
+    String title,
+    List<ForwardRecipient> recipients, {
+    bool searchable = false,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+            if (searchable)
+              IconButton(
+                tooltip: 'Search $title',
+                onPressed: () => setState(() => _searchOpen = true),
+                icon: const Icon(Icons.search),
+              ),
+          ],
+        ),
+        ...recipients.map(_recipientRow),
+      ],
+    );
+  }
+
+  Widget _recipientRow(ForwardRecipient recipient) {
+    final selected = recipient.id == _selectedRecipientId;
+    return Semantics(
+      selected: selected,
+      button: true,
+      child: ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: _RecipientAvatar(recipient: recipient),
+        title: Text(recipient.displayName),
+        trailing: selected
+            ? const Icon(Icons.check_circle_outline)
+            : const Icon(Icons.radio_button_unchecked),
+        onTap: () {
+          setState(() => _selectedRecipientId = recipient.id);
+          widget.onRecipientSelected(recipient);
+        },
+      ),
+    );
+  }
+
+  Widget _buildSearchOverlay(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Positioned.fill(
+      child: ColoredBox(
+        color: colors.scrim.withValues(alpha: 0.45),
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: SafeArea(
+            minimum: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+            child: Material(
+              color: colors.surfaceContainerHighest,
+              elevation: 8,
+              borderRadius: BorderRadius.circular(20),
+              clipBehavior: Clip.antiAlias,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 8, 12),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      autofocus: true,
+                      controller: _searchController,
+                      onChanged: widget.onSearchChanged,
+                      decoration: InputDecoration(
+                        hintText: 'Search recipients',
+                        prefixIcon: const Icon(Icons.search),
+                        suffixIcon: IconButton(
+                          tooltip: 'Close search',
+                          onPressed: _closeSearch,
+                          icon: const Icon(Icons.close),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    ...ForwardSearchFilter.values.map(
+                      (filter) => ListTile(
+                        dense: true,
+                        leading: const Icon(Icons.search),
+                        title: Text(_filterLabel(filter)),
+                        onTap: () {
+                          widget.onSearchFilterSelected?.call(filter);
+                          _closeSearch();
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _closeSearch() {
+    _searchController.clear();
+    widget.onSearchChanged('');
+    setState(() => _searchOpen = false);
+  }
+
+  String _filterLabel(ForwardSearchFilter filter) => switch (filter) {
+    ForwardSearchFilter.user => 'User',
+    ForwardSearchFilter.group => 'Group',
+    ForwardSearchFilter.id => 'ID',
+    ForwardSearchFilter.chat => 'Chat',
+    ForwardSearchFilter.trustedVerified => 'Trusted / verified',
+  };
+}
+
+class _RecipientAvatar extends StatelessWidget {
+  const _RecipientAvatar({required this.recipient});
+
+  final ForwardRecipient recipient;
+
+  @override
+  Widget build(BuildContext context) {
+    if (recipient.kind == ForwardRecipientKind.public) {
+      return const CircleAvatar(child: Icon(Icons.campaign_outlined));
+    }
+
+    final avatar = CircleAvatar(
+      backgroundColor: recipient.avatarColor,
+      child: recipient.kind == ForwardRecipientKind.group
+          ? const Icon(Icons.groups, color: Colors.white)
+          : Text(
+              _avatarLabel(recipient),
+              style: const TextStyle(color: Colors.white),
+            ),
+    );
+
+    if (!recipient.isOnline) return avatar;
+    return SizedBox.square(
+      dimension: 40,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(child: avatar),
+          Positioned(
+            right: -1,
+            bottom: -1,
+            child: Container(
+              key: const ValueKey('forward-recipient-online-indicator'),
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                color: Colors.greenAccent.shade700,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: Theme.of(context).scaffoldBackgroundColor,
+                  width: 2,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _avatarLabel(ForwardRecipient recipient) {
+    final initials = recipient.initials?.trim();
+    if (initials != null && initials.isNotEmpty) return initials;
+
+    final displayName = recipient.displayName.trim();
+    return displayName.isEmpty ? '?' : displayName.characters.first;
+  }
+}

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/forward_recipient_selector.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/forward_recipient_selector.dart
@@ -38,6 +38,7 @@ class ForwardRecipientSelector extends StatefulWidget {
     this.initialSelectedRecipientId,
     this.initialSearchOpen = false,
     this.onSearchFilterSelected,
+    this.onMore,
     this.title = 'Forward message to:',
   });
 
@@ -46,6 +47,7 @@ class ForwardRecipientSelector extends StatefulWidget {
   final ValueChanged<String> onSearchChanged;
   final VoidCallback onCancel;
   final ValueChanged<ForwardSearchFilter>? onSearchFilterSelected;
+  final VoidCallback? onMore;
   final String? initialSelectedRecipientId;
   final bool initialSearchOpen;
   final String title;
@@ -83,21 +85,44 @@ class _ForwardRecipientSelectorState extends State<ForwardRecipientSelector> {
     final publicRecipients = _ofKind(ForwardRecipientKind.public);
     final users = _ofKind(ForwardRecipientKind.user);
     final groups = _ofKind(ForwardRecipientKind.group);
+    final backgroundColor = Theme.of(context).brightness == Brightness.dark
+        ? Colors.black
+        : Colors.white;
 
     return Scaffold(
+      backgroundColor: backgroundColor,
       appBar: AppBar(
+        backgroundColor: backgroundColor,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        shape: const Border(),
         leading: IconButton(
           tooltip: 'Back',
           onPressed: widget.onCancel,
           icon: const Icon(Icons.arrow_back),
         ),
-        title: Text(widget.title),
+        actions: [
+          IconButton(
+            tooltip: 'More options',
+            onPressed: widget.onMore ?? () {},
+            icon: const Icon(Icons.more_vert),
+          ),
+        ],
       ),
       body: Stack(
         children: [
           ListView(
             padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
             children: [
+              Text(
+                widget.title,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 12),
               if (publicRecipients.isNotEmpty) ...[
                 _section(context, 'Public', publicRecipients),
                 const Divider(height: 28),

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -6,6 +6,7 @@ export 'design_components/chat/chat_timeline.dart';
 export 'design_components/chat/compute_message_presentation.dart'
     show computeChatMessagePresentation, computeChatBubbleDisplayItems;
 export 'design_components/chat/duplicate_username_meta_message.dart';
+export 'design_components/chat/forward_recipient_selector.dart';
 export 'design_components/chat/group_chat_messages.dart'
     show
         ChatMessageRenderer,

--- a/qaul_ui/packages/qaul_components/test/forward_recipient_selector_test.dart
+++ b/qaul_ui/packages/qaul_components/test/forward_recipient_selector_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+void main() {
+  const recipients = [
+    ForwardRecipient(
+      id: 'public',
+      displayName: 'Public',
+      kind: ForwardRecipientKind.public,
+    ),
+    ForwardRecipient(
+      id: 'ada',
+      displayName: 'Ada',
+      kind: ForwardRecipientKind.user,
+    ),
+    ForwardRecipient(
+      id: 'group',
+      displayName: 'Qaul group',
+      kind: ForwardRecipientKind.group,
+    ),
+  ];
+
+  testWidgets('renders sections and updates single selection', (tester) async {
+    ForwardRecipient? selected;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ForwardRecipientSelector(
+          recipients: recipients,
+          onRecipientSelected: (value) => selected = value,
+          onSearchChanged: (_) {},
+          onCancel: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('Public'), findsNWidgets(2));
+    expect(find.text('Users / Contacts'), findsOneWidget);
+    expect(find.text('Groups'), findsOneWidget);
+
+    await tester.tap(find.text('Ada'));
+    await tester.pump();
+
+    expect(selected?.id, 'ada');
+    expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+  });
+
+  testWidgets('opens search and reports query and close', (tester) async {
+    final changes = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ForwardRecipientSelector(
+          recipients: recipients,
+          onRecipientSelected: (_) {},
+          onSearchChanged: changes.add,
+          onCancel: () {},
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Search Users / Contacts'));
+    await tester.pump();
+    expect(find.text('Search recipients'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'Ada');
+    expect(changes, contains('Ada'));
+
+    await tester.tap(find.byTooltip('Close search'));
+    await tester.pump();
+    expect(changes.last, '');
+    expect(find.text('Search recipients'), findsNothing);
+  });
+
+  testWidgets('reflects updated initial state from its parent', (tester) async {
+    late StateSetter rebuild;
+    var selectedId = 'ada';
+    var searchOpen = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return ForwardRecipientSelector(
+              recipients: recipients,
+              initialSelectedRecipientId: selectedId,
+              initialSearchOpen: searchOpen,
+              onRecipientSelected: (_) {},
+              onSearchChanged: (_) {},
+              onCancel: () {},
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+    rebuild(() {
+      selectedId = 'group';
+      searchOpen = true;
+    });
+    await tester.pump();
+
+    expect(find.text('Search recipients'), findsOneWidget);
+    await tester.tap(find.byTooltip('Close search'));
+    await tester.pump();
+    expect(find.text('Search recipients'), findsNothing);
+  });
+
+  testWidgets('uses a safe avatar fallback for an empty user name', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ForwardRecipientSelector(
+          recipients: const [
+            ForwardRecipient(
+              id: 'empty',
+              displayName: '',
+              kind: ForwardRecipientKind.user,
+            ),
+          ],
+          onRecipientSelected: (_) {},
+          onSearchChanged: (_) {},
+          onCancel: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('?'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('positions the online indicator over the avatar edge', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ForwardRecipientSelector(
+          recipients: const [
+            ForwardRecipient(
+              id: 'online',
+              displayName: 'Online user',
+              initials: 'OU',
+              kind: ForwardRecipientKind.user,
+              isOnline: true,
+            ),
+          ],
+          onRecipientSelected: (_) {},
+          onSearchChanged: (_) {},
+          onCancel: () {},
+        ),
+      ),
+    );
+
+    final avatarRect = tester.getRect(find.byType(CircleAvatar));
+    final indicatorRect = tester.getRect(
+      find.byKey(const ValueKey('forward-recipient-online-indicator')),
+    );
+
+    expect(indicatorRect.center.dx, greaterThan(avatarRect.center.dx));
+    expect(indicatorRect.center.dy, greaterThan(avatarRect.center.dy));
+    expect(indicatorRect.left, lessThan(avatarRect.right));
+    expect(indicatorRect.top, lessThan(avatarRect.bottom));
+  });
+}

--- a/qaul_ui/packages/qaul_components/test/forward_recipient_selector_test.dart
+++ b/qaul_ui/packages/qaul_components/test/forward_recipient_selector_test.dart
@@ -163,4 +163,57 @@ void main() {
     expect(indicatorRect.left, lessThan(avatarRect.right));
     expect(indicatorRect.top, lessThan(avatarRect.bottom));
   });
+
+  testWidgets('renders and wires the forwarding header', (tester) async {
+    var backedOut = false;
+    var openedMore = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ForwardRecipientSelector(
+          recipients: recipients,
+          onRecipientSelected: (_) {},
+          onSearchChanged: (_) {},
+          onCancel: () => backedOut = true,
+          onMore: () => openedMore = true,
+        ),
+      ),
+    );
+
+    expect(find.text('Forward message to:'), findsOneWidget);
+    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(find.byTooltip('More options'));
+
+    expect(backedOut, isTrue);
+    expect(openedMore, isTrue);
+  });
+
+  testWidgets('header blends into the background in both themes', (
+    tester,
+  ) async {
+    for (final brightness in Brightness.values) {
+      final expectedColor = brightness == Brightness.dark
+          ? Colors.black
+          : Colors.white;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Theme(
+            data: ThemeData(brightness: brightness),
+            child: ForwardRecipientSelector(
+              recipients: recipients,
+              onRecipientSelected: (_) {},
+              onSearchChanged: (_) {},
+              onCancel: () {},
+            ),
+          ),
+        ),
+      );
+
+      final appBar = tester.widget<AppBar>(find.byType(AppBar));
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
+      expect(appBar.backgroundColor, expectedColor);
+      expect(scaffold.backgroundColor, expectedColor);
+      expect(appBar.elevation, 0);
+      expect((appBar.shape! as Border).bottom.style, BorderStyle.none);
+    }
+  });
 }

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -18,6 +18,8 @@ import 'package:qaul_components_widgetbook/use_cases/design_components/chat/chat
     as _qaul_components_widgetbook_use_cases_design_components_chat_chat_header;
 import 'package:qaul_components_widgetbook/use_cases/design_components/chat/chat_timeline.dart'
     as _qaul_components_widgetbook_use_cases_design_components_chat_chat_timeline;
+import 'package:qaul_components_widgetbook/use_cases/design_components/chat/forward_recipient_selector.dart'
+    as _qaul_components_widgetbook_use_cases_design_components_chat_forward_recipient_selector;
 import 'package:qaul_components_widgetbook/use_cases/design_components/qaul_color_sheet.dart'
     as _qaul_components_widgetbook_use_cases_design_components_qaul_color_sheet;
 import 'package:qaul_components_widgetbook/use_cases/design_components/shell/qaul_fab.dart'
@@ -163,6 +165,29 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _qaul_components_widgetbook_use_cases_special_forms_duplicate_username_meta_message
                         .buildDuplicateUsernameMetaMessageUseCase,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'ForwardRecipientSelector',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Recipients — selected',
+                builder:
+                    _qaul_components_widgetbook_use_cases_design_components_chat_forward_recipient_selector
+                        .buildForwardRecipientSelectorSelectedUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Recipients — unselected',
+                builder:
+                    _qaul_components_widgetbook_use_cases_design_components_chat_forward_recipient_selector
+                        .buildForwardRecipientSelectorUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Search — open',
+                builder:
+                    _qaul_components_widgetbook_use_cases_design_components_chat_forward_recipient_selector
+                        .buildForwardRecipientSelectorSearchUseCase,
               ),
             ],
           ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -12,6 +12,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:qaul_components_widgetbook/use_cases/design/account/account_management.dart'
     as _qaul_components_widgetbook_use_cases_design_account_account_management;
+import 'package:qaul_components_widgetbook/use_cases/design/message_forwarding/message_forwarding.dart'
+    as _qaul_components_widgetbook_use_cases_design_message_forwarding_message_forwarding;
 import 'package:qaul_components_widgetbook/use_cases/design_components/chat/chat_footer.dart'
     as _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer;
 import 'package:qaul_components_widgetbook/use_cases/design_components/chat/chat_header.dart'
@@ -40,6 +42,22 @@ final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookCategory(
     name: 'design',
     children: [
+      _widgetbook.WidgetbookFolder(
+        name: 'Message forwarding',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'ForwardRecipientSelector',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Recipient selection with message',
+                builder:
+                    _qaul_components_widgetbook_use_cases_design_message_forwarding_message_forwarding
+                        .buildMessageForwardingFlowUseCase,
+              ),
+            ],
+          ),
+        ],
+      ),
       _widgetbook.WidgetbookFolder(
         name: 'account',
         children: [

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design/message_forwarding/message_forwarding.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design/message_forwarding/message_forwarding.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+const _recipients = [
+  ForwardRecipient(
+    id: 'public',
+    displayName: 'Public',
+    kind: ForwardRecipientKind.public,
+  ),
+  ForwardRecipient(
+    id: 'cem',
+    displayName: 'Cem Member',
+    initials: 'CM',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.teal,
+  ),
+  ForwardRecipient(
+    id: 'grey',
+    displayName: 'Grey 2',
+    initials: 'G2',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.orange,
+    isOnline: true,
+  ),
+  ForwardRecipient(
+    id: 'gur',
+    displayName: 'Gur Girl',
+    initials: 'GG',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.indigo,
+  ),
+  ForwardRecipient(
+    id: 'francis',
+    displayName: 'Francis',
+    initials: 'F',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.amber,
+    isOnline: true,
+  ),
+  ForwardRecipient(
+    id: 'anna',
+    displayName: 'Anna K',
+    initials: 'AK',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.lime,
+  ),
+  ForwardRecipient(
+    id: 'group-1',
+    displayName: 'Group 1',
+    kind: ForwardRecipientKind.group,
+    avatarColor: Colors.purple,
+  ),
+  ForwardRecipient(
+    id: 'group-2',
+    displayName: 'Group 2',
+    kind: ForwardRecipientKind.group,
+    avatarColor: Colors.purple,
+  ),
+];
+
+@widgetbook.UseCase(
+  name: 'Recipient selection with message',
+  type: ForwardRecipientSelector,
+  path: '[design]/Message forwarding',
+)
+Widget buildMessageForwardingFlowUseCase(BuildContext context) =>
+    const _MessageForwardingFlow();
+
+class _MessageForwardingFlow extends StatefulWidget {
+  const _MessageForwardingFlow();
+
+  @override
+  State<_MessageForwardingFlow> createState() => _MessageForwardingFlowState();
+}
+
+class _MessageForwardingFlowState extends State<_MessageForwardingFlow> {
+  final _messageController = TextEditingController(
+    text: 'Example for forwarding',
+  );
+  String? _selectedRecipientId;
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ColoredBox(
+      color: theme.scaffoldBackgroundColor,
+      child: Column(
+        children: [
+          Expanded(
+            child: ForwardRecipientSelector(
+              recipients: _recipients,
+              initialSelectedRecipientId: _selectedRecipientId,
+              onRecipientSelected: (recipient) {
+                setState(() => _selectedRecipientId = recipient.id);
+              },
+              onSearchChanged: (_) {},
+              onSearchFilterSelected: (_) {},
+              onCancel: () {},
+            ),
+          ),
+          Divider(height: 1, color: theme.dividerColor),
+          SafeArea(
+            top: false,
+            child: ChatFooter(
+              controller: _messageController,
+              placeholder: 'Message to forward',
+              onSend: (_) {},
+              onMoreAttachmentsPressed: () {},
+              sendTooltip: 'Forward message',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design_components/chat/forward_recipient_selector.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design_components/chat/forward_recipient_selector.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+const _recipients = [
+  ForwardRecipient(
+    id: 'public',
+    displayName: 'Public',
+    kind: ForwardRecipientKind.public,
+  ),
+  ForwardRecipient(
+    id: 'cem',
+    displayName: 'Cem Member',
+    initials: 'CM',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.teal,
+  ),
+  ForwardRecipient(
+    id: 'grey',
+    displayName: 'Grey 2',
+    initials: 'G2',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.orange,
+    isOnline: true,
+  ),
+  ForwardRecipient(
+    id: 'gur',
+    displayName: 'Gur Girl',
+    initials: 'GG',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.indigo,
+  ),
+  ForwardRecipient(
+    id: 'francis',
+    displayName: 'Francis',
+    initials: 'F',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.amber,
+    isOnline: true,
+  ),
+  ForwardRecipient(
+    id: 'anna',
+    displayName: 'Anna K',
+    initials: 'AK',
+    kind: ForwardRecipientKind.user,
+    avatarColor: Colors.lime,
+  ),
+  ForwardRecipient(
+    id: 'group-1',
+    displayName: 'Group 1',
+    kind: ForwardRecipientKind.group,
+    avatarColor: Colors.purple,
+  ),
+  ForwardRecipient(
+    id: 'group-2',
+    displayName: 'Group 2',
+    kind: ForwardRecipientKind.group,
+    avatarColor: Colors.purple,
+  ),
+  ForwardRecipient(
+    id: 'friends',
+    displayName: 'Friends of qaul',
+    kind: ForwardRecipientKind.group,
+    avatarColor: Colors.purple,
+  ),
+];
+
+Widget _selector({bool searchOpen = false, String? selectedId}) {
+  return ForwardRecipientSelector(
+    recipients: _recipients,
+    initialSelectedRecipientId: selectedId,
+    initialSearchOpen: searchOpen,
+    onRecipientSelected: (_) {},
+    onSearchChanged: (_) {},
+    onSearchFilterSelected: (_) {},
+    onCancel: () {},
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Recipients — unselected',
+  type: ForwardRecipientSelector,
+)
+Widget buildForwardRecipientSelectorUseCase(BuildContext context) =>
+    _selector();
+
+@widgetbook.UseCase(
+  name: 'Recipients — selected',
+  type: ForwardRecipientSelector,
+)
+Widget buildForwardRecipientSelectorSelectedUseCase(BuildContext context) =>
+    _selector(selectedId: 'francis');
+
+@widgetbook.UseCase(name: 'Search — open', type: ForwardRecipientSelector)
+Widget buildForwardRecipientSelectorSearchUseCase(BuildContext context) =>
+    _selector(searchOpen: true);


### PR DESCRIPTION
## Description
Adds a reusable recipient selection screen for forwarding messages.

The selector:
- Separates Public, Users/Contacts, and Groups.
- Displays avatars, initials, online status, and selection indicators.
- Supports single-recipient selection.
- Provides open and closed search states with filter suggestions.
- Exposes callbacks for selection, search changes, filter selection, and cancellation.
- Includes Widgetbook previews for unselected, selected, and search-open states.
- Includes widget tests covering selection, search, parent-driven state updates, avatar fallbacks, and online-indicator positioning.

## Evidence
<img width="250" alt="Screenshot 2026-07-20 at 13 16 23" src="https://github.com/user-attachments/assets/939047f8-3a0d-4c01-b39d-902138abc5c3" />

