### PR TITLE
Solidify loading states

### DIFF
--- a/qaul_ui/lib/providers/account_session_provider.dart
+++ b/qaul_ui/lib/providers/account_session_provider.dart
@@ -21,6 +21,8 @@ final accountSessionProvider = FutureProvider<QaulAccountSessionState>((
   }
 
   final worker = ref.read(qaulWorkerProvider);
+  await worker.initialized;
+
   final user = await worker.getDefaultUserAccount();
   if (user == null) return QaulAccountSessionState.noLocalAccount;
 

--- a/qaul_ui/lib/providers/notification_controller/public_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/public_notification_controller_provider.dart
@@ -23,9 +23,19 @@ class PublicNotificationController
   @override
   Future<void> initialize() async {
     await super.initialize();
+    await _loadFirstPage();
+  }
+
+  Future<PaginatedPosts?> initializeWithFirstPage() async {
+    await super.initialize();
+    return _loadFirstPage();
+  }
+
+  Future<PaginatedPosts?> _loadFirstPage() async {
     if (preferences.containsKey(cacheKey)) {
       _lastIndex = preferences.getInt(cacheKey)!;
     }
+
     final result = await ref
         .read(qaulWorkerProvider)
         .requestPublicMessages(offset: 0, limit: 50);
@@ -33,6 +43,7 @@ class PublicNotificationController
       await ref.read(feedMessageStoreProvider.notifier).applyPaginatedPosts(result);
     }
     _log.config('Initialized:\n\t· Last Post Index: $_lastIndex');
+    return result;
   }
 
   @override

--- a/qaul_ui/lib/screens/home/tabs/public_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/public_tab.dart
@@ -44,6 +44,7 @@ class _PublicTabView extends ConsumerStatefulWidget {
 class _PublicTabViewState extends ConsumerState<_PublicTabView> {
   static const _pageSize = 50;
   late final ScrollController _scrollController;
+  bool _isLoadingInitialPage = true;
   bool _isLoadingMore = false;
   bool _hasMore = true;
   int _currentOffset = 0;
@@ -54,8 +55,7 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(publicNotificationControllerProvider).initialize();
-      _currentOffset = _pageSize;
+      _initializePublicFeed();
     });
   }
 
@@ -84,20 +84,38 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
   }
 
   Future<void> _loadMore() async {
-    if (_isLoadingMore || !_hasMore) return;
+    if (_isLoadingInitialPage || _isLoadingMore || !_hasMore) return;
 
     setState(() => _isLoadingMore = true);
     try {
       final result = await ref
           .read(feedMessageStoreProvider.notifier)
           .loadMore(_currentOffset, limit: _pageSize);
+      if (!mounted) return;
       _updatePaginationFromResult(result);
     } finally {
       if (mounted) setState(() => _isLoadingMore = false);
     }
   }
 
+  Future<void> _initializePublicFeed() async {
+    if (!mounted) return;
+
+    setState(() => _isLoadingInitialPage = true);
+    try {
+      final result = await ref
+          .read(publicNotificationControllerProvider)
+          .initializeWithFirstPage();
+      if (!mounted) return;
+      _updatePaginationFromResult(result);
+    } finally {
+      if (mounted) setState(() => _isLoadingInitialPage = false);
+    }
+  }
+
   Future<void> _refreshPublic() async {
+    if (_isLoadingInitialPage) return;
+
     await ref.read(feedMessageStoreProvider.notifier).refreshPublic();
   }
 
@@ -119,6 +137,7 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
     });
 
     final messages = ref.watch(feedMessageStoreProvider);
+    final isInitialContentLoading = _isLoadingInitialPage && messages.isEmpty;
 
     final l10n = AppLocalizations.of(context)!;
 
@@ -151,10 +170,11 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
         child: RefreshIndicator(
           onRefresh: () async => await _refreshPublic(),
           child: LoadingDecorator(
-            isLoading: _isLoadingMore,
+            isLoading: isInitialContentLoading || _isLoadingMore,
+            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             child: EmptyStateTextDecorator(
               l10n.emptyPublicList,
-              isEmpty: messages.isEmpty,
+              isEmpty: !isInitialContentLoading && messages.isEmpty,
               child: ListView.separated(
                 controller: _scrollController,
                 physics: const AlwaysScrollableScrollPhysics(),

--- a/qaul_ui/lib/screens/splash_screen.dart
+++ b/qaul_ui/lib/screens/splash_screen.dart
@@ -28,20 +28,26 @@ class SplashScreen extends ConsumerWidget {
     final session = ref.watch(accountSessionProvider);
 
     return session.when(
-      data: (state) => QaulAccountLanding(
-        state: state,
-        logo: const QaulAccountLogo(),
-        languageSelector: const LanguageSelectDropDown(),
-        onCreateAccount: () => Navigator.pushReplacementNamed(
-          context,
-          NavigationHelper.createAccount,
-        ),
-        onRestoreAccount: () =>
-            AccountManagementCoordinator.showRestoreFlow(context, ref),
-        onLogin: () => AccountManagementCoordinator.showLoginFlow(context, ref),
-        onLearnMore: () =>
-            launchUrl(Uri.parse('https://qaul.net/tutorials/onboarding/')),
-      ),
+      data: (state) {
+        if (state == QaulAccountSessionState.signedIn) {
+          return const _SplashLoadingState();
+        }
+
+        return QaulAccountLanding(
+          state: state,
+          logo: const QaulAccountLogo(),
+          languageSelector: const LanguageSelectDropDown(),
+          onCreateAccount: () => Navigator.pushReplacementNamed(
+            context,
+            NavigationHelper.createAccount,
+          ),
+          onRestoreAccount: () =>
+              AccountManagementCoordinator.showRestoreFlow(context, ref),
+          onLogin: () => AccountManagementCoordinator.showLoginFlow(context, ref),
+          onLearnMore: () =>
+              launchUrl(Uri.parse('https://qaul.net/tutorials/onboarding/')),
+        );
+      },
       error: (error, stackTrace) => QaulAccountLanding(
         state: QaulAccountSessionState.noLocalAccount,
         logo: const QaulAccountLogo(),
@@ -55,9 +61,25 @@ class SplashScreen extends ConsumerWidget {
         onLearnMore: () =>
             launchUrl(Uri.parse('https://qaul.net/tutorials/onboarding/')),
       ),
-      loading: () => const Scaffold(
-        body: Center(
-          child: SizedBox(width: 320, height: 320, child: QaulAccountLogo()),
+      loading: () => const _SplashLoadingState(),
+    );
+  }
+}
+
+class _SplashLoadingState extends StatelessWidget {
+  const _SplashLoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(width: 320, height: 320, child: QaulAccountLogo()),
+            SizedBox(height: 24),
+            QaulLoadingIndicator(),
+          ],
         ),
       ),
     );

--- a/qaul_ui/test/account_session_provider_test.dart
+++ b/qaul_ui/test/account_session_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -13,13 +14,22 @@ class _SessionWorker extends StubLibqaulWorker {
     super.ref, {
     this.user,
     this.authenticated = false,
-  });
+    Future<bool>? initialized,
+  }) : _initialized = initialized ?? Future.value(true);
 
+  final Future<bool> _initialized;
   final User? user;
   final bool authenticated;
+  int defaultUserAccountReads = 0;
 
   @override
-  Future<User?> getDefaultUserAccount() async => user;
+  Future<bool> get initialized => _initialized;
+
+  @override
+  Future<User?> getDefaultUserAccount() async {
+    defaultUserAccountReads++;
+    return user;
+  }
 
   @override
   Future<bool> getSessionStatus({Uint8List? userId}) async => authenticated;
@@ -76,6 +86,28 @@ void main() {
         await container.read(accountSessionProvider.future),
         QaulAccountSessionState.noLocalAccount,
       );
+    });
+
+    test('waits for the worker before reading the default account', () async {
+      final initialized = Completer<bool>();
+      late _SessionWorker worker;
+      final container = _container(
+        workerBuilder: (ref) {
+          worker = _SessionWorker(ref, initialized: initialized.future);
+          return worker;
+        },
+      );
+      addTearDown(container.dispose);
+
+      final session = container.read(accountSessionProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(worker.defaultUserAccountReads, 0);
+
+      initialized.complete(true);
+
+      expect(await session, QaulAccountSessionState.noLocalAccount);
+      expect(worker.defaultUserAccountReads, 1);
     });
 
     test('forceSignedOut skips daemon check after explicit logout', () async {

--- a/qaul_ui/test/public_tab_loading_test.dart
+++ b/qaul_ui/test/public_tab_loading_test.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:qaul_rpc/qaul_rpc.dart';
+import 'package:qaul_ui/providers/providers.dart';
+import 'package:qaul_ui/screens/home/tabs/tab.dart';
+
+import 'test_utils/test_utils.dart';
+
+class _PublicLoadingController extends PublicNotificationController {
+  _PublicLoadingController(super.ref, this.firstPage);
+
+  final Completer<PaginatedPosts?> firstPage;
+
+  @override
+  Future<PaginatedPosts?> initializeWithFirstPage() => firstPage.future;
+}
+
+PaginatedPosts _emptyFirstPage() => PaginatedPosts(
+      posts: [],
+      pagination: PaginationState(
+        hasMore: false,
+        total: 0,
+        offset: 0,
+        limit: 50,
+      ),
+    );
+
+void main() {
+  testWidgets('shows loading instead of empty public text during first load',
+      (tester) async {
+    final firstPage = Completer<PaginatedPosts?>();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          publicNotificationControllerProvider.overrideWith(
+            (ref) => _PublicLoadingController(ref, firstPage),
+          ),
+        ],
+        child: materialAppWithLocalizations(
+          BaseTab.public(disablePageViewScroll: ValueNotifier(false)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(QaulLoadingIndicator), findsOneWidget);
+    expect(find.text('No public messages yet'), findsNothing);
+
+    firstPage.complete(_emptyFirstPage());
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(QaulLoadingIndicator), findsNothing);
+    expect(find.text('No public messages yet'), findsOneWidget);
+  });
+}

--- a/qaul_ui/test/splash_screen_test.dart
+++ b/qaul_ui/test/splash_screen_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qaul_components/qaul_components.dart';
+import 'package:qaul_ui/helpers/navigation_helper.dart';
+import 'package:qaul_ui/providers/account_session_provider.dart';
+import 'package:qaul_ui/screens/splash_screen.dart';
+
+void main() {
+  testWidgets('keeps the splash loading state while redirecting signed in users',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountSessionProvider.overrideWith(
+            (ref) => QaulAccountSessionState.signedIn,
+          ),
+        ],
+        child: MaterialApp(
+          routes: {
+            NavigationHelper.initial: (_) => const SplashScreen(),
+            NavigationHelper.home: (_) => const Text('home'),
+          },
+        ),
+      ),
+    );
+
+    expect(find.byType(QaulLoadingIndicator), findsOneWidget);
+    expect(find.byKey(SplashScreen.createUserButtonKey), findsNothing);
+  });
+}


### PR DESCRIPTION
## Description
- Fixes loading-state gaps during app startup and first public feed load.
- On startup, the app now keeps the splash/loading state visible while resolving the account session, preventing the login screen from briefly flashing before automatically routing signed-in users to Home.
- For the public messenger screen, the app now shows a loading animation while the first public messages request is pending. The empty state is only shown after the initial request finishes with no messages, avoiding a blank screen or premature “no messages” state on slower devices.

## Evidence

https://github.com/user-attachments/assets/377a4b1c-cbea-4799-939f-fb0f4fe6a24f



