### PR TITLE
Rename and optimize group invite processing

### DIFF
--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -23,7 +23,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
   @override
   Future<void> initialize() async {
     await super.initialize();
-    ref.listen(groupInvitesProvider, _executeGroupInvites);
+    ref.listen(groupInvitesProvider, _processNewGroupInvite);
     if (preferences.containsKey(cacheKey)) {
       _chats.addAll(
         preferences.getStringList(cacheKey)!.map((e) {
@@ -37,19 +37,18 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
     );
   }
 
-  void _executeGroupInvites(
+  void _processNewGroupInvite(
     List<GroupInvite>? previous,
     List<GroupInvite> current,
   ) {
-    final previousInvites = previous ?? const <GroupInvite>[];
-    final newInvites = current.where((invite) {
-      return !previousInvites.contains(invite);
-    }).toList();
-    if (newInvites.isEmpty ||
-        currentVisibleHomeTab == TabType.chat ||
+    if (currentVisibleHomeTab == TabType.chat ||
         !UserPrefsHelper.instance.chatNotificationsEnabled) {
       return;
     }
+    final newInvites = current.toSet().difference(
+      (previous ?? const <GroupInvite>[]).toSet(),
+    );
+    if (newInvites.isEmpty) return;
 
     newNotificationCount.value =
         (newNotificationCount.value ?? 0) + newInvites.length;


### PR DESCRIPTION
## Description
Improves group invite notification handling by detecting newly received invites with set difference and skipping unnecessary processing when chat notifications are disabled or the chat tab is already visible.

Related to the comments on #920 