### PR TITLE
Implement chat reply flow integration

### DIFF
--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
@@ -713,6 +713,7 @@ class _SendButton extends StatelessWidget {
     return _wrapTooltip(
       tooltip,
       IconButton(
+        key: const ValueKey('chat-footer-send'),
         onPressed: onPressed,
         icon: const _ChatFooterSvgIcon(
           asset: _kSendSvg,

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer.dart
@@ -467,12 +467,7 @@ class _ChatFooterState extends State<ChatFooter> {
       decoration: BoxDecoration(
         color: shell,
         border: Border(
-          top: BorderSide(
-            color: theme.brightness == Brightness.dark
-                ? Colors.white
-                : const Color(0xFFD1D1D6),
-            width: 0.5,
-          ),
+          top: BorderSide(color: sheet.chatFooterDivider, width: 0.5),
         ),
         boxShadow: shadows,
       ),

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_header.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_header.dart
@@ -4,7 +4,6 @@ import '../../l10n/qaul_components_l10n_ext.dart';
 import '../../styles/qaul_color_sheet.dart';
 
 const Color _kChatHeaderControlColor = Color(0xFF999999);
-const Color _kChatHeaderDividerColor = Color(0xFF9E9E9E);
 const double _kChatHeaderDividerWidth = 0.5;
 const Color _kOnlineColor = Color(0xFF34C759);
 
@@ -30,12 +29,8 @@ Color _chatHeaderShellColor(ThemeData theme) {
   return sheet.background;
 }
 
-/// The bottom divider is a dark-mode affordance. In light mode it blends into
-/// the header background so it reads as invisible.
 Color _chatHeaderDividerColor(ThemeData theme) {
-  return theme.brightness == Brightness.dark
-      ? _kChatHeaderDividerColor
-      : _chatHeaderShellColor(theme);
+  return QaulColorSheet(theme.brightness).chatHeaderDivider;
 }
 
 Color _chatHeaderTextColor(ThemeData theme) => theme.colorScheme.onSurface;
@@ -241,6 +236,7 @@ class ChatHeader extends StatelessWidget {
         : header;
 
     return DecoratedBox(
+      key: const ValueKey('chat-header-surface'),
       decoration: BoxDecoration(
         color: _chatHeaderShellColor(theme),
         border: Border(

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_message_context_menu.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_message_context_menu.dart
@@ -11,6 +11,10 @@ const _kDisabledLightColor = Color(0xFFC7C7C7);
 const _kMenuPageSize = 5;
 const _kRowHeight = 49.0;
 
+abstract final class ChatMessageContextMenuStyle {
+  static const quickReactionFontSize = 27.0;
+}
+
 /// Asset paths for the actions supplied with [ChatMessageContextMenu].
 abstract final class ChatMessageContextMenuIcons {
   static const reply = 'assets/icons/sub_menu/reply_arrow.svg';
@@ -162,7 +166,7 @@ class ChatMessageContextMenu extends StatefulWidget {
 
   final List<ChatMessageContextMenuElement> elements;
 
-  static const double width = 216;
+  static const double width = 200;
 
   @override
   State<ChatMessageContextMenu> createState() => _ChatMessageContextMenuState();
@@ -324,7 +328,12 @@ class _ReactionButton extends StatelessWidget {
               onPressed: enabled ? reaction.onPressed : null,
               icon: Opacity(
                 opacity: !enabled ? 0.28 : (hovered ? 1.0 : 0.72),
-                child: reaction.child,
+                child: DefaultTextStyle.merge(
+                  style: const TextStyle(
+                    fontSize: ChatMessageContextMenuStyle.quickReactionFontSize,
+                  ),
+                  child: reaction.child,
+                ),
               ),
               iconSize: 30,
               padding: EdgeInsets.zero,

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_timeline.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_timeline.dart
@@ -11,6 +11,9 @@ import 'message_presentation_meta.dart';
 import 'qaul_chat_bubble.dart';
 import 'room_meta_message.dart';
 
+typedef ChatTextMessageLongPressStart =
+    void Function(model.TextChatMessage message, Offset globalPosition);
+
 /// A design-system-friendly chat timeline widget.
 ///
 /// Consumers own the scroll context; this widget renders a plain [Column].
@@ -24,6 +27,8 @@ class ChatTimeline extends StatelessWidget {
     required this.messages,
     this.clock,
     this.padding = const EdgeInsets.all(16),
+    this.onTextMessageLongPressStart,
+    this.selectedTextMessageId,
   }) : _mode = ChatRenderMode.direct;
 
   /// Creates a group chat timeline. Sender identity is derived from each
@@ -34,6 +39,8 @@ class ChatTimeline extends StatelessWidget {
     required this.messages,
     this.clock,
     this.padding = const EdgeInsets.all(16),
+    this.onTextMessageLongPressStart,
+    this.selectedTextMessageId,
   }) : _mode = ChatRenderMode.group;
 
   final ChatUser currentUser;
@@ -45,6 +52,14 @@ class ChatTimeline extends StatelessWidget {
 
   /// Outer inset around the timeline column (matches legacy [ChatRoom]).
   final EdgeInsetsGeometry padding;
+
+  /// Notifies the screen parent that a text message was selected.
+  ///
+  /// The timeline does not own selection state or contextual actions.
+  final ChatTextMessageLongPressStart? onTextMessageLongPressStart;
+
+  /// Message currently highlighted by a screen-owned contextual selection.
+  final String? selectedTextMessageId;
 
   final ChatRenderMode _mode;
 
@@ -127,6 +142,7 @@ class ChatTimeline extends StatelessWidget {
                 : MessageType.secondary,
             edges: const [],
             senderIdBase58: e.message.sender.id,
+            replyPreview: e.message.replyPreview,
           ),
         ),
     ];
@@ -210,11 +226,24 @@ class ChatTimeline extends StatelessWidget {
             computation: computation,
           );
 
+          final bubble = ChatMessageRenderer.renderText(
+            presentation: presentation,
+            mode: _mode,
+            clock: effectiveClock,
+            isSelected: message.id == selectedTextMessageId,
+          );
+
           children.add(
-            ChatMessageRenderer.renderText(
-              presentation: presentation,
-              mode: _mode,
-              clock: effectiveClock,
+            GestureDetector(
+              key: ValueKey('chat-message-${message.id}'),
+              behavior: HitTestBehavior.opaque,
+              onLongPressStart: onTextMessageLongPressStart == null
+                  ? null
+                  : (details) => onTextMessageLongPressStart!(
+                      message,
+                      details.globalPosition,
+                    ),
+              child: bubble,
             ),
           );
           isFirst = false;

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/group_chat_messages.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/group_chat_messages.dart
@@ -54,18 +54,24 @@ class ChatMessageRenderer {
     required MessagePresentation presentation,
     required ChatRenderMode mode,
     required DateTime clock,
+    bool isSelected = false,
   }) {
     final display = presentation.bubbleDisplay;
     if (display == null) return const SizedBox.shrink();
 
     if (mode == ChatRenderMode.group && !presentation.isPrimary) {
-      return GroupTextMessageItem(presentation: presentation, clock: clock);
+      return GroupTextMessageItem(
+        presentation: presentation,
+        clock: clock,
+        isSelected: isSelected,
+      );
     }
 
     return DirectTextMessageItem(
       presentation: presentation,
       clock: clock,
       horizontalGutter: true,
+      isSelected: isSelected,
     );
   }
 
@@ -94,10 +100,12 @@ class DirectTextMessageItem extends StatelessWidget {
     required this.presentation,
     required this.clock,
     this.horizontalGutter = true,
+    this.isSelected = false,
   });
 
   final MessagePresentation presentation;
   final DateTime clock;
+  final bool isSelected;
 
   /// When true, applies a 16px gutter on the trailing edge for primary
   /// (outgoing) bubbles and on the leading edge for secondary (incoming).
@@ -118,6 +126,7 @@ class DirectTextMessageItem extends StatelessWidget {
         message: display.message,
         clock: clock,
         showTimestamp: presentation.meta.showTimestamp,
+        isSelected: isSelected,
       ),
     );
   }
@@ -128,10 +137,12 @@ class GroupTextMessageItem extends StatelessWidget {
     super.key,
     required this.presentation,
     required this.clock,
+    this.isSelected = false,
   });
 
   final MessagePresentation presentation;
   final DateTime clock;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -156,6 +167,7 @@ class GroupTextMessageItem extends StatelessWidget {
         message: bubbleMessage,
         clock: clock,
         showTimestamp: presentation.meta.showTimestamp,
+        isSelected: isSelected,
       ),
     );
   }

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/qaul_chat_bubble.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../styles/qaul_color_sheet.dart';
 import 'chat_message.dart';
 import 'chat_reply_bubble_preview.dart';
 
@@ -40,6 +41,7 @@ class ChatBubbleStyle {
   static const verticalPadding = 6.0;
   static const replyBubbleVerticalPadding = 10.0;
   static const gapAfterReplyPreview = 6.0;
+  static const selectedOutlineWidth = 2.0;
 
   static const gapBetweenTextAndDate = 4.0;
 
@@ -196,6 +198,7 @@ class QaulChatBubble extends StatelessWidget {
     required this.message,
     required this.clock,
     this.showTimestamp = true,
+    this.isSelected = false,
   });
 
   final QaulChatBubbleMessage message;
@@ -205,6 +208,7 @@ class QaulChatBubble extends StatelessWidget {
   final DateTime clock;
 
   final bool showTimestamp;
+  final bool isSelected;
 
   Widget? _buildStatusIcon(Color textColor, double iconSize) {
     switch (message.status) {
@@ -230,6 +234,7 @@ class QaulChatBubble extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isPrimary = message.messageType == MessageType.primary;
+    final sheet = QaulColorSheet(Theme.of(context).brightness);
 
     final width = MediaQuery.sizeOf(context).width;
     final isMobile = width < kChatBubbleWidthBreakpoint;
@@ -278,6 +283,12 @@ class QaulChatBubble extends StatelessWidget {
           decoration: BoxDecoration(
             color: backgroundColor,
             borderRadius: borderRadius,
+            border: isSelected
+                ? Border.all(
+                    color: sheet.chatBubbleSelectionOutline,
+                    width: ChatBubbleStyle.selectedOutlineWidth,
+                  )
+                : null,
           ),
           child: Padding(
             key: const ValueKey('chat-bubble-padding'),

--- a/qaul_ui/packages/qaul_components/lib/models/chat_message.dart
+++ b/qaul_ui/packages/qaul_components/lib/models/chat_message.dart
@@ -1,3 +1,4 @@
+import '../design_components/chat/chat_reply_bubble_preview.dart';
 import '../design_components/chat/qaul_chat_bubble.dart' show MessageStatus;
 import 'chat_user.dart';
 
@@ -16,6 +17,7 @@ class TextChatMessage extends ChatMessage {
     required this.sentAt,
     required this.receivedAt,
     required this.status,
+    this.replyPreview,
   });
 
   @override
@@ -25,6 +27,7 @@ class TextChatMessage extends ChatMessage {
   final DateTime sentAt;
   final DateTime receivedAt;
   final MessageStatus status;
+  final ChatReplyPreviewData? replyPreview;
 }
 
 /// Caller-supplied event meta, pre-formatted for i18n.

--- a/qaul_ui/packages/qaul_components/lib/styles/qaul_color_sheet.dart
+++ b/qaul_ui/packages/qaul_components/lib/styles/qaul_color_sheet.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 class QaulColorSheet {
   const QaulColorSheet(this.brightness);
 
+  static const _lightChatDivider = Color(0xFFD1D1D6);
+  static const _darkHeaderDivider = Color(0xFF9E9E9E);
+
   final Brightness brightness;
 
   bool get _isDark => brightness == Brightness.dark;
@@ -11,4 +14,11 @@ class QaulColorSheet {
 
   Color get surfaceContainer =>
       _isDark ? const Color(0xFF333333) : const Color(0xFFE5E5E5);
+
+  Color get chatBubbleSelectionOutline => _isDark ? Colors.white : Colors.black;
+
+  Color get chatFooterDivider => _isDark ? Colors.white : _lightChatDivider;
+
+  Color get chatHeaderDivider =>
+      _isDark ? _darkHeaderDivider : _lightChatDivider;
 }

--- a/qaul_ui/packages/qaul_components/test/chat_header_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_header_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+
+void main() {
+  Future<BorderSide> headerDivider(WidgetTester tester, ThemeData theme) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: ChatHeader(
+            applyTopSafeArea: false,
+            onBackPressed: () {},
+            avatar: const CircleAvatar(child: Text('M')),
+            displayName: 'MaxX',
+            isOnline: true,
+            onlineLabel: 'online',
+            lastSeenLabel: '',
+          ),
+        ),
+      ),
+    );
+
+    final surface = tester.widget<DecoratedBox>(
+      find.byKey(const ValueKey('chat-header-surface')),
+    );
+    final border = (surface.decoration as BoxDecoration).border! as Border;
+    return border.bottom;
+  }
+
+  testWidgets('uses the shared light chat divider', (tester) async {
+    final divider = await headerDivider(tester, ThemeData.light());
+
+    expect(divider.width, 0.5);
+    expect(divider.color, const Color(0xFFD1D1D6));
+    expect(
+      divider.color,
+      const QaulColorSheet(Brightness.light).chatHeaderDivider,
+    );
+  });
+
+  testWidgets('preserves the dark header divider', (tester) async {
+    final divider = await headerDivider(tester, ThemeData.dark());
+
+    expect(divider.width, 0.5);
+    expect(
+      divider.color,
+      const QaulColorSheet(Brightness.dark).chatHeaderDivider,
+    );
+  });
+}

--- a/qaul_ui/packages/qaul_components/test/chat_message_context_menu_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_message_context_menu_test.dart
@@ -68,6 +68,11 @@ void main() {
     );
 
     expect(tester.getSize(find.byTooltip('Love')), const Size.square(40));
+    final reactionText = tester.renderObject<RenderParagraph>(find.text('❤️'));
+    expect(
+      reactionText.text.style?.fontSize,
+      ChatMessageContextMenuStyle.quickReactionFontSize,
+    );
     expect(find.byTooltip('Next page'), findsNothing);
     await tester.tap(find.byTooltip('Love'));
     await tester.tap(find.text('Reply'));

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/main.directories.g.dart
@@ -20,6 +20,8 @@ import 'package:qaul_components_widgetbook/use_cases/design/account/account_mana
     as _qaul_components_widgetbook_use_cases_design_account_account_management;
 import 'package:qaul_components_widgetbook/use_cases/design/chat/chat_journey.dart'
     as _qaul_components_widgetbook_use_cases_design_chat_chat_journey;
+import 'package:qaul_components_widgetbook/use_cases/design/chat/reply_journey/reply_journey.dart'
+    as _qaul_components_widgetbook_use_cases_design_chat_reply_journey_reply_journey;
 import 'package:qaul_components_widgetbook/use_cases/design_components/chat/chat_footer.dart'
     as _qaul_components_widgetbook_use_cases_design_components_chat_chat_footer;
 import 'package:qaul_components_widgetbook/use_cases/design_components/chat/chat_header.dart'
@@ -91,6 +93,28 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _qaul_components_widgetbook_use_cases_design_chat_chat_journey
                         .buildChatJourneyPlusMenuUseCase,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookFolder(
+            name: 'reply_journey',
+            children: [
+              _widgetbook.WidgetbookComponent(
+                name: 'ChatReplyJourney',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'Direct chat',
+                    builder:
+                        _qaul_components_widgetbook_use_cases_design_chat_reply_journey_reply_journey
+                            .buildDirectReplyJourneyUseCase,
+                  ),
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'Group chat',
+                    builder:
+                        _qaul_components_widgetbook_use_cases_design_chat_reply_journey_reply_journey
+                            .buildGroupReplyJourneyUseCase,
+                  ),
+                ],
               ),
             ],
           ),
@@ -189,7 +213,7 @@ final directories = <_widgetbook.WidgetbookNode>[
                         .buildContextMenuUseCase,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Disabled and hidden elements',
+                name: 'Disabled and omitted elements',
                 builder:
                     _qaul_components_widgetbook_use_cases_components_chat_chat_message_context_menu
                         .buildRestrictedContextMenuUseCase,
@@ -290,6 +314,12 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _qaul_components_widgetbook_use_cases_special_forms_qaul_chat_bubble
                         .buildIncomingShortUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive — long press',
+                builder:
+                    _qaul_components_widgetbook_use_cases_special_forms_qaul_chat_bubble
+                        .buildInteractiveLongPressUseCase,
               ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Outgoing — not sent',

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/support/chat_fixtures.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/support/chat_fixtures.dart
@@ -137,7 +137,7 @@ List<ChatMessage> buildDirectChatFixtureMessages({
     chatFixtureTextMessage(
       id: 'direct-12',
       sender: peer,
-      content: '**Markdown** _preview_ message for bubble spacing context',
+      content: 'Reply preview message for bubble spacing context',
       sentAt: clock.subtract(const Duration(seconds: 20)),
     ),
     chatFixtureTextMessage(

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/components/chat/chat_message_context_menu.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/components/chat/chat_message_context_menu.dart
@@ -9,17 +9,17 @@ ChatMessageReactionRow _reactions({bool enabled = true}) {
     enabled: enabled,
     reactions: [
       ChatMessageQuickReaction(
-        child: const Text('❤️', style: TextStyle(fontSize: 27)),
+        child: const Text('❤️'),
         semanticLabel: 'Love',
         onPressed: () {},
       ),
       ChatMessageQuickReaction(
-        child: const Text('👍', style: TextStyle(fontSize: 27)),
+        child: const Text('👍'),
         semanticLabel: 'Like',
         onPressed: () {},
       ),
       ChatMessageQuickReaction(
-        child: const Text('🔥', style: TextStyle(fontSize: 27)),
+        child: const Text('🔥'),
         semanticLabel: 'Fire',
         onPressed: () {},
       ),

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design/chat/reply_journey/reply_journey.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/design/chat/reply_journey/reply_journey.dart
@@ -1,0 +1,371 @@
+import 'package:flutter/material.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+import '../../../../support/chat_fixtures.dart';
+import '../../../../support/widgetbook_preview.dart';
+
+/// UI-only parent that connects message selection, reply composition, and the
+/// resulting reply bubble.
+///
+/// Messages sent here are held locally. This component deliberately has no
+/// backend, protocol, storage, or navigation knowledge.
+class ChatReplyJourney extends StatefulWidget {
+  const ChatReplyJourney.direct({
+    super.key,
+    required this.currentUser,
+    required this.initialMessages,
+    required this.placeholder,
+    this.clock,
+    this.currentUserReplyLabel,
+    this.quickReactions = const [],
+    this.onAddReaction,
+    this.sendTooltip,
+    this.cancelReplyTooltip,
+    this.onMessageSent,
+  }) : mode = ChatRenderMode.direct;
+
+  const ChatReplyJourney.group({
+    super.key,
+    required this.currentUser,
+    required this.initialMessages,
+    required this.placeholder,
+    this.clock,
+    this.currentUserReplyLabel,
+    this.quickReactions = const [],
+    this.onAddReaction,
+    this.sendTooltip,
+    this.cancelReplyTooltip,
+    this.onMessageSent,
+  }) : mode = ChatRenderMode.group;
+
+  final ChatUser currentUser;
+  final List<ChatMessage> initialMessages;
+  final String placeholder;
+  final DateTime? clock;
+  final String? currentUserReplyLabel;
+  final List<ChatMessageQuickReaction> quickReactions;
+  final VoidCallback? onAddReaction;
+  final String? sendTooltip;
+  final String? cancelReplyTooltip;
+  final ValueChanged<TextChatMessage>? onMessageSent;
+  final ChatRenderMode mode;
+
+  @override
+  State<ChatReplyJourney> createState() => _ChatReplyJourneyState();
+}
+
+class _ChatReplyJourneyState extends State<ChatReplyJourney> {
+  late final TextEditingController _composerController;
+  late final List<ChatMessage> _messages;
+  final GlobalKey _timelineStackKey = GlobalKey();
+  TextChatMessage? _contextMenuTarget;
+  Offset? _contextMenuAnchor;
+  TextChatMessage? _activeReplyTarget;
+  var _localMessageSequence = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _composerController = TextEditingController();
+    _messages = List<ChatMessage>.of(widget.initialMessages);
+  }
+
+  @override
+  void dispose() {
+    _composerController.dispose();
+    super.dispose();
+  }
+
+  String _replyAuthor(TextChatMessage message) {
+    if (message.sender.id == widget.currentUser.id) {
+      return widget.currentUserReplyLabel ?? widget.currentUser.name;
+    }
+    return message.sender.name;
+  }
+
+  ChatFooterReplyPreviewData? get _footerReplyPreview {
+    final target = _activeReplyTarget;
+    if (target == null) return null;
+    return ChatFooterReplyPreviewData(
+      author: _replyAuthor(target),
+      content: target.content,
+    );
+  }
+
+  void _openContextMenu(TextChatMessage message, Offset globalPosition) {
+    final renderBox =
+        _timelineStackKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+    setState(() {
+      _contextMenuTarget = message;
+      _contextMenuAnchor = renderBox.globalToLocal(globalPosition);
+    });
+  }
+
+  void _closeContextMenu() {
+    if (_contextMenuTarget == null) return;
+    setState(() {
+      _contextMenuTarget = null;
+      _contextMenuAnchor = null;
+    });
+  }
+
+  void _startReply() {
+    final target = _contextMenuTarget;
+    if (target == null) return;
+    setState(() {
+      _activeReplyTarget = target;
+      _contextMenuTarget = null;
+      _contextMenuAnchor = null;
+    });
+  }
+
+  void _cancelReply() {
+    if (_activeReplyTarget == null) return;
+    setState(() => _activeReplyTarget = null);
+  }
+
+  void _send(String rawText) {
+    final text = rawText.trim();
+    if (text.isEmpty) return;
+
+    final target = _activeReplyTarget;
+    final sentAt = widget.clock ?? DateTime.now();
+    final sentMessage = TextChatMessage(
+      id: 'local-reply-${_localMessageSequence++}',
+      sender: widget.currentUser,
+      content: text,
+      sentAt: sentAt,
+      receivedAt: sentAt,
+      status: MessageStatus.sent,
+      replyPreview: target == null
+          ? null
+          : ChatReplyPreviewData(
+              author: _replyAuthor(target),
+              content: target.content,
+            ),
+    );
+
+    setState(() {
+      _messages.add(sentMessage);
+      _activeReplyTarget = null;
+      _contextMenuTarget = null;
+      _contextMenuAnchor = null;
+      _composerController.clear();
+    });
+    widget.onMessageSent?.call(sentMessage);
+  }
+
+  List<ChatMessageContextMenuElement> _contextMenuElements() {
+    return [
+      if (widget.quickReactions.isNotEmpty)
+        ChatMessageReactionRow(
+          reactions: widget.quickReactions,
+          onAddReaction: widget.onAddReaction,
+          showAddReaction: widget.onAddReaction != null,
+        ),
+      ChatMessageContextMenuAction.reply(onPressed: _startReply),
+      const ChatMessageContextMenuAction.forward(enabled: false),
+      const ChatMessageContextMenuAction.edit(enabled: false),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timeline = widget.mode == ChatRenderMode.group
+        ? ChatTimeline.group(
+            currentUser: widget.currentUser,
+            messages: _messages,
+            clock: widget.clock,
+            onTextMessageLongPressStart: _openContextMenu,
+            selectedTextMessageId: _contextMenuTarget?.id,
+          )
+        : ChatTimeline.direct(
+            currentUser: widget.currentUser,
+            messages: _messages,
+            clock: widget.clock,
+            onTextMessageLongPressStart: _openContextMenu,
+            selectedTextMessageId: _contextMenuTarget?.id,
+          );
+
+    return ColoredBox(
+      key: const ValueKey('chat-reply-flow'),
+      color: QaulColorSheet(Theme.of(context).brightness).background,
+      child: Column(
+        children: [
+          Expanded(
+            child: Stack(
+              key: _timelineStackKey,
+              children: [
+                Positioned.fill(
+                  child: SingleChildScrollView(reverse: true, child: timeline),
+                ),
+                if (_contextMenuTarget != null &&
+                    _contextMenuAnchor != null) ...[
+                  Positioned.fill(
+                    child: GestureDetector(
+                      key: const ValueKey('chat-reply-menu-dismiss-area'),
+                      behavior: HitTestBehavior.opaque,
+                      onTap: _closeContextMenu,
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: CustomSingleChildLayout(
+                      delegate: _ContextMenuPositionDelegate(
+                        anchor: _contextMenuAnchor!,
+                      ),
+                      child: ChatMessageContextMenu(
+                        key: const ValueKey('chat-reply-context-menu'),
+                        elements: _contextMenuElements(),
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          ChatFooter(
+            placeholder: widget.placeholder,
+            controller: _composerController,
+            replyPreview: _footerReplyPreview,
+            onCancelReply: _cancelReply,
+            onSend: _send,
+            sendTooltip: widget.sendTooltip,
+            cancelReplyTooltip: widget.cancelReplyTooltip,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContextMenuPositionDelegate extends SingleChildLayoutDelegate {
+  const _ContextMenuPositionDelegate({required this.anchor});
+
+  final Offset anchor;
+
+  static const _margin = 12.0;
+  static const _anchorGap = 20.0;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return constraints.loosen();
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final maxLeft = (size.width - childSize.width - _margin).clamp(
+      _margin,
+      double.infinity,
+    );
+    final left = (anchor.dx - childSize.width / 2).clamp(_margin, maxLeft);
+
+    final below = anchor.dy + _anchorGap;
+    final above = anchor.dy - childSize.height - _anchorGap;
+    final preferredTop = below + childSize.height <= size.height - _margin
+        ? below
+        : above;
+    final maxTop = (size.height - childSize.height - _margin).clamp(
+      _margin,
+      double.infinity,
+    );
+    final top = preferredTop.clamp(_margin, maxTop);
+
+    return Offset(left.toDouble(), top.toDouble());
+  }
+
+  @override
+  bool shouldRelayout(_ContextMenuPositionDelegate oldDelegate) {
+    return oldDelegate.anchor != anchor;
+  }
+}
+
+final _replyJourneyClock = DateTime(2026, 4, 18, 12, 42);
+
+const _replyQuickReactions = [
+  ChatMessageQuickReaction(child: Text('❤️'), semanticLabel: 'Love'),
+  ChatMessageQuickReaction(child: Text('👍'), semanticLabel: 'Like'),
+  ChatMessageQuickReaction(child: Text('🔥'), semanticLabel: 'Fire'),
+];
+
+class _ReplyJourneyScreen extends StatelessWidget {
+  const _ReplyJourneyScreen({required this.isGroup});
+
+  final bool isGroup;
+
+  @override
+  Widget build(BuildContext context) {
+    final messages = buildDirectChatFixtureMessages(clock: _replyJourneyClock);
+    final journey = isGroup
+        ? ChatReplyJourney.group(
+            currentUser: chatFixtureCurrentUser,
+            initialMessages: messages,
+            placeholder: 'Group message',
+            clock: _replyJourneyClock,
+            currentUserReplyLabel: 'You',
+            quickReactions: _replyQuickReactions,
+            onAddReaction: () {},
+            sendTooltip: 'Send',
+            cancelReplyTooltip: 'Cancel reply',
+          )
+        : ChatReplyJourney.direct(
+            currentUser: chatFixtureCurrentUser,
+            initialMessages: messages,
+            placeholder: 'Secure private message',
+            clock: _replyJourneyClock,
+            currentUserReplyLabel: 'You',
+            quickReactions: _replyQuickReactions,
+            onAddReaction: () {},
+            sendTooltip: 'Send',
+            cancelReplyTooltip: 'Cancel reply',
+          );
+    final header = isGroup
+        ? ChatHeader.group(
+            applyTopSafeArea: false,
+            extraTopPadding: 24,
+            onBackPressed: () {},
+            avatar: chatFixtureAvatar(initials: 'G'),
+            groupName: 'Group Name',
+            membersCount: 12,
+          )
+        : ChatHeader(
+            applyTopSafeArea: false,
+            extraTopPadding: 24,
+            onBackPressed: () {},
+            avatar: chatFixtureAvatar(initials: 'M'),
+            displayName: chatFixturePeer.name,
+            isOnline: true,
+            onlineLabel: 'online',
+            lastSeenLabel: '',
+          );
+
+    return Material(
+      color: widgetbookChatSurfaceColor(context),
+      child: Column(
+        children: [
+          header,
+          Expanded(child: journey),
+        ],
+      ),
+    );
+  }
+}
+
+@widgetbook.UseCase(
+  name: 'Direct chat',
+  type: ChatReplyJourney,
+  path: '[design]/chat/reply_journey',
+)
+Widget buildDirectReplyJourneyUseCase(BuildContext context) {
+  return const _ReplyJourneyScreen(isGroup: false);
+}
+
+@widgetbook.UseCase(
+  name: 'Group chat',
+  type: ChatReplyJourney,
+  path: '[design]/chat/reply_journey',
+)
+Widget buildGroupReplyJourneyUseCase(BuildContext context) {
+  return const _ReplyJourneyScreen(isGroup: true);
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/special_forms/qaul_chat_bubble.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/lib/use_cases/special_forms/qaul_chat_bubble.dart
@@ -111,3 +111,51 @@ Widget buildIncomingLongUseCase(BuildContext context) {
     ),
   );
 }
+
+class _LongPressSelectionPreview extends StatefulWidget {
+  const _LongPressSelectionPreview();
+
+  @override
+  State<_LongPressSelectionPreview> createState() =>
+      _LongPressSelectionPreviewState();
+}
+
+class _LongPressSelectionPreviewState
+    extends State<_LongPressSelectionPreview> {
+  var _isSelected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return widgetbookChatComponentFrame(
+      context,
+      alignment: Alignment.centerLeft,
+      child: GestureDetector(
+        key: const ValueKey('widgetbook-pressable-chat-bubble'),
+        behavior: HitTestBehavior.opaque,
+        onLongPress: () => setState(() => _isSelected = true),
+        onTap: _isSelected ? () => setState(() => _isSelected = false) : null,
+        child: QaulChatBubble(
+          message: QaulChatBubbleMessage(
+            content: 'Another answer',
+            sentAt: _clock.subtract(const Duration(minutes: 1)),
+            receivedAt: _clock.subtract(const Duration(minutes: 1)),
+            status: MessageStatus.sent,
+            messageType: MessageType.secondary,
+            edges: const [],
+            senderIdBase58: 'group-member-2',
+            senderDisplayName: 'Groupmember 2',
+            senderDisplayNameColor: const Color(0xFFFF9800),
+          ),
+          clock: _clock,
+          showTimestamp: true,
+          isSelected: _isSelected,
+        ),
+      ),
+    );
+  }
+}
+
+@widgetbook.UseCase(name: 'Interactive — long press', type: QaulChatBubble)
+Widget buildInteractiveLongPressUseCase(BuildContext context) {
+  return const _LongPressSelectionPreview();
+}

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/pubspec.yaml
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   widgetbook_annotation: ^3.1.0
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^3.0.0
   widgetbook_generator: ^3.7.0
   build_runner: ^2.4.9

--- a/qaul_ui/packages/qaul_components/widgetbook_workspace/test/reply_journey_test.dart
+++ b/qaul_ui/packages/qaul_components/widgetbook_workspace/test/reply_journey_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:qaul_components_widgetbook/use_cases/design/chat/reply_journey/reply_journey.dart';
+
+const _me = ChatUser(id: 'me', name: 'Me');
+const _other = ChatUser(id: 'other', name: 'Other user');
+final _clock = DateTime(2026, 4, 18, 18, 30);
+
+Finder _findBubbleText(String text) => find.byWidgetPredicate(
+  (widget) =>
+      widget is RichText &&
+      widget.text is TextSpan &&
+      (widget.text as TextSpan).text == text,
+);
+
+TextChatMessage _message({
+  required String id,
+  required ChatUser sender,
+  required String content,
+  int minutesAgo = 1,
+}) {
+  return TextChatMessage(
+    id: id,
+    sender: sender,
+    content: content,
+    sentAt: _clock.subtract(Duration(minutes: minutesAgo)),
+    receivedAt: _clock.subtract(Duration(minutes: minutesAgo)),
+    status: MessageStatus.read,
+  );
+}
+
+Widget _app({
+  bool group = false,
+  List<ChatMessage>? initialMessages,
+  ValueChanged<TextChatMessage>? onMessageSent,
+  ThemeData? theme,
+}) {
+  final messages =
+      initialMessages ??
+      <ChatMessage>[
+        _message(id: 'target', sender: _other, content: 'Original message'),
+      ];
+  final flow = group
+      ? ChatReplyJourney.group(
+          currentUser: _me,
+          initialMessages: messages,
+          placeholder: 'Group message',
+          clock: _clock,
+          currentUserReplyLabel: 'You',
+          onMessageSent: onMessageSent,
+        )
+      : ChatReplyJourney.direct(
+          currentUser: _me,
+          initialMessages: messages,
+          placeholder: 'Secure private message',
+          clock: _clock,
+          currentUserReplyLabel: 'You',
+          onMessageSent: onMessageSent,
+        );
+
+  return MaterialApp(
+    theme: theme ?? ThemeData.dark(),
+    home: Scaffold(body: flow),
+  );
+}
+
+Future<void> _startReply(WidgetTester tester) async {
+  await tester.longPress(find.byKey(const ValueKey('chat-message-target')));
+  await tester.pump();
+  expect(find.byKey(const ValueKey('chat-reply-context-menu')), findsOneWidget);
+
+  await tester.tap(find.text('Reply'));
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('context menu follows the newly selected message', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        initialMessages: [
+          _message(
+            id: 'first',
+            sender: _other,
+            content: 'First message',
+            minutesAgo: 10,
+          ),
+          _message(id: 'second', sender: _other, content: 'Second message'),
+        ],
+      ),
+    );
+
+    await tester.longPress(find.byKey(const ValueKey('chat-message-first')));
+    await tester.pump();
+    final firstMenuPosition = tester.getTopLeft(
+      find.byKey(const ValueKey('chat-reply-context-menu')),
+    );
+
+    await tester.tap(find.text('Reply'));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('cancel-chat-reply')));
+    await tester.pump();
+
+    await tester.longPress(find.byKey(const ValueKey('chat-message-second')));
+    await tester.pump();
+    final secondMenuPosition = tester.getTopLeft(
+      find.byKey(const ValueKey('chat-reply-context-menu')),
+    );
+
+    expect(secondMenuPosition, isNot(firstMenuPosition));
+  });
+
+  testWidgets('selected outline follows dark and light themes', (tester) async {
+    Future<Color> selectedOutline(ThemeData theme) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await tester.pumpWidget(_app(theme: theme));
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.byKey(const ValueKey('chat-message-target')));
+      await tester.pump();
+
+      final selectedSurface = tester.widget<DecoratedBox>(
+        find.byKey(const ValueKey('chat-bubble-surface')),
+      );
+      final selectedBorder =
+          (selectedSurface.decoration as BoxDecoration).border! as Border;
+      expect(selectedBorder.top.width, 2);
+      return selectedBorder.top.color;
+    }
+
+    expect(await selectedOutline(ThemeData.dark()), Colors.white);
+    expect(await selectedOutline(ThemeData.light()), Colors.black);
+
+    await tester.tap(find.text('Reply'));
+    await tester.pump();
+
+    final clearedSurface = tester.widget<DecoratedBox>(
+      find.byKey(const ValueKey('chat-bubble-surface')),
+    );
+    expect((clearedSurface.decoration as BoxDecoration).border, isNull);
+  });
+
+  testWidgets(
+    'Reply closes the menu and shows the selected message in footer',
+    (tester) async {
+      await tester.pumpWidget(_app());
+
+      await _startReply(tester);
+
+      expect(
+        find.byKey(const ValueKey('chat-reply-context-menu')),
+        findsNothing,
+      );
+      final footerPreview = find.byKey(
+        const ValueKey('chat-footer-reply-preview'),
+      );
+      expect(footerPreview, findsOneWidget);
+      expect(
+        find.descendant(of: footerPreview, matching: find.text('Other user')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: footerPreview,
+          matching: find.text('Original message'),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets('cancel clears the active footer reply', (tester) async {
+    await tester.pumpWidget(_app());
+    await _startReply(tester);
+
+    await tester.tap(find.byKey(const ValueKey('cancel-chat-reply')));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('chat-footer-reply-preview')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('send adds a reply bubble and clears active reply state', (
+    tester,
+  ) async {
+    TextChatMessage? sentMessage;
+    await tester.pumpWidget(
+      _app(onMessageSent: (message) => sentMessage = message),
+    );
+    await _startReply(tester);
+
+    await tester.enterText(find.byType(TextField), 'My reply');
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('chat-footer-send')));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('chat-footer-reply-preview')),
+      findsNothing,
+    );
+    expect(find.byKey(const ValueKey('chat-reply-preview')), findsOneWidget);
+    expect(find.text('Original message'), findsWidgets);
+    expect(find.text('Other user'), findsOneWidget);
+    expect(_findBubbleText('My reply'), findsOneWidget);
+    expect(sentMessage?.replyPreview?.author, 'Other user');
+    expect(sentMessage?.replyPreview?.content, 'Original message');
+  });
+
+  testWidgets('group chat uses the same reply flow', (tester) async {
+    TextChatMessage? sentMessage;
+    await tester.pumpWidget(
+      _app(group: true, onMessageSent: (message) => sentMessage = message),
+    );
+    await _startReply(tester);
+
+    await tester.enterText(find.byType(TextField), 'Group reply');
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('chat-footer-send')));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('chat-reply-preview')), findsOneWidget);
+    expect(_findBubbleText('Group reply'), findsOneWidget);
+    expect(sentMessage?.replyPreview?.content, 'Original message');
+    expect(
+      find.byKey(const ValueKey('chat-footer-reply-preview')),
+      findsNothing,
+    );
+  });
+}


### PR DESCRIPTION
## Description
Implements the chat reply flow integration across the qaul chat components.

This adds support for selecting a message to reply to, showing the selected reply target in the chat footer, rendering reply previews inside chat bubbles, and wiring the flow through the chat timeline/journey use cases. It also refines the message context menu presentation and aligns chat divider colors across themes.

- Integrates reply selection into the chat timeline flow.
- Adds reply metadata support to chat messages.
- Shows reply preview state in the chat footer/composer.
- Displays reply previews in chat bubbles.
- Updates message context menu behavior/presentation for reply actions.
- Adds Widgetbook reply journey coverage.
- Adds and updates focused component tests.

## Evidence

https://github.com/user-attachments/assets/b4f3357d-e4cf-4948-9754-4a503dbf3ac5

