### PR TITLE
qauld-ctl tui Refactor: qauld tui async refresh (without demo script)

### DIFF
--- a/rust/clients/qauld-ctl/src/tui/app.rs
+++ b/rust/clients/qauld-ctl/src/tui/app.rs
@@ -302,18 +302,18 @@ impl App {
         }
     }
 
-    /// Append new rotation events and advance the floor so subsequent
-    /// fetches only ask for what's newer.
-    pub fn append_crypto_events(&mut self, mut new_events: Vec<CryptoRotationEvent>) {
-        if new_events.is_empty() {
-            return;
+    /// Append rotation events from the poll path, deduping each against
+    /// what's already buffered.
+    ///
+    /// Poll and push now advance independent floors (the background
+    /// refresh task owns the poll floor), so the same event can arrive
+    /// on both paths; routing every poll event through the same dedup
+    /// as the push path keeps the list free of duplicates without the
+    /// two paths having to share a floor.
+    pub fn append_crypto_events(&mut self, new_events: Vec<CryptoRotationEvent>) {
+        for e in new_events {
+            self.merge_crypto_event(e);
         }
-        for e in &new_events {
-            if e.timestamp_ms > self.crypto_event_floor_ms {
-                self.crypto_event_floor_ms = e.timestamp_ms;
-            }
-        }
-        self.crypto_events.append(&mut new_events);
         // Cap the buffer so it doesn't grow unbounded; keep newest.
         const MAX: usize = 500;
         if self.crypto_events.len() > MAX {
@@ -402,4 +402,63 @@ fn push_capped(buf: &mut VecDeque<u64>, value: u64) {
         buf.pop_front();
     }
     buf.push_back(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::data::CryptoRotationEvent;
+
+    fn ev(ts: u64, primary: u32, draining: u32) -> CryptoRotationEvent {
+        CryptoRotationEvent {
+            timestamp_ms: ts,
+            kind: "Rotated",
+            remote_id: "peer".to_string(),
+            primary_session_id: primary,
+            draining_session_id: draining,
+        }
+    }
+
+    // The background refresh task owns its own poll floor, so the
+    // daemon's inclusive `since_ms` filter re-sends the boundary event
+    // every cycle. append_crypto_events must drop those duplicates
+    // instead of appending them (the old code relied on a floor shared
+    // with the push path, which no longer exists).
+    #[test]
+    fn append_crypto_events_drops_duplicates() {
+        let mut app = App::new();
+        app.append_crypto_events(vec![ev(10, 1, 0), ev(20, 2, 1)]);
+        assert_eq!(app.crypto_events.len(), 2);
+
+        // Next poll re-sends the boundary event (ts=20) plus a new one.
+        app.append_crypto_events(vec![ev(20, 2, 1), ev(30, 3, 2)]);
+        assert_eq!(app.crypto_events.len(), 3, "boundary dup must be dropped");
+        assert_eq!(app.crypto_events.last().unwrap().timestamp_ms, 30);
+    }
+
+    // A poll event that the push path already delivered is deduped too,
+    // since both now route through the same merge.
+    #[test]
+    fn append_crypto_events_dedups_against_push_path() {
+        let mut app = App::new();
+        app.push_event_line(EventLine {
+            topic: "crypto.rotation".into(),
+            text: String::new(),
+            parsed: ParsedEvent::CryptoRotation(ev(50, 5, 4)),
+        });
+        assert_eq!(app.crypto_events.len(), 1);
+
+        // The poll path fetches the same event → no duplicate.
+        app.append_crypto_events(vec![ev(50, 5, 4)]);
+        assert_eq!(app.crypto_events.len(), 1);
+    }
+
+    // Distinct events at the same timestamp (different sessions) are
+    // kept — dedup is by the full identifying tuple, not timestamp.
+    #[test]
+    fn append_crypto_events_keeps_distinct_same_timestamp() {
+        let mut app = App::new();
+        app.append_crypto_events(vec![ev(10, 1, 0), ev(10, 2, 1)]);
+        assert_eq!(app.crypto_events.len(), 2);
+    }
 }

--- a/rust/clients/qauld-ctl/src/tui/data.rs
+++ b/rust/clients/qauld-ctl/src/tui/data.rs
@@ -544,6 +544,83 @@ fn _codec_dummy() -> LengthDelimitedCodec {
     LengthDelimitedCodec::new()
 }
 
+/// A complete set of polled views fetched in one refresh cycle.
+///
+/// Every field is `Result<_, String>` — not `Box<dyn Error>` — so the
+/// whole struct is `Send` and can be handed from the background refresh
+/// task to the render loop over a channel. Errors are surfaced
+/// per-field in the events pane, exactly as the old inline refresh did.
+#[derive(Debug)]
+pub struct Snapshot {
+    pub default_user: Result<DefaultUser, String>,
+    pub users: Result<Vec<UserRow>, String>,
+    pub feed: Result<Vec<FeedRow>, String>,
+    pub dtn_state: Result<DtnState, String>,
+    pub dtn_config: Result<DtnConfig, String>,
+    pub network: Result<NetworkSnapshot, String>,
+    pub crypto_config: Result<CryptoConfig, String>,
+    pub crypto_events: Result<Vec<CryptoRotationEvent>, String>,
+}
+
+/// Fetch every polled view for one refresh cycle.
+///
+/// Runs off the render loop (in a background task) so a slow or hung
+/// RPC can never stall input handling or redraws. `fetch_default_user`
+/// resolves first because the DTN fetches need the account id as the
+/// envelope `user_id`; the remaining seven fetches are independent and
+/// are fanned out concurrently, so a cycle costs one round-trip's
+/// latency rather than the sum of eight.
+pub async fn refresh_once(
+    connect: &ConnectInfo,
+    timeout: Duration,
+    crypto_since_ms: u64,
+) -> Snapshot {
+    let default_user = fetch_default_user(connect, timeout)
+        .await
+        .map_err(|e| e.to_string());
+    let uid: Vec<u8> = default_user
+        .as_ref()
+        .map(|d| d.id_bytes.clone())
+        .unwrap_or_default();
+
+    let (users, feed, dtn_state, dtn_config, network, crypto_config, crypto_events) = tokio::join!(
+        async { fetch_users(connect, timeout).await.map_err(|e| e.to_string()) },
+        async { fetch_feed(connect, timeout).await.map_err(|e| e.to_string()) },
+        async {
+            fetch_dtn_state(connect, timeout, &uid)
+                .await
+                .map_err(|e| e.to_string())
+        },
+        async {
+            fetch_dtn_config(connect, timeout, &uid)
+                .await
+                .map_err(|e| e.to_string())
+        },
+        async { fetch_network(connect, timeout).await.map_err(|e| e.to_string()) },
+        async {
+            fetch_crypto_config(connect, timeout)
+                .await
+                .map_err(|e| e.to_string())
+        },
+        async {
+            fetch_crypto_events(connect, timeout, crypto_since_ms)
+                .await
+                .map_err(|e| e.to_string())
+        },
+    );
+
+    Snapshot {
+        default_user,
+        users,
+        feed,
+        dtn_state,
+        dtn_config,
+        network,
+        crypto_config,
+        crypto_events,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/clients/qauld-ctl/src/tui/mod.rs
+++ b/rust/clients/qauld-ctl/src/tui/mod.rs
@@ -7,7 +7,7 @@
 //! ratatui / crossterm deps entirely.
 
 use std::io;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crossterm::{
     event::{
@@ -62,6 +62,41 @@ pub async fn run(cli: Cli, refresh_secs: u64) -> Result<(), Box<dyn std::error::
         });
     }
 
+    // Background refresh: a task fans out every polled fetch
+    // concurrently (never on the render loop) and posts a `Snapshot`
+    // into this channel. A slow or hung RPC can no longer stall input
+    // or redraws — the loop simply keeps painting the last snapshot.
+    let (snapshot_tx, mut snapshot_rx) = tokio::sync::mpsc::unbounded_channel::<data::Snapshot>();
+    // Manual-refresh trigger (`r` key, and after sending a feed post).
+    let (refresh_tx, mut refresh_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    {
+        let connect = connect.clone();
+        let refresh_secs = refresh_secs.max(1);
+        tokio::spawn(async move {
+            // The poll floor for crypto events lives with the task (the
+            // sole owner of the poll path); the UI dedups against the
+            // push path, so overlaps are harmless.
+            let mut crypto_since: u64 = 0;
+            let mut interval = tokio::time::interval(Duration::from_secs(refresh_secs));
+            // interval's first tick is immediate → prime without blocking
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = refresh_rx.recv() => {}
+                }
+                let snap = data::refresh_once(&connect, timeout, crypto_since).await;
+                if let Ok(ref events) = snap.crypto_events {
+                    for e in events {
+                        crypto_since = crypto_since.max(e.timestamp_ms);
+                    }
+                }
+                if snapshot_tx.send(snap).is_err() {
+                    break; // UI gone
+                }
+            }
+        });
+    }
+
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
@@ -69,24 +104,18 @@ pub async fn run(cli: Cli, refresh_secs: u64) -> Result<(), Box<dyn std::error::
     let mut terminal = Terminal::new(backend)?;
 
     let mut app = App::new();
-    // Paint the frame skeleton immediately: the priming refresh below
-    // performs network round-trips, and until it returns the user
-    // would otherwise stare at a blank alternate screen.
-    terminal.draw(|f| ui::draw(f, &app))?;
-    // Prime data on launch
-    refresh(&mut app, &connect, timeout).await;
 
     let mut term_events = EventStream::new();
-    let mut next_refresh = Instant::now() + Duration::from_secs(refresh_secs);
     let result = loop {
+        // The frame skeleton renders immediately (even before the first
+        // snapshot lands), so startup never shows a blank alt-screen.
         terminal.draw(|f| ui::draw(f, &app))?;
 
-        let tick = tokio::time::sleep_until(tokio::time::Instant::from_std(next_refresh));
         tokio::select! {
             biased;
             ev = term_events.next() => match ev {
                 Some(Ok(CtEvent::Key(k))) if k.kind == KeyEventKind::Press => {
-                    if let Some(exit) = handle_key(&mut app, k, &connect, timeout).await {
+                    if let Some(exit) = handle_key(&mut app, k, &connect, timeout, &refresh_tx).await {
                         break exit;
                     }
                 }
@@ -97,10 +126,10 @@ pub async fn run(cli: Cli, refresh_secs: u64) -> Result<(), Box<dyn std::error::
             line = event_rx.recv() => if let Some(line) = line {
                 app.push_event_line(line);
             },
-            _ = tick => {
-                refresh(&mut app, &connect, timeout).await;
-                next_refresh = Instant::now() + Duration::from_secs(refresh_secs);
-            }
+            snap = snapshot_rx.recv() => match snap {
+                Some(snap) => apply_snapshot(&mut app, snap),
+                None => {} // refresh task ended; keep the UI up
+            },
         }
     };
 
@@ -124,6 +153,7 @@ async fn handle_key(
     key: KeyEvent,
     connect: &qauld_rpc::transport::ConnectInfo,
     timeout: Duration,
+    refresh_tx: &tokio::sync::mpsc::UnboundedSender<()>,
 ) -> Option<Result<(), Box<dyn std::error::Error>>> {
     // Modal text input wins.
     if app.input_mode == InputMode::Composing {
@@ -141,7 +171,9 @@ async fn handle_key(
                         Ok(()) => app.push_event(format!("feed sent: {body}")),
                         Err(e) => app.push_event(format!("feed send FAILED: {e}")),
                     }
-                    refresh(app, connect, timeout).await;
+                    // Ask the background task to pull the new post in;
+                    // the snapshot arrives on the render loop's channel.
+                    let _ = refresh_tx.send(());
                 }
             }
             KeyCode::Backspace => {
@@ -196,7 +228,9 @@ async fn handle_key(
         }
         KeyCode::Tab => app.next_tab(),
         KeyCode::BackTab => app.prev_tab(),
-        KeyCode::Char('r') => refresh(app, connect, timeout).await,
+        KeyCode::Char('r') => {
+            let _ = refresh_tx.send(());
+        }
         KeyCode::Char('/') => {
             app.input_mode = InputMode::Filtering;
             app.filter.clear();
@@ -218,59 +252,52 @@ async fn handle_key(
     None
 }
 
-async fn refresh(
-    app: &mut App,
-    connect: &qauld_rpc::transport::ConnectInfo,
-    timeout: Duration,
-) {
-    match data::fetch_default_user(connect, timeout).await {
+/// Apply a `Snapshot` from the background refresh task to the app
+/// state. Pure state mutation — no I/O, no awaits — so it never blocks
+/// the render loop. Per-field errors are surfaced in the events pane,
+/// mirroring the old inline refresh exactly.
+fn apply_snapshot(app: &mut App, snap: data::Snapshot) {
+    match snap.default_user {
         Ok(d) => {
             app.node_name = d.label;
             app.default_user_id = d.id_bytes;
         }
         Err(e) => app.push_event(format!("default user fetch failed: {e}")),
     }
-    match data::fetch_users(connect, timeout).await {
+    match snap.users {
         Ok(users) => app.users = users,
         Err(e) => app.push_event(format!("users fetch failed: {e}")),
     }
-    match data::fetch_feed(connect, timeout).await {
+    match snap.feed {
         Ok(feed) => app.feed = feed,
         Err(e) => app.push_event(format!("feed fetch failed: {e}")),
     }
-    match data::fetch_dtn_state(connect, timeout, &app.default_user_id).await {
+    match snap.dtn_state {
         Ok(state) => {
             app.record_unconfirmed(state.unconfirmed_count);
             app.dtn_state = Some(state);
         }
         Err(e) => app.push_event(format!("dtn state fetch failed: {e}")),
     }
-    match data::fetch_dtn_config(connect, timeout, &app.default_user_id).await {
+    match snap.dtn_config {
         Ok(cfg) => app.dtn_config = Some(cfg),
         Err(e) => app.push_event(format!("dtn config fetch failed: {e}")),
     }
-    match data::fetch_network(connect, timeout).await {
+    match snap.network {
         Ok(snapshot) => {
             app.record_network(&snapshot);
             app.network = Some(snapshot);
         }
         Err(e) => app.push_event(format!("network fetch failed: {e}")),
     }
-    match data::fetch_crypto_config(connect, timeout).await {
+    match snap.crypto_config {
         Ok(cfg) => app.crypto_config = Some(cfg),
         Err(e) => app.push_event(format!("crypto config fetch failed: {e}")),
     }
-    let since = app.crypto_event_floor_ms;
-    match data::fetch_crypto_events(connect, timeout, since).await {
-        Ok(events) => {
-            // The `since_ms` filter is inclusive on the daemon side, so
-            // drop anything we've already buffered.
-            let fresh: Vec<_> = events
-                .into_iter()
-                .filter(|e| since == 0 || e.timestamp_ms > since)
-                .collect();
-            app.append_crypto_events(fresh);
-        }
+    match snap.crypto_events {
+        // append_crypto_events dedups against the push path, so events
+        // the daemon's inclusive `since_ms` filter re-sends are dropped.
+        Ok(events) => app.append_crypto_events(events),
         Err(e) => app.push_event(format!("crypto events fetch failed: {e}")),
     }
 }


### PR DESCRIPTION
TUI changes of #929 without the demo script

Polling used to run inline in the render loop's select tick — 8 RPCs awaited sequentially, freezing input/redraws while they ran and up to ~40s/cycle if the daemon was unreachable. Move polling to a background task: refresh_once fans the fetches out concurrently (one round-trip's latency, not eight) and posts a Send-able Snapshot to the loop, which applies it synchronously. No network .await anywhere in the loop. r and post-feed-send just fire a trigger.

Crypto events now dedup through one path (the poll floor lives with the task), so poll/push overlaps and the daemon's inclusive since_ms re-sends are dropped. Three new dedup unit tests.