### PR TITLE
Implement chat reply bubble preview

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_reply_bubble_preview.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_reply_bubble_preview.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+/// Display-only data for a replied-message excerpt inside a chat bubble.
+@immutable
+class ChatReplyPreviewData {
+  const ChatReplyPreviewData({required this.author, required this.content});
+
+  final String author;
+  final String content;
+}
+
+/// The quoted-message block rendered inside a reply bubble.
+class ChatReplyBubblePreview extends StatelessWidget {
+  const ChatReplyBubblePreview({
+    super.key,
+    required this.data,
+    required this.isOutgoing,
+    required this.textScaler,
+  });
+
+  final ChatReplyPreviewData data;
+  final bool isOutgoing;
+  final TextScaler textScaler;
+
+  static const _outgoingColor = Color(0xFF0277BD);
+  static const _incomingColor = Color(0xFF303030);
+  static const _radius = Radius.circular(3);
+
+  static const _authorStyle = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w600,
+    height: 1.2,
+    letterSpacing: 0,
+    color: Colors.white,
+  );
+
+  static const _contentStyle = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w300,
+    height: 1.2,
+    letterSpacing: 0,
+    color: Colors.white,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      key: const ValueKey('chat-reply-preview'),
+      decoration: BoxDecoration(
+        color: isOutgoing ? _outgoingColor : _incomingColor,
+        borderRadius: const BorderRadius.all(_radius),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              data.author.trim(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: _authorStyle,
+              textScaler: textScaler,
+            ),
+            const SizedBox(height: 2),
+            Text(
+              data.content.trim(),
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: _contentStyle,
+              textScaler: textScaler,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'chat_message.dart';
+import 'chat_reply_bubble_preview.dart';
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -37,6 +38,8 @@ class ChatBubbleStyle {
 
   static const horizontalPadding = 10.0;
   static const verticalPadding = 6.0;
+  static const replyBubbleVerticalPadding = 10.0;
+  static const gapAfterReplyPreview = 6.0;
 
   static const gapBetweenTextAndDate = 4.0;
 
@@ -82,6 +85,7 @@ class QaulChatBubbleMessage extends ChatMessage {
     this.senderIdBase58,
     this.senderDisplayName,
     this.senderDisplayNameColor,
+    this.replyPreview,
   });
 
   final String content;
@@ -95,6 +99,7 @@ class QaulChatBubbleMessage extends ChatMessage {
   final String? senderIdBase58;
   final String? senderDisplayName;
   final Color? senderDisplayNameColor;
+  final ChatReplyPreviewData? replyPreview;
 
   QaulChatBubbleMessage copyWith({
     Key? key,
@@ -109,6 +114,7 @@ class QaulChatBubbleMessage extends ChatMessage {
     String? senderIdBase58,
     String? senderDisplayName,
     Color? senderDisplayNameColor,
+    ChatReplyPreviewData? replyPreview,
   }) {
     return QaulChatBubbleMessage(
       key: key ?? this.key,
@@ -124,6 +130,7 @@ class QaulChatBubbleMessage extends ChatMessage {
       senderDisplayName: senderDisplayName ?? this.senderDisplayName,
       senderDisplayNameColor:
           senderDisplayNameColor ?? this.senderDisplayNameColor,
+      replyPreview: replyPreview ?? this.replyPreview,
     );
   }
 
@@ -267,14 +274,18 @@ class QaulChatBubble extends StatelessWidget {
           maxWidth: maxBubbleWidth,
         ),
         child: DecoratedBox(
+          key: const ValueKey('chat-bubble-surface'),
           decoration: BoxDecoration(
             color: backgroundColor,
             borderRadius: borderRadius,
           ),
           child: Padding(
-            padding: const EdgeInsets.symmetric(
+            key: const ValueKey('chat-bubble-padding'),
+            padding: EdgeInsets.symmetric(
               horizontal: ChatBubbleStyle.horizontalPadding,
-              vertical: ChatBubbleStyle.verticalPadding,
+              vertical: message.replyPreview == null
+                  ? ChatBubbleStyle.verticalPadding
+                  : ChatBubbleStyle.replyBubbleVerticalPadding,
             ),
             child: ConstrainedBox(
               constraints: BoxConstraints(maxWidth: maxTextWidth),
@@ -334,6 +345,7 @@ class QaulChatBubble extends StatelessWidget {
                     ],
                   );
 
+                  final replyPreview = message.replyPreview;
                   Widget messageContent;
                   if (!showTimestamp) {
                     messageContent = RichText(
@@ -341,6 +353,22 @@ class QaulChatBubble extends StatelessWidget {
                       textWidthBasis: TextWidthBasis.longestLine,
                       textScaler: textScaler,
                       text: messageSpan,
+                    );
+                  } else if (fitsOnOneLine && replyPreview != null) {
+                    messageContent = Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Expanded(
+                          child: RichText(
+                            textAlign: TextAlign.left,
+                            textWidthBasis: TextWidthBasis.longestLine,
+                            textScaler: textScaler,
+                            text: messageSpan,
+                          ),
+                        ),
+                        const SizedBox(width: gap),
+                        timeRow,
+                      ],
                     );
                   } else if (fitsOnOneLine) {
                     messageContent = Row(
@@ -357,6 +385,26 @@ class QaulChatBubble extends StatelessWidget {
                         ),
                         const SizedBox(width: gap),
                         timeRow,
+                      ],
+                    );
+                  } else if (replyPreview != null) {
+                    messageContent = Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        RichText(
+                          textAlign: TextAlign.left,
+                          textWidthBasis: TextWidthBasis.longestLine,
+                          textScaler: textScaler,
+                          text: messageSpan,
+                        ),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: Padding(
+                            padding: const EdgeInsets.only(top: gap),
+                            child: timeRow,
+                          ),
+                        ),
                       ],
                     );
                   } else {
@@ -380,8 +428,11 @@ class QaulChatBubble extends StatelessWidget {
                     );
                   }
 
-                  if (message.senderDisplayName == null ||
-                      message.senderDisplayName!.isEmpty) {
+                  final hasSenderDisplayName =
+                      message.senderDisplayName != null &&
+                      message.senderDisplayName!.isNotEmpty;
+
+                  if (!hasSenderDisplayName && replyPreview == null) {
                     return messageContent;
                   }
 
@@ -389,18 +440,33 @@ class QaulChatBubble extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 4),
-                        child: Text(
-                          message.senderDisplayName!,
-                          style: kGroupSenderNameTextStyle.copyWith(
-                            color:
-                                message.senderDisplayNameColor ??
-                                Colors.white.withValues(alpha: 0.85),
+                      if (hasSenderDisplayName)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Text(
+                            message.senderDisplayName!,
+                            style: kGroupSenderNameTextStyle.copyWith(
+                              color:
+                                  message.senderDisplayNameColor ??
+                                  Colors.white.withValues(alpha: 0.85),
+                            ),
+                            textScaler: textScaler,
                           ),
-                          textScaler: textScaler,
                         ),
-                      ),
+                      if (replyPreview != null)
+                        Padding(
+                          padding: const EdgeInsets.only(
+                            bottom: ChatBubbleStyle.gapAfterReplyPreview,
+                          ),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: ChatReplyBubblePreview(
+                              data: replyPreview,
+                              isOutgoing: isPrimary,
+                              textScaler: textScaler,
+                            ),
+                          ),
+                        ),
                       messageContent,
                     ],
                   );

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -2,6 +2,7 @@ export 'design_components/account/account_management.dart';
 export 'design_components/chat/chat_footer.dart';
 export 'design_components/chat/chat_header.dart';
 export 'design_components/chat/chat_message_context_menu.dart';
+export 'design_components/chat/chat_reply_bubble_preview.dart';
 export 'design_components/chat/chat_room_list.dart';
 export 'design_components/chat/chat_timeline.dart';
 export 'design_components/chat/compute_message_presentation.dart'

--- a/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
+++ b/qaul_ui/packages/qaul_components/test/qaul_chat_bubble_test.dart
@@ -14,6 +14,13 @@ Finder _findTimestampText(WidgetTester tester) {
   );
 }
 
+Finder _findMessageRichText(String content) {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is RichText && widget.text.toPlainText().trim() == content,
+  );
+}
+
 void main() {
   group('computeChatBubbleDisplayItems', () {
     test('links messages from same sender and same minute', () {
@@ -467,6 +474,197 @@ void main() {
         moreOrLessEquals(
           ChatBubbleStyle.timeStyle.fontSize! * kChatBubbleMaxTextScaleFactor,
         ),
+      );
+    });
+  });
+
+  group('QaulChatBubble reply preview', () {
+    Widget app(QaulChatBubbleMessage message, DateTime clock) {
+      return MaterialApp(
+        home: Material(
+          child: QaulChatBubble(
+            message: message,
+            clock: clock,
+            showTimestamp: true,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders an outgoing reply to own message above content', (
+      tester,
+    ) async {
+      final clock = DateTime(2026, 4, 19, 10, 53);
+      final message = QaulChatBubbleMessage(
+        content: 'As I said earlier...',
+        sentAt: clock,
+        receivedAt: clock,
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [TailEdge.bottomEnd],
+        replyPreview: const ChatReplyPreviewData(
+          author: 'You',
+          content: 'This is about quoting myself.',
+        ),
+      );
+
+      await tester.pumpWidget(app(message, clock));
+
+      expect(find.byKey(const ValueKey('chat-reply-preview')), findsOneWidget);
+      expect(find.text('You'), findsOneWidget);
+      expect(find.text('This is about quoting myself.'), findsOneWidget);
+      expect(_findMessageRichText('As I said earlier...'), findsOneWidget);
+      expect(find.text('Now'), findsOneWidget);
+      expect(find.byIcon(Icons.done_all), findsOneWidget);
+
+      final previewPadding = tester.widget<Padding>(
+        find.descendant(
+          of: find.byKey(const ValueKey('chat-reply-preview')),
+          matching: find.byType(Padding),
+        ),
+      );
+      expect(
+        previewPadding.padding,
+        const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      );
+      final bubblePadding = tester.widget<Padding>(
+        find.byKey(const ValueKey('chat-bubble-padding')),
+      );
+      expect(
+        bubblePadding.padding,
+        const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+      );
+
+      final bubbleRect = tester.getRect(
+        find.byKey(const ValueKey('chat-bubble-surface')),
+      );
+      final messageRect = tester.getRect(
+        _findMessageRichText('As I said earlier...'),
+      );
+      final statusRect = tester.getRect(find.byIcon(Icons.done_all));
+      expect(messageRect.left - bubbleRect.left, 10);
+      expect(bubbleRect.right - statusRect.right, 10);
+
+      final previewTop = tester.getTopLeft(find.text('You')).dy;
+      final messageTop = tester
+          .getTopLeft(_findMessageRichText('As I said earlier...'))
+          .dy;
+      expect(previewTop, lessThan(messageTop));
+    });
+
+    testWidgets('renders an incoming reply to another user', (tester) async {
+      final clock = DateTime(2026, 4, 19, 10, 53);
+      final message = QaulChatBubbleMessage(
+        content: 'Written in the morning',
+        sentAt: clock.subtract(const Duration(minutes: 44)),
+        receivedAt: clock.subtract(const Duration(minutes: 44)),
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [TailEdge.bottomStart],
+        replyPreview: const ChatReplyPreviewData(
+          author: 'MaxX',
+          content: 'This is a quote sent by another user.',
+        ),
+      );
+
+      await tester.pumpWidget(app(message, clock));
+
+      expect(find.text('MaxX'), findsOneWidget);
+      expect(
+        find.text('This is a quote sent by another user.'),
+        findsOneWidget,
+      );
+      expect(_findMessageRichText('Written in the morning'), findsOneWidget);
+
+      final author = tester.widget<Text>(find.text('MaxX'));
+      expect(author.style!.color, Colors.white);
+    });
+
+    testWidgets('constrains and truncates a long reply excerpt', (
+      tester,
+    ) async {
+      final clock = DateTime(2026, 4, 19, 10, 53);
+      const excerpt =
+          'This is a very long replied message that should remain inside the '
+          'bubble and be truncated after a few lines instead of expanding the '
+          'timeline row indefinitely or overflowing its horizontal bounds.';
+      final message = QaulChatBubbleMessage(
+        content: 'Short response',
+        sentAt: clock,
+        receivedAt: clock,
+        status: MessageStatus.sent,
+        messageType: MessageType.primary,
+        edges: const [TailEdge.bottomEnd],
+        replyPreview: const ChatReplyPreviewData(
+          author: 'Another participant with a long name',
+          content: excerpt,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(320, 640)),
+            child: Material(
+              child: QaulChatBubble(
+                message: message,
+                clock: clock,
+                showTimestamp: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byKey(const ValueKey('chat-reply-preview'))).width,
+        lessThanOrEqualTo(
+          ChatBubbleStyle.maxBubbleWidthMobile -
+              ChatBubbleStyle.horizontalPadding * 2,
+        ),
+      );
+      final excerptText = tester.widget<Text>(find.text(excerpt));
+      expect(excerptText.maxLines, 3);
+      expect(excerptText.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('does not render reply UI without reply data', (tester) async {
+      final clock = DateTime(2026, 4, 19, 10, 53);
+      final message = QaulChatBubbleMessage(
+        content: 'Regular message',
+        sentAt: clock,
+        receivedAt: clock,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [TailEdge.bottomStart],
+      );
+
+      await tester.pumpWidget(app(message, clock));
+
+      expect(find.byKey(const ValueKey('chat-reply-preview')), findsNothing);
+      expect(_findMessageRichText('Regular message'), findsOneWidget);
+    });
+
+    testWidgets('keeps timestamp beside short text without reply data', (
+      tester,
+    ) async {
+      final clock = DateTime(2026, 4, 19, 10, 53);
+      final message = QaulChatBubbleMessage(
+        content: 'Hi',
+        sentAt: clock,
+        receivedAt: clock,
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [TailEdge.bottomStart],
+      );
+
+      await tester.pumpWidget(app(message, clock));
+
+      final messageRect = tester.getRect(_findMessageRichText('Hi'));
+      final timestampRect = tester.getRect(find.text('Now'));
+      expect(
+        timestampRect.left - messageRect.right,
+        ChatBubbleStyle.gapBetweenTextAndDate,
       );
     });
   });

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -12,6 +12,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:qaul_components_widgetbook/use_cases/components/chat/chat_message_context_menu.dart'
     as _qaul_components_widgetbook_use_cases_components_chat_chat_message_context_menu;
+import 'package:qaul_components_widgetbook/use_cases/components/chat/chat_reply_bubble_preview.dart'
+    as _qaul_components_widgetbook_use_cases_components_chat_chat_reply_bubble_preview;
 import 'package:qaul_components_widgetbook/use_cases/design/account/account_management.dart'
     as _qaul_components_widgetbook_use_cases_design_account_account_management;
 import 'package:qaul_components_widgetbook/use_cases/design/chat/chat_journey.dart'
@@ -190,6 +192,35 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _qaul_components_widgetbook_use_cases_components_chat_chat_message_context_menu
                         .buildManyActionsContextMenuUseCase,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'ChatReplyBubblePreview',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Incoming — another user',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_reply_bubble_preview
+                        .buildIncomingReplyToAnotherUserUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Incoming — own message',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_reply_bubble_preview
+                        .buildIncomingReplyToOwnMessageUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Outgoing — another user',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_reply_bubble_preview
+                        .buildOutgoingReplyToAnotherUserUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Outgoing — own message',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_reply_bubble_preview
+                        .buildOutgoingReplyToOwnMessageUseCase,
               ),
             ],
           ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/components/chat/chat_reply_bubble_preview.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/components/chat/chat_reply_bubble_preview.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+import '../../../support/widgetbook_preview.dart';
+
+final _clock = DateTime(2026, 4, 12, 14, 30);
+
+@widgetbook.UseCase(
+  name: 'Outgoing — own message',
+  type: ChatReplyBubblePreview,
+)
+Widget buildOutgoingReplyToOwnMessageUseCase(BuildContext context) {
+  return widgetbookChatComponentFrame(
+    context,
+    alignment: Alignment.centerLeft,
+    child: QaulChatBubble(
+      message: QaulChatBubbleMessage(
+        content: 'As I said earlier...',
+        sentAt: _clock.subtract(const Duration(minutes: 8)),
+        receivedAt: _clock.subtract(const Duration(minutes: 8)),
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [TailEdge.bottomEnd],
+        senderIdBase58: 'me',
+        replyPreview: const ChatReplyPreviewData(
+          author: 'You',
+          content: 'This is about quoting myself, which is actually possible.',
+        ),
+      ),
+      clock: _clock,
+      showTimestamp: true,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Outgoing — another user',
+  type: ChatReplyBubblePreview,
+)
+Widget buildOutgoingReplyToAnotherUserUseCase(BuildContext context) {
+  return widgetbookChatComponentFrame(
+    context,
+    alignment: Alignment.centerLeft,
+    child: QaulChatBubble(
+      message: QaulChatBubbleMessage(
+        content: 'I think this is the quote',
+        sentAt: _clock.subtract(const Duration(minutes: 18)),
+        receivedAt: _clock.subtract(const Duration(minutes: 18)),
+        status: MessageStatus.read,
+        messageType: MessageType.primary,
+        edges: const [TailEdge.bottomEnd],
+        senderIdBase58: 'me',
+        replyPreview: const ChatReplyPreviewData(
+          author: 'Group member 2',
+          content:
+              'This is a quote sent by another user in the group, and the '
+              'message is long enough to wrap.',
+        ),
+      ),
+      clock: _clock,
+      showTimestamp: true,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Incoming — own message',
+  type: ChatReplyBubblePreview,
+)
+Widget buildIncomingReplyToOwnMessageUseCase(BuildContext context) {
+  return widgetbookChatComponentFrame(
+    context,
+    alignment: Alignment.centerLeft,
+    child: QaulChatBubble(
+      message: QaulChatBubbleMessage(
+        content: 'That answers my question.',
+        sentAt: _clock.subtract(const Duration(minutes: 28)),
+        receivedAt: _clock.subtract(const Duration(minutes: 28)),
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [TailEdge.bottomStart],
+        senderIdBase58: 'them',
+        replyPreview: const ChatReplyPreviewData(
+          author: 'You',
+          content: 'Can this work in private chats too?',
+        ),
+      ),
+      clock: _clock,
+      showTimestamp: true,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Incoming — another user',
+  type: ChatReplyBubblePreview,
+)
+Widget buildIncomingReplyToAnotherUserUseCase(BuildContext context) {
+  return widgetbookChatComponentFrame(
+    context,
+    alignment: Alignment.centerLeft,
+    child: QaulChatBubble(
+      message: QaulChatBubbleMessage(
+        content: 'Written in the morning',
+        sentAt: _clock.subtract(const Duration(minutes: 44)),
+        receivedAt: _clock.subtract(const Duration(minutes: 44)),
+        status: MessageStatus.sent,
+        messageType: MessageType.secondary,
+        edges: const [TailEdge.bottomStart],
+        senderIdBase58: 'them',
+        replyPreview: const ChatReplyPreviewData(
+          author: 'MaxX',
+          content:
+              'This is a quote sent by another user and the message is too '
+              'long to display without truncation.',
+        ),
+      ),
+      clock: _clock,
+      showTimestamp: true,
+    ),
+  );
+}


### PR DESCRIPTION
## Description
Adds replied-message previews to incoming and outgoing chat bubbles, showing the original author and a truncated message excerpt while preserving the existing message, timestamp, and status layout. Includes Widgetbook examples and widget tests.

## Evidence
<img width="250" alt="Screenshot 2026-07-26 at 15 44 59" src="https://github.com/user-attachments/assets/04fae57b-1195-41ee-a60c-54ab2dbc84d0" />
<img width="250" alt="Screenshot 2026-07-26 at 15 44 50" src="https://github.com/user-attachments/assets/3f9829fd-bf9d-4663-9cc3-57c46db4c219" />

