### PR TITLE
Fix changing account log in chat issues

### DIFF
--- a/qaul_ui/lib/coordinators/account_management_coordinator.dart
+++ b/qaul_ui/lib/coordinators/account_management_coordinator.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -9,6 +7,7 @@ import 'package:qaul_rpc/qaul_rpc.dart';
 import '../helpers/navigation_helper.dart';
 import '../l10n/app_localizations.dart';
 import '../providers/account_session_provider.dart';
+import '../providers/session_state_reset.dart';
 
 class AccountManagementCoordinator {
   const AccountManagementCoordinator._();
@@ -42,7 +41,7 @@ class AccountManagementCoordinator {
     final path = picked?.files.single.path;
     if (path == null || !context.mounted) return;
 
-    await _runWithProgress(context, () async {
+    final restoredAndLoggedIn = await _runWithProgress<bool>(context, () async {
       final worker = ref.read(qaulWorkerProvider);
       final restored = await ref.read(qaulWorkerProvider).restoreAccount(path);
       if (restored == null) throw const RpcRequestException('Restore failed');
@@ -66,9 +65,10 @@ class AccountManagementCoordinator {
 
       final loggedIn = await worker.loginLocalAccount(restoredAccount);
       if (!loggedIn) throw const RpcRequestException('Restore login failed');
+      return true;
     });
-    if (!context.mounted) return;
-    Navigator.pushReplacementNamed(context, NavigationHelper.home);
+    if (!context.mounted || restoredAndLoggedIn != true) return;
+    _returnHomeWithActiveSession(context, ref);
   }
 
   static Future<void> showLoginFlow(BuildContext context, WidgetRef ref) async {
@@ -107,7 +107,7 @@ class AccountManagementCoordinator {
     );
     if (!context.mounted || loggedIn != true) return;
 
-    Navigator.pushReplacementNamed(context, NavigationHelper.home);
+    _returnHomeWithActiveSession(context, ref);
   }
 
   static Future<void> showExportFlow(
@@ -161,16 +161,20 @@ class AccountManagementCoordinator {
     final user = ref.read(defaultUserProvider);
     if (user == null) return;
 
+    final loggedOut = await ref
+        .read(qaulWorkerProvider)
+        .logout(userId: user.id)
+        .catchError((_) => false);
+    if (!context.mounted) return;
+    if (!loggedOut) {
+      _showMessage(context, AppLocalizations.of(context)!.genericErrorMessage);
+      return;
+    }
+
     final navigator = Navigator.of(context, rootNavigator: true);
     ref.read(forceSignedOutProvider.notifier).state = true;
     if (!navigator.mounted) return;
     _returnToInitial(navigator, ref);
-
-    unawaited(
-      ref.read(qaulWorkerProvider).logout(userId: user.id).catchError((_) {
-        return false;
-      }),
-    );
   }
 
   static Future<void> showDeleteFlow(
@@ -295,11 +299,16 @@ class AccountManagementCoordinator {
   }
 
   static void _returnToInitial(NavigatorState navigator, WidgetRef ref) {
+    resetSessionScopedState(ref);
+    ref.invalidate(accountSessionProvider);
     navigator.pushNamedAndRemoveUntil(NavigationHelper.initial, (_) => false);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(defaultUserProvider.notifier).state = null;
-      ref.invalidate(accountSessionProvider);
-    });
+  }
+
+  static void _returnHomeWithActiveSession(BuildContext context, WidgetRef ref) {
+    final activeUser = ref.read(defaultUserProvider);
+    if (activeUser == null) return;
+    resetSessionScopedState(ref, activeUser: activeUser);
+    Navigator.pushReplacementNamed(context, NavigationHelper.home);
   }
 
   static LocalAccount? _findAccount(

--- a/qaul_ui/lib/decorators/search_user_decorator.dart
+++ b/qaul_ui/lib/decorators/search_user_decorator.dart
@@ -7,8 +7,8 @@ import 'package:qaul_rpc/qaul_rpc.dart';
 
 import '../l10n/app_localizations.dart';
 import '../stores/stores.dart';
-
 import '../widgets/widgets.dart';
+import 'loading_decorator.dart';
 
 typedef SearchUserResultBuilder = Widget Function(
     BuildContext context, List<User> users);
@@ -30,14 +30,26 @@ class SearchUserDecorator extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final controller = useTextEditingController();
+    final isLoadingInitialUsers = useState(false);
     final searchNotifier = ref.read(usersSearchProvider.notifier);
 
     useEffect(() {
+      Future.microtask(() {
+        if (ref.read(usersStoreProvider).isEmpty) {
+          isLoadingInitialUsers.value = true;
+          ref.read(usersStoreProvider.notifier).getUsers().whenComplete(() {
+            if (!context.mounted) return;
+            isLoadingInitialUsers.value = false;
+          });
+        }
+      });
       return searchNotifier.clear;
     }, const []);
 
     final search = ref.watch(usersSearchProvider);
     final users = search.isActive ? search.results : _localUsersForPicker(ref);
+    final isLoading = isLoadingInitialUsers.value ||
+        (search.isActive && search.isLoading && search.results.isEmpty);
 
     final l10n = AppLocalizations.of(context)!;
     return UserSearchScaffold(
@@ -50,7 +62,11 @@ class SearchUserDecorator extends HookConsumerWidget {
         controller.clear();
         searchNotifier.clear();
       },
-      body: builder(context, users),
+      body: LoadingDecorator(
+        isLoading: isLoading,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        child: builder(context, users),
+      ),
     );
   }
 }

--- a/qaul_ui/lib/providers/session_state_reset.dart
+++ b/qaul_ui/lib/providers/session_state_reset.dart
@@ -1,0 +1,31 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+
+import '../stores/stores.dart';
+import 'providers.dart';
+
+void resetSessionScopedState(WidgetRef ref, {User? activeUser}) {
+  ref.invalidate(currentOpenChatRoom);
+  ref.invalidate(chatRoomsProvider);
+  ref.invalidate(groupInvitesProvider);
+  ref.invalidate(chatRoomsSearchProvider);
+  ref.invalidate(chatRoomsStoreProvider);
+
+  ref.invalidate(feedMessageStoreProvider);
+
+  ref.invalidate(usersSearchProvider);
+  ref.invalidate(usersStoreProvider);
+  ref.invalidate(userLookupProvider);
+  ref.invalidate(defaultUserProvider);
+
+  ref.read(homeScreenControllerProvider.notifier).goToTab(TabType.public);
+  ref.invalidate(nodeInfoProvider);
+  ref.invalidate(dtnConfigurationProvider);
+  ref.invalidate(connectedNodesProvider);
+  ref.invalidate(bleStatusProvider);
+
+  if (activeUser == null) return;
+
+  ref.read(defaultUserProvider.notifier).state = activeUser;
+  ref.read(usersStoreProvider.notifier).startOnlinePolling();
+}

--- a/qaul_ui/lib/screens/create_account_screen.dart
+++ b/qaul_ui/lib/screens/create_account_screen.dart
@@ -7,6 +7,7 @@ import 'package:qaul_rpc/qaul_rpc.dart';
 import '../decorators/loading_decorator.dart';
 import '../helpers/navigation_helper.dart';
 import '../l10n/app_localizations.dart';
+import '../providers/session_state_reset.dart';
 import '../widgets/widgets.dart';
 
 class CreateAccountScreen extends HookConsumerWidget {
@@ -108,6 +109,7 @@ class CreateAccountScreen extends HookConsumerWidget {
     loading.value = false;
 
     if (createdUser != null) {
+      resetSessionScopedState(ref, activeUser: createdUser);
       Navigator.pushReplacementNamed(context, NavigationHelper.home);
       return;
     }

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -12,6 +12,7 @@ class _ChatState extends _BaseTabState<_Chat> {
   static const _pageSize = ChatRoomsStore.defaultPageSize;
   late final ScrollController _scrollController;
   bool _isLoadingMore = false;
+  bool _isLoadingInitialPage = true;
   bool _hasMoreChatRooms = true;
   bool _hasMoreInvites = true;
   int _chatRoomsOffset = 0;
@@ -23,9 +24,17 @@ class _ChatState extends _BaseTabState<_Chat> {
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await ref.read(chatNotificationControllerProvider).initialize();
+      _initializeNotifications();
       await _fetchFirstPage();
     });
+  }
+
+  Future<void> _initializeNotifications() async {
+    try {
+      await ref.read(chatNotificationControllerProvider).initialize();
+    } catch (error, stackTrace) {
+      _log.warning('Failed to initialize chat notifications', error, stackTrace);
+    }
   }
 
   @override
@@ -64,19 +73,24 @@ class _ChatState extends _BaseTabState<_Chat> {
     _chatRoomsOffset = 0;
     _invitesOffset = 0;
     setState(() {
+      _isLoadingInitialPage = true;
       _hasMoreChatRooms = true;
       _hasMoreInvites = true;
     });
 
-    final groups = ref.read(chatRoomsStoreProvider.notifier);
-    final results = await Future.wait([
-      groups.getChatRooms(offset: 0, limit: _pageSize),
-      groups.getGroupInvites(offset: 0, limit: _pageSize),
-    ]);
-    if (!mounted) return;
+    try {
+      final groups = ref.read(chatRoomsStoreProvider.notifier);
+      final results = await Future.wait([
+        groups.getChatRooms(offset: 0, limit: _pageSize),
+        groups.getGroupInvites(offset: 0, limit: _pageSize),
+      ]);
+      if (!mounted) return;
 
-    _updatePaginationFromRoomsResult(results.first as PaginatedChatRooms?);
-    _updatePaginationFromInvitesResult(results.last as PaginatedGroupInvites?);
+      _updatePaginationFromRoomsResult(results.first as PaginatedChatRooms?);
+      _updatePaginationFromInvitesResult(results.last as PaginatedGroupInvites?);
+    } finally {
+      if (mounted) setState(() => _isLoadingInitialPage = false);
+    }
   }
 
   Future<void> _refreshChatsAndInvites() async {
@@ -174,7 +188,8 @@ class _ChatState extends _BaseTabState<_Chat> {
     final showInvites = !roomSearch.isActive;
     final listItemCount =
         (showInvites ? groupInvites.length : 0) + displayRooms.length;
-    final isListLoading = _isLoadingMore ||
+    final isListLoading = _isLoadingInitialPage ||
+        _isLoadingMore ||
         (roomSearch.isActive &&
             roomSearch.isLoading &&
             roomSearch.results.isEmpty);
@@ -202,7 +217,10 @@ class _ChatState extends _BaseTabState<_Chat> {
         MaterialPageRoute(builder: (_) => const _CreateNewRoomDialog()),
       );
       if (newChat is User) {
-        final newRoom = ChatRoom.blank(otherUser: newChat);
+        final newRoom = ChatRoom.blank(
+          otherUser: newChat,
+          localUser: defaultUser,
+        );
         setOpenChat(newRoom, newChat);
       } else if (newChat is ChatRoom) {
         setOpenChat(newChat);
@@ -229,7 +247,7 @@ class _ChatState extends _BaseTabState<_Chat> {
             ref.read(chatRoomsSearchProvider.notifier).clear();
           },
           onRefresh: _refreshChatsAndInvites,
-          isEmpty: listItemCount == 0,
+          isEmpty: !isListLoading && listItemCount == 0,
           emptyMessage: l10n.emptyChatsList,
           itemCount: listItemCount,
           itemBuilder: (_, i) {

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -193,6 +193,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   final Map<String, String> _overflowMenuOptions = {};
   Map<String, MessagePresentation> _messagePresentations = {};
   ChatRenderMode _chatRenderMode = ChatRenderMode.direct;
+  bool _draftDirectMessageSent = false;
 
   void _handleClick(String value) {
     switch (value) {
@@ -219,6 +220,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   void _scheduleUpdateCurrentOpenChat() =>
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ref.read(currentOpenChatRoom.notifier).state = room;
+        if (room.isDraftDirectChat) return;
         ref.read(qaulWorkerProvider).getChatRoomMessages(room.conversationId);
       });
 
@@ -252,6 +254,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     final refreshCurrentRoom = useCallback(() async {
       if (!mounted) return;
+      if (room.isDraftDirectChat && !_draftDirectMessageSent) return;
       final worker = ref.read(qaulWorkerProvider);
       worker.getChatRoomMessages(
         room.conversationId,
@@ -269,6 +272,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     final sendMessage = useCallback((types.PartialText msg) {
       if (!mounted) return;
+      if (room.isDraftDirectChat) _draftDirectMessageSent = true;
       final worker = ref.read(qaulWorkerProvider);
       worker.sendMessage(room.conversationId, msg.text);
     }, [room]);

--- a/qaul_ui/lib/screens/home/user_details_screen.dart
+++ b/qaul_ui/lib/screens/home/user_details_screen.dart
@@ -68,8 +68,11 @@ class UserDetailsScreen extends HookConsumerWidget {
                     child: QaulButton(
                       label: l10n.newChatTooltip,
                       onPressed: () {
-                        final defaultUser = ref.watch(defaultUserProvider)!;
-                        final newRoom = ChatRoom.blank(otherUser: user);
+                        final defaultUser = ref.read(defaultUserProvider)!;
+                        final newRoom = ChatRoom.blank(
+                          otherUser: user,
+                          localUser: defaultUser,
+                        );
                         Navigator.pop(context);
                         openChat(
                           newRoom,
@@ -110,8 +113,11 @@ class UserDetailsScreen extends HookConsumerWidget {
                     child: QaulButton(
                       label: l10n.newChatTooltip,
                       onPressed: () {
-                        final defaultUser = ref.watch(defaultUserProvider)!;
-                        final newRoom = ChatRoom.blank(otherUser: user);
+                        final defaultUser = ref.read(defaultUserProvider)!;
+                        final newRoom = ChatRoom.blank(
+                          otherUser: user,
+                          localUser: defaultUser,
+                        );
                         Navigator.pop(context);
                         openChat(
                           newRoom,

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -157,7 +157,10 @@ class UsersStore extends Notifier<List<User>> {
   static const _pollingInterval = Duration(seconds: 3);
 
   @override
-  List<User> build() => [];
+  List<User> build() {
+    ref.onDispose(stopOnlinePolling);
+    return [];
+  }
 
   // ---------------------------------------------------------------------------
   // Paginated user fetching

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -60,10 +60,9 @@ class ChatRoom with EquatableMixin implements Comparable {
 
   final String idBase58;
 
-  factory ChatRoom.blank({required User otherUser}) {
-    assert(otherUser.conversationId != null);
+  factory ChatRoom.blank({required User otherUser, required User localUser}) {
     return ChatRoom(
-      conversationId: otherUser.conversationId!,
+      conversationId: _directConversationId(localUser, otherUser),
       name: otherUser.name,
       members: [
         ChatRoomUser(
@@ -72,6 +71,24 @@ class ChatRoom with EquatableMixin implements Comparable {
         ),
       ],
     );
+  }
+
+  static Uint8List _directConversationId(User localUser, User otherUser) {
+    final localQ8id = localUser.id.sublist(6, 14);
+    final otherQ8id = otherUser.id.sublist(6, 14);
+    final first = _compareBytes(localQ8id, otherQ8id) <= 0
+        ? localQ8id
+        : otherQ8id;
+    final second = identical(first, localQ8id) ? otherQ8id : localQ8id;
+    return Uint8List.fromList([...first, ...second]);
+  }
+
+  static int _compareBytes(List<int> a, List<int> b) {
+    for (var i = 0; i < a.length && i < b.length; i++) {
+      final diff = a[i].compareTo(b[i]);
+      if (diff != 0) return diff;
+    }
+    return a.length.compareTo(b.length);
   }
 
   factory ChatRoom.fromRpcGroupInfo(GroupInfo g, List<User> users) {
@@ -100,6 +117,12 @@ class ChatRoom with EquatableMixin implements Comparable {
   }
 
   bool get isGroupChatRoom => !isDirectChat;
+
+  bool get isDraftDirectChat =>
+      isDirectChat &&
+      createdAt == null &&
+      lastMessageIndex == null &&
+      messages == null;
 
   String? get groupAdminIdBase58 => members
       .firstWhereOrNull((m) => m.role == ChatRoomUserRole.admin)

--- a/qaul_ui/test/chat_room_equality_and_notifier_test.dart
+++ b/qaul_ui/test/chat_room_equality_and_notifier_test.dart
@@ -7,6 +7,19 @@ import 'package:qaul_rpc/qaul_rpc.dart';
 void main() {
   final conversationId = Uint8List.fromList('room1'.codeUnits);
 
+  Uint8List peerIdWithQ8id(List<int> q8id) {
+    return Uint8List.fromList([
+      0,
+      36,
+      8,
+      1,
+      18,
+      32,
+      ...q8id,
+      ...List<int>.filled(24, 7),
+    ]);
+  }
+
   Message message(int index) => Message(
         senderId: Uint8List.fromList('sender'.codeUnits),
         messageId: Uint8List.fromList('msg$index'.codeUnits),
@@ -26,6 +39,47 @@ void main() {
         messages: messages,
         lastMessageIndex: lastMessageIndex,
       );
+
+  group('ChatRoom.blank direct chat ids', () {
+    test('builds the direct conversation id from the active local user', () {
+      final localUser = User(
+        name: 'Local',
+        id: peerIdWithQ8id([8, 7, 6, 5, 4, 3, 2, 1]),
+      );
+      final otherUser = User(
+        name: 'Other',
+        id: peerIdWithQ8id([1, 2, 3, 4, 5, 6, 7, 8]),
+        conversationId: Uint8List.fromList(List<int>.filled(16, 99)),
+      );
+
+      final draft = ChatRoom.blank(otherUser: otherUser, localUser: localUser);
+
+      expect(
+        draft.conversationId,
+        orderedEquals([1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]),
+      );
+      expect(draft.conversationId, isNot(orderedEquals(otherUser.conversationId!)));
+    });
+
+    test('marks newly opened direct chats as drafts', () {
+      final localUser = User(
+        name: 'Local',
+        id: peerIdWithQ8id([1, 1, 1, 1, 1, 1, 1, 1]),
+      );
+      final otherUser = User(
+        name: 'Other',
+        id: peerIdWithQ8id([2, 2, 2, 2, 2, 2, 2, 2]),
+      );
+
+      final draft = ChatRoom.blank(otherUser: otherUser, localUser: localUser);
+
+      expect(draft.isDraftDirectChat, isTrue);
+      expect(
+        draft.copyWith(messages: [message(1)], lastMessageIndex: 1).isDraftDirectChat,
+        isFalse,
+      );
+    });
+  });
 
   group('ChatRoom Equatable props (idBase58, lastMessageIndex, messages)', () {
     test('rooms with same idBase58, lastMessageIndex, and messages are equal', () {

--- a/qaul_ui/test/session_state_reset_test.dart
+++ b/qaul_ui/test/session_state_reset_test.dart
@@ -1,0 +1,92 @@
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/providers/session_state_reset.dart';
+import 'package:qaul_ui/stores/stores.dart';
+
+void main() {
+  User user(String name, int byte) => User(
+        name: name,
+        id: Uint8List.fromList(List<int>.filled(38, byte)),
+      );
+
+  ChatRoom room(String id) => ChatRoom(
+        conversationId: Uint8List.fromList(id.codeUnits),
+        name: id,
+      );
+
+  testWidgets('resetSessionScopedState clears stale account scoped providers',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    late VoidCallback reset;
+
+    final oldUser = user('Old', 1);
+    final oldRoom = room('old-room');
+    final invite = GroupInvite(
+      senderId: oldUser.id,
+      receivedAt: DateTime(2026),
+      groupDetails: oldRoom,
+    );
+
+    container.read(defaultUserProvider.notifier).state = oldUser;
+    container.read(userLookupProvider.notifier).state = [oldUser];
+    container.read(chatRoomsProvider.notifier).add(oldRoom);
+    container.read(currentOpenChatRoom.notifier).state = oldRoom;
+    container.read(groupInvitesProvider.notifier).add(invite);
+    container.read(homeScreenControllerProvider.notifier).goToTab(TabType.chat);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: Consumer(
+          builder: (_, ref, _) {
+            reset = () => resetSessionScopedState(ref);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    reset();
+    await tester.pump();
+
+    expect(container.read(defaultUserProvider), isNull);
+    expect(container.read(userLookupProvider), isEmpty);
+    expect(container.read(chatRoomsProvider), isEmpty);
+    expect(container.read(currentOpenChatRoom), isNull);
+    expect(container.read(groupInvitesProvider), isEmpty);
+    expect(container.read(homeScreenControllerProvider), TabType.public);
+  });
+
+  testWidgets('resetSessionScopedState preserves the newly active user',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    late VoidCallback reset;
+
+    final newUser = user('New', 2);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: Consumer(
+          builder: (_, ref, _) {
+            reset = () => resetSessionScopedState(ref, activeUser: newUser);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    reset();
+    await tester.pump();
+
+    expect(container.read(defaultUserProvider), newUser);
+    container.read(usersStoreProvider.notifier).stopOnlinePolling();
+  });
+}


### PR DESCRIPTION
## Description
Fixes stale session state after logging out and signing in with a different account.

The issue was that some Riverpod providers/stores kept data from the previous session after logout. When a new account authenticated, the UI could still show old chats/users, open invalid conversations, and try to send messages to groups the new user could not access, causing Group not found errors.

Changes included:
- Centralized session-state reset on logout, login/restore, and account creation.
- Clearing chat, user, invite, open chat, feed, and home-related providers when switching sessions.
- Rehydrating defaultUserProvider with the active user after login/account creation.
- Creating direct chats with a conversationId computed from the active local user instead of stale cached user data.
- Treating newly opened direct chats as drafts to avoid premature unread/refresh calls before the backend group exists.
- Adding initial loading states for chats/users to avoid empty-state flashes while the new session loads.
- Adding focused tests for session reset and direct chat id generation.
## Evidence
Before:

https://github.com/user-attachments/assets/1875fcf9-8936-43da-b507-207646051d22


After:

https://github.com/user-attachments/assets/19dc4d8f-0b39-41b3-a692-f163e673db31

