### PR TITLE
Implement chat reply footer preview

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+
 import '../../styles/qaul_color_sheet.dart';
+import 'chat_footer_reply_preview.dart';
 
 const Color _kActionIconColor = Color(0xFF999999);
 const double _kInputBorderRadius = 15;
@@ -29,6 +31,7 @@ const double _kTextActionSpacing = 20;
 const double _kAttachmentIconSpacing = 24;
 const double _kActionButtonMinSize = 40;
 const double _kAttachmentMenuTopSpacing = 12;
+const double _kReplyPreviewBottomSpacing = 12;
 const double _kAttachmentMenuItemMaxSize = 45;
 const double _kAttachmentMenuItemMinSize = 35;
 const double _kAttachmentMenuArrowSize = 35;
@@ -159,6 +162,8 @@ class ChatFooter extends StatefulWidget {
     required this.placeholder,
     this.controller,
     this.onSend,
+    this.replyPreview,
+    this.onCancelReply,
     this.onVoicePressed,
     this.onCameraPressed,
     this.onMoreAttachmentsPressed,
@@ -168,6 +173,7 @@ class ChatFooter extends StatefulWidget {
     this.applyBottomSafeArea = true,
     this.initialAttachmentMenuOpen = false,
     this.sendTooltip,
+    this.cancelReplyTooltip,
     this.voiceTooltip,
     this.cameraTooltip,
     this.attachmentsTooltip,
@@ -180,6 +186,8 @@ class ChatFooter extends StatefulWidget {
 
   final TextEditingController? controller;
   final ValueChanged<String>? onSend;
+  final ChatFooterReplyPreviewData? replyPreview;
+  final VoidCallback? onCancelReply;
   final VoidCallback? onVoicePressed;
   final VoidCallback? onCameraPressed;
   final VoidCallback? onMoreAttachmentsPressed;
@@ -189,6 +197,7 @@ class ChatFooter extends StatefulWidget {
   final bool applyBottomSafeArea;
   final bool initialAttachmentMenuOpen;
   final String? sendTooltip;
+  final String? cancelReplyTooltip;
   final String? voiceTooltip;
   final String? cameraTooltip;
   final String? attachmentsTooltip;
@@ -421,6 +430,14 @@ class _ChatFooterState extends State<ChatFooter> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (widget.replyPreview != null) ...[
+            ChatFooterReplyPreview(
+              data: widget.replyPreview!,
+              onCancelReply: widget.onCancelReply,
+              cancelTooltip: widget.cancelReplyTooltip,
+            ),
+            const SizedBox(height: _kReplyPreviewBottomSpacing),
+          ],
           _ComposerPill(
             footer: widget,
             theme: theme,
@@ -446,7 +463,19 @@ class _ChatFooterState extends State<ChatFooter> {
     );
 
     return DecoratedBox(
-      decoration: BoxDecoration(color: shell, boxShadow: shadows),
+      key: const ValueKey('chat-footer-surface'),
+      decoration: BoxDecoration(
+        color: shell,
+        border: Border(
+          top: BorderSide(
+            color: theme.brightness == Brightness.dark
+                ? Colors.white
+                : const Color(0xFFD1D1D6),
+            width: 0.5,
+          ),
+        ),
+        boxShadow: shadows,
+      ),
       child: Material(
         color: Colors.transparent,
         child: widget.applyBottomSafeArea

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer_reply_preview.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer_reply_preview.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+/// Display-only data for the message currently selected as a reply target.
+@immutable
+class ChatFooterReplyPreviewData {
+  const ChatFooterReplyPreviewData({
+    required this.author,
+    required this.content,
+  });
+
+  final String author;
+  final String content;
+}
+
+/// Reply target shown above the chat composer.
+///
+/// This component is controlled by its parent and has no knowledge of message
+/// storage, navigation, or sending behavior.
+class ChatFooterReplyPreview extends StatelessWidget {
+  const ChatFooterReplyPreview({
+    super.key,
+    required this.data,
+    required this.onCancelReply,
+    this.cancelTooltip,
+  });
+
+  final ChatFooterReplyPreviewData data;
+  final VoidCallback? onCancelReply;
+  final String? cancelTooltip;
+
+  static const _darkBackground = Color(0xFF2C2C2E);
+  static const _lightBackground = Color(0xFFE5E5EA);
+  static const _darkText = Colors.white;
+  static const _lightText = Color(0xFF252525);
+  static const _horizontalPadding = 12.0;
+  static const _verticalPadding = 8.0;
+  static const _radius = 3.0;
+  static const _closeButtonSize = 40.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final textColor = isDark ? _darkText : _lightText;
+
+    return DecoratedBox(
+      key: const ValueKey('chat-footer-reply-preview'),
+      decoration: BoxDecoration(
+        color: isDark ? _darkBackground : _lightBackground,
+        borderRadius: BorderRadius.circular(_radius),
+      ),
+      child: Padding(
+        padding: const EdgeInsetsDirectional.only(
+          start: _horizontalPadding,
+          top: _verticalPadding,
+          bottom: _verticalPadding,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    data.author.trim(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: 'Roboto',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      height: 1.2,
+                      color: textColor,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    data.content.trim(),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: 'Roboto',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w400,
+                      height: 1.2,
+                      color: textColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox.square(
+              dimension: _closeButtonSize,
+              child: IconButton(
+                key: const ValueKey('cancel-chat-reply'),
+                tooltip:
+                    cancelTooltip ??
+                    MaterialLocalizations.of(context).closeButtonTooltip,
+                onPressed: onCancelReply,
+                icon: Icon(
+                  Icons.close,
+                  size: 24,
+                  color: textColor.withValues(alpha: 0.55),
+                ),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints.tightFor(
+                  width: _closeButtonSize,
+                  height: _closeButtonSize,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/qaul_ui/packages/qaul_components/lib/qaul_components.dart
+++ b/qaul_ui/packages/qaul_components/lib/qaul_components.dart
@@ -1,5 +1,6 @@
 export 'design_components/account/account_management.dart';
 export 'design_components/chat/chat_footer.dart';
+export 'design_components/chat/chat_footer_reply_preview.dart';
 export 'design_components/chat/chat_header.dart';
 export 'design_components/chat/chat_message_context_menu.dart';
 export 'design_components/chat/chat_room_list.dart';

--- a/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+void main() {
+  const reply = ChatFooterReplyPreviewData(
+    author: 'Group member 2',
+    content: 'Another answer',
+  );
+
+  Widget app({
+    ChatFooterReplyPreviewData? replyPreview,
+    VoidCallback? onCancelReply,
+    TextEditingController? controller,
+    ThemeData? theme,
+  }) {
+    return MaterialApp(
+      theme: theme,
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.bottomCenter,
+          child: ChatFooter(
+            placeholder: 'Secure private message',
+            controller: controller,
+            replyPreview: replyPreview,
+            onCancelReply: onCancelReply,
+            applyBottomSafeArea: false,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders the regular footer without reply data', (tester) async {
+    await tester.pumpWidget(app());
+
+    expect(
+      find.byKey(const ValueKey('chat-footer-reply-preview')),
+      findsNothing,
+    );
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.text('Secure private message'), findsOneWidget);
+  });
+
+  testWidgets('renders a themed divider above the entire footer', (
+    tester,
+  ) async {
+    Future<BorderSide> topDivider(ThemeData theme) async {
+      await tester.pumpWidget(app(theme: theme));
+      await tester.pumpAndSettle();
+      final surface = tester.widget<DecoratedBox>(
+        find.byKey(const ValueKey('chat-footer-surface')),
+      );
+      final border = (surface.decoration as BoxDecoration).border! as Border;
+      return border.top;
+    }
+
+    final darkTheme = ThemeData.dark();
+    final lightTheme = ThemeData.light();
+
+    final darkDivider = await topDivider(darkTheme);
+    expect(darkDivider.width, 0.5);
+    expect(darkDivider.color, darkTheme.colorScheme.onSurface);
+
+    final lightDivider = await topDivider(lightTheme);
+    expect(lightDivider.width, 0.5);
+    expect(lightDivider.color, const Color(0xFFD1D1D6));
+  });
+
+  testWidgets('renders reply target above an editable composer', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(app(replyPreview: reply, controller: controller));
+
+    expect(
+      find.byKey(const ValueKey('chat-footer-reply-preview')),
+      findsOneWidget,
+    );
+    expect(find.text('Group member 2'), findsOneWidget);
+    expect(find.text('Another answer'), findsOneWidget);
+
+    final previewTop = tester
+        .getTopLeft(find.byKey(const ValueKey('chat-footer-reply-preview')))
+        .dy;
+    final fieldTop = tester.getTopLeft(find.byType(TextField)).dy;
+    expect(previewTop, lessThan(fieldTop));
+
+    await tester.enterText(find.byType(TextField), 'Example for a reply');
+    expect(controller.text, 'Example for a reply');
+  });
+
+  testWidgets('cancel button triggers onCancelReply', (tester) async {
+    var cancelCount = 0;
+
+    await tester.pumpWidget(
+      app(replyPreview: reply, onCancelReply: () => cancelCount++),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('cancel-chat-reply')));
+    expect(cancelCount, 1);
+  });
+
+  testWidgets('long author and excerpt remain constrained', (tester) async {
+    const longAuthor =
+        'A participant with a display name that is much too long for the row';
+    const longContent =
+        'This is a long selected message that should be truncated after two '
+        'lines so the reply preview cannot expand the composer indefinitely.';
+
+    await tester.pumpWidget(
+      app(
+        replyPreview: const ChatFooterReplyPreviewData(
+          author: longAuthor,
+          content: longContent,
+        ),
+      ),
+    );
+
+    final authorText = tester.widget<Text>(find.text(longAuthor));
+    final contentText = tester.widget<Text>(find.text(longContent));
+    expect(authorText.maxLines, 1);
+    expect(authorText.overflow, TextOverflow.ellipsis);
+    expect(contentText.maxLines, 2);
+    expect(contentText.overflow, TextOverflow.ellipsis);
+  });
+
+  testWidgets('uses theme-appropriate preview surfaces', (tester) async {
+    Future<Color?> previewColor(ThemeData theme) async {
+      await tester.pumpWidget(app(replyPreview: reply, theme: theme));
+      await tester.pumpAndSettle();
+      final preview = tester.widget<DecoratedBox>(
+        find.byKey(const ValueKey('chat-footer-reply-preview')),
+      );
+      return (preview.decoration as BoxDecoration).color;
+    }
+
+    expect(await previewColor(ThemeData.dark()), const Color(0xFF2C2C2E));
+    expect(await previewColor(ThemeData.light()), const Color(0xFFE5E5EA));
+  });
+}

--- a/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
@@ -60,7 +60,7 @@ void main() {
 
     final darkDivider = await topDivider(darkTheme);
     expect(darkDivider.width, 0.5);
-    expect(darkDivider.color, darkTheme.colorScheme.onSurface);
+    expect(darkDivider.color, Colors.white);
 
     final lightDivider = await topDivider(lightTheme);
     expect(lightDivider.width, 0.5);

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -10,6 +10,8 @@
 // **************************************************************************
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:qaul_components_widgetbook/use_cases/components/chat/chat_footer_reply_preview.dart'
+    as _qaul_components_widgetbook_use_cases_components_chat_chat_footer_reply_preview;
 import 'package:qaul_components_widgetbook/use_cases/components/chat/chat_message_context_menu.dart'
     as _qaul_components_widgetbook_use_cases_components_chat_chat_message_context_menu;
 import 'package:qaul_components_widgetbook/use_cases/design/account/account_management.dart'
@@ -116,24 +118,6 @@ final directories = <_widgetbook.WidgetbookNode>[
                         .buildChatFooterEmptyOpenUseCase,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Light — empty actions',
-                builder:
-                    _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer
-                        .buildChatFooterLightEmptyClosedUseCase,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Light — submenu open',
-                builder:
-                    _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer
-                        .buildChatFooterLightEmptyOpenUseCase,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Light — with text',
-                builder:
-                    _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer
-                        .buildChatFooterLightWithTextUseCase,
-              ),
-              _widgetbook.WidgetbookUseCase(
                 name: 'Long draft (multiline)',
                 builder:
                     _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer
@@ -144,6 +128,29 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer
                         .buildChatFooterWithTextUseCase,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'ChatFooterReplyPreview',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Empty draft',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_footer_reply_preview
+                        .buildReplyFooterEmptyUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Long excerpt',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_footer_reply_preview
+                        .buildLongReplyFooterUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With draft',
+                builder:
+                    _qaul_components_widgetbook_use_cases_components_chat_chat_footer_reply_preview
+                        .buildReplyFooterDraftUseCase,
               ),
             ],
           ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/components/chat/chat_footer_reply_preview.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/components/chat/chat_footer_reply_preview.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+const _reply = ChatFooterReplyPreviewData(
+  author: 'Group member 2',
+  content: 'Another answer',
+);
+
+Widget _frame(BuildContext context, Widget child) {
+  final sheet = QaulColorSheet(Theme.of(context).brightness);
+  return Material(
+    child: ColoredBox(
+      color: sheet.surfaceContainer,
+      child: Column(
+        children: [
+          const Expanded(child: SizedBox.expand()),
+          child,
+        ],
+      ),
+    ),
+  );
+}
+
+ChatFooter _footer({
+  ChatFooterReplyPreviewData reply = _reply,
+  TextEditingController? controller,
+}) {
+  return ChatFooter(
+    placeholder: 'Secure private message',
+    replyPreview: reply,
+    onCancelReply: () {},
+    controller: controller,
+    onSend: (_) {},
+    onMoreAttachmentsPressed: () {},
+    cancelReplyTooltip: 'Cancel reply',
+    sendTooltip: 'Send',
+  );
+}
+
+@widgetbook.UseCase(name: 'Empty draft', type: ChatFooterReplyPreview)
+Widget buildReplyFooterEmptyUseCase(BuildContext context) {
+  return _frame(context, _footer());
+}
+
+@widgetbook.UseCase(name: 'With draft', type: ChatFooterReplyPreview)
+Widget buildReplyFooterDraftUseCase(BuildContext context) {
+  return _frame(
+    context,
+    _footer(controller: TextEditingController(text: 'Example for a reply')),
+  );
+}
+
+@widgetbook.UseCase(name: 'Long excerpt', type: ChatFooterReplyPreview)
+Widget buildLongReplyFooterUseCase(BuildContext context) {
+  return _frame(
+    context,
+    _footer(
+      reply: const ChatFooterReplyPreviewData(
+        author: 'A participant with a very long display name',
+        content:
+            'This selected message is intentionally long so the preview can '
+            'demonstrate truncation without breaking the composer layout.',
+      ),
+    ),
+  );
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design_components/chat/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design_components/chat/chat_footer.dart
@@ -6,13 +6,6 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 /// should pass `AppLocalizations.of(context).securePrivateMessageHint`).
 const String _kPlaceholderEn = 'Secure private message';
 
-Widget _lightFooter(Widget child) {
-  return Theme(
-    data: QaulAppTheme.light,
-    child: Builder(builder: (context) => _frameFooter(context, child)),
-  );
-}
-
 Widget _frameFooter(BuildContext context, Widget child) {
   final sheet = QaulColorSheet(Theme.of(context).brightness);
   return Material(
@@ -24,66 +17,6 @@ Widget _frameFooter(BuildContext context, Widget child) {
           child,
         ],
       ),
-    ),
-  );
-}
-
-@widgetbook.UseCase(name: 'Light — empty actions', type: ChatFooter)
-Widget buildChatFooterLightEmptyClosedUseCase(BuildContext context) {
-  return _lightFooter(
-    ChatFooter(
-      placeholder: _kPlaceholderEn,
-      onSend: (_) {},
-      onVoicePressed: () {},
-      onCameraPressed: () {},
-      onMoreAttachmentsPressed: () {},
-      onAttachmentPressed: () {},
-      onEmojiPressed: () {},
-      onLocationPressed: () {},
-      voiceTooltip: 'Voice message',
-      cameraTooltip: 'Photo',
-      attachmentsTooltip: 'More',
-      emojiTooltip: 'Emoji',
-      locationTooltip: 'Location',
-      sendTooltip: 'Send',
-    ),
-  );
-}
-
-@widgetbook.UseCase(name: 'Light — submenu open', type: ChatFooter)
-Widget buildChatFooterLightEmptyOpenUseCase(BuildContext context) {
-  return _lightFooter(
-    ChatFooter(
-      placeholder: _kPlaceholderEn,
-      initialAttachmentMenuOpen: true,
-      onSend: (_) {},
-      onVoicePressed: () {},
-      onCameraPressed: () {},
-      onMoreAttachmentsPressed: () {},
-      onAttachmentPressed: () {},
-      onEmojiPressed: () {},
-      onLocationPressed: () {},
-      voiceTooltip: 'Voice message',
-      cameraTooltip: 'Photo',
-      attachmentsTooltip: 'Attachment',
-      emojiTooltip: 'Emoji',
-      locationTooltip: 'Location',
-      sendTooltip: 'Send',
-    ),
-  );
-}
-
-@widgetbook.UseCase(name: 'Light — with text', type: ChatFooter)
-Widget buildChatFooterLightWithTextUseCase(BuildContext context) {
-  return _lightFooter(
-    ChatFooter(
-      placeholder: _kPlaceholderEn,
-      controller: TextEditingController(text: 'Start writing a message'),
-      onSend: (_) {},
-      onVoicePressed: () {},
-      onCameraPressed: () {},
-      onMoreAttachmentsPressed: () {},
-      sendTooltip: 'Send',
     ),
   );
 }


### PR DESCRIPTION
## Description
Adds a reply preview above the chat composer, displaying the original message author and excerpt with an option to cancel the reply. Includes themed styling, Widgetbook examples, and widget tests.

## Evidence
<img width="250"  alt="Screenshot 2026-07-27 at 11 53 01" src="https://github.com/user-attachments/assets/95448f31-47a1-4626-a8ef-4b3fdd2a6312" />
