### PR TITLE
feat(crypto): enforce the final-nonce boundary on the draining session

### DIFF
--- a/docs/protocols/Noise-Session-Rotation.md
+++ b/docs/protocols/Noise-Session-Rotation.md
@@ -87,12 +87,12 @@ Every encrypted payload carries `session_id`, so receiver logic is straightforwa
 | Incoming `session_id` | Behaviour |
 |---|---|
 | matches `primary` | decrypt with primary, normal path. |
-| matches `draining` (and not yet expired) | decrypt with draining, normal out-of-order handling. Decrement `draining_remaining_volume`. |
-| matches `draining` (already expired) | drop, emit `MessageDroppedPastGrace`. |
-| matches `last_retired_session_id` | drop, emit `MessageDroppedPastGrace` — UI surfaces "message expired, ask sender to resend." |
+| matches `draining`, nonce ≤ declared final (`draining_recv_target`) | decrypt with draining, normal out-of-order handling; record the nonce in the drain bitmap. |
+| matches `draining`, nonce > declared final | **refuse** before decrypting, emit `MessageDroppedPostDrain`. The cut-over ACK fixed the last legitimate old-session nonce; a sender overrunning it is not accepted. While the final nonce is still unknown (ACK not yet received) nothing is refused. |
+| matches `last_retired_session_id` | drop, emit `MessageDroppedPostDrain` — UI surfaces "message expired, ask sender to resend." |
 | unknown, from a peer with an active session | treat as a fresh first-handshake attempt. |
 
-This keeps the UX clean for the common failure mode: a message sent under session N, crossed a rotation boundary, and arrived during N's grace window or shortly after.
+This is the *final-nonce boundary* from the 1st-July rotation spec: the in-flight tail up to the sender's declared final nonce stays deliverable across the rotation, but nothing above it is accepted, so a peer cannot keep the old session alive indefinitely by continuing to send on it.
 
 ## State
 

--- a/rust/libqaul/src/services/crypto/mod.rs
+++ b/rust/libqaul/src/services/crypto/mod.rs
@@ -632,6 +632,21 @@ impl Crypto {
         Self::fire_rotation_if_triggered(state, user_account, crypto_account, remote_id);
     }
 
+    /// Whether an inbound transport frame must be refused because it
+    /// arrived on the draining session with a nonce above the peer's
+    /// declared final (learned from the rotation cut-over frames).
+    ///
+    /// Spec (Crypto Session Rotation Update, 1st July): the cut-over
+    /// ACK references the nonce of the last message sent via the old
+    /// session; after that, no message with a higher nonce is accepted
+    /// on it. While the final nonce is still unknown nothing is refused
+    /// — the peer may legitimately keep sending on the old session
+    /// until it promotes.
+    fn refuse_beyond_final_nonce(meta: &RotationMeta, session_id: u32, nonce: u64) -> bool {
+        Some(session_id) == meta.draining_session_id
+            && matches!(meta.draining_recv_target, Some(target) if nonce > target)
+    }
+
     /// Retire the draining session for `remote_id` iff it is safe to:
     /// the inbound drain is complete (every nonce up to the peer's
     /// declared final has arrived) AND none of this node's outbound
@@ -789,6 +804,36 @@ impl Crypto {
                         );
 
                         let session_id = session.session_id;
+
+                        // Final-nonce boundary: on the draining session,
+                        // frames above the peer's declared final nonce
+                        // are refused (the cut-over ACK fixed the last
+                        // legitimate old-session nonce). Distinct from the
+                        // already-retired-session drop below: here the
+                        // session is still draining but the sender has
+                        // overrun its declared tail.
+                        if let Some(meta) = crypto_account.get_rotation_meta(remote_id) {
+                            if message.data.iter().any(|data| {
+                                Self::refuse_beyond_final_nonce(&meta, session_id, data.nonce)
+                            }) {
+                                log::info!(
+                                    "refusing message beyond final nonce on draining session {} from {}",
+                                    session_id,
+                                    remote_id.to_base58()
+                                );
+                                events::record_and_emit(
+                                    Some(state),
+                                    events::RotationEvent {
+                                        kind: events::RotationEventKind::MessageDroppedPostDrain,
+                                        remote_id,
+                                        primary_session_id: meta.primary_session_id,
+                                        draining_session_id: session_id,
+                                        timestamp_ms: 0,
+                                    },
+                                );
+                                return None;
+                            }
+                        }
 
                         // decrypt transport message
                         for data in message.data {
@@ -1697,6 +1742,62 @@ mod phase2_tests {
 
         let meta = acct.get_rotation_meta(remote).unwrap();
         assert_eq!(meta, original);
+    }
+
+    // ── final-nonce boundary refusal ──
+    //
+    // Spec (Crypto Session Rotation Update, 1st July): the cut-over
+    // ACK references the nonce of the last message sent via the old
+    // session, and the receiver "then refuses to accept any additional
+    // message with a higher NONCE" on that session.
+
+    // On the draining session with a known final-nonce target, frames
+    // above the target are refused; frames at or below it are not.
+    #[test]
+    fn refuses_nonce_beyond_declared_final_on_draining() {
+        let meta = RotationMeta {
+            primary_session_id: 100,
+            draining_session_id: Some(50),
+            draining_recv_target: Some(7),
+            draining_recv_base: 0,
+            ..Default::default()
+        };
+        // in-flight tail up to the declared final: accepted
+        assert!(!Crypto::refuse_beyond_final_nonce(&meta, 50, 6));
+        assert!(!Crypto::refuse_beyond_final_nonce(&meta, 50, 7));
+        // beyond the declared final: refused
+        assert!(Crypto::refuse_beyond_final_nonce(&meta, 50, 8));
+        assert!(Crypto::refuse_beyond_final_nonce(&meta, 50, u64::MAX));
+    }
+
+    // While the final nonce is not yet known (ACK not yet received),
+    // nothing is refused — the peer may legitimately still be sending
+    // on the old session before it promotes.
+    #[test]
+    fn no_refusal_while_final_nonce_unknown() {
+        let meta = RotationMeta {
+            primary_session_id: 100,
+            draining_session_id: Some(50),
+            draining_recv_target: None,
+            draining_recv_base: 0,
+            ..Default::default()
+        };
+        assert!(!Crypto::refuse_beyond_final_nonce(&meta, 50, u64::MAX));
+    }
+
+    // The boundary only applies to the draining session — the primary
+    // and unrelated sessions are never refused by it.
+    #[test]
+    fn refusal_only_applies_to_draining_session() {
+        let meta = RotationMeta {
+            primary_session_id: 100,
+            draining_session_id: Some(50),
+            draining_recv_target: Some(7),
+            draining_recv_base: 0,
+            ..Default::default()
+        };
+        assert!(!Crypto::refuse_beyond_final_nonce(&meta, 100, 999));
+        assert!(!Crypto::refuse_beyond_final_nonce(&meta, 99, 999));
     }
 
     // Cold re-key supersede: a fresh handshake session must replace any


### PR DESCRIPTION
Implements the receiver-side rule from the **Crypto Session Rotation Update, 1st July**: the cut-over ACK references the nonce of the last message sent via the old session, and the receiver then **refuses any further message on that session with a higher nonce**.

## Why this is a new PR

Main already ships the clock-free nonce-drain rotation (base machinery merged via #853). The cut-over frames declare `final_nonce_out` and the receiver accepts the in-flight tail up to `draining_recv_target` — but it never **rejected** frames *above* that boundary, so a peer could keep the old (draining) session alive indefinitely by continuing to send on it. The spec forbids that.

This increment sat on `feat/crypto-session-rotation`, whose PR (#853) is already merged, so it had no open PR. Ported cleanly onto current main's structures.

## What it does

- `refuse_beyond_final_nonce(meta, session_id, nonce)` — true only on the draining session when `nonce > draining_recv_target`.
- The decrypt path refuses such frames **before decryption** and emits `MessageDroppedPostDrain`.
- While the final nonce is still unknown (ACK not yet received) nothing is refused — the peer may legitimately keep sending on the old session until it promotes.
- Distinct from the existing already-retired-session drop: there the session no longer exists; here it is still draining but the sender overran its declared tail.

## Tests

Three boundary cases: refuse above final, accept at/below, no refusal while final unknown (plus primary/unrelated never affected). Full libqaul suite green (139), workspace builds clean, no warnings.

## Note for the reviewer

The receiver-routing table in `docs/protocols/Noise-Session-Rotation.md` is updated to the nonce-drain + refusal reality. The **rest of that doc still carries stale wall-clock-grace text** (`grace_period_seconds`, `GraceExpired`, `draining_until`) that predates this PR — it was left stale when the nonce-drain landed via #853. A full doc reconciliation is intentionally out of scope here to keep this PR focused on the spec-compliance change.