### PR TITLE
docs: subsystem docs for DTN v2, crypto sessions, groups, tooling

### DIFF
--- a/docs/protocols/crypto-sessions.md
+++ b/docs/protocols/crypto-sessions.md
@@ -1,0 +1,49 @@
+# Crypto — Session Lifecycle
+
+Node-to-node encryption uses Noise KK (`Noise_KK_X25519_ChaChaPoly_SHA256`).
+This covers two features around the session lifecycle. Session **rotation** has
+its own document: `Noise-Session-Rotation.md`.
+
+Code: `rust/libqaul/src/services/crypto/`.
+
+## Handshake extras
+
+Noise KK normally lets the initiator send nothing useful until the responder
+completes the handshake — a problem under DTN, where the responder may be
+offline for hours. Handshake extras let the initiator send **multiple encrypted
+chat messages during session creation**, before the handshake completes.
+
+The extra payloads ride under the partial-handshake cipher (which Noise KK
+allows) and are queued on disk for DTN delivery. The responder drains them once
+it finishes the handshake, with correct ordering and replay protection. Counts
+and sizes are bounded so the pre-completion queue can't grow without limit.
+
+This keeps KK intact — no per-message ratchet, no pattern switch — and only
+widens what the initiator may put on the wire during message 1's extended
+window.
+
+## Cold re-key
+
+Recovers a session after one side loses its crypto state (e.g. a wiped
+database) while the peer is still reachable.
+
+When a node receives undecryptable traffic for an unknown session, and it has
+**no** existing session with that peer, it re-initiates a fresh KK handshake.
+KK is mutually identity-authenticated, so this is safe: the new session is
+provably with the real peer. The trigger is rate-limited per peer, and stale
+traffic for a peer we *do* still have a session with is dropped rather than
+re-keyed — that's the guard against a re-key storm.
+
+When the fresh handshake completes, it supersedes any prior transport session
+for that peer: the old row is deleted and the new session becomes primary, so
+both sides converge on one live session.
+
+## Rationale
+
+- **Full session rotation over a per-message ratchet** — a Signal-style ratchet
+  gives strong forward secrecy but is hostile to delayed/out-of-order delivery,
+  which qaul depends on. Rotating the whole KK session preserves per-session
+  out-of-order tolerance. (See the rotation doc.)
+- **Cold re-key is separate from rotation** — different threat: rotation is
+  "keys are fine, refresh them"; cold re-key is "one side's state is gone." They
+  share no trigger and shouldn't be conflated.

--- a/docs/protocols/dtn-v2.md
+++ b/docs/protocols/dtn-v2.md
@@ -1,0 +1,87 @@
+# DTN v2 — Custody Store-and-Forward
+
+Delivers a message when the recipient is offline: instead of failing, it is
+handed to **custodian** nodes that hold it and carry it forward until it
+reaches the recipient. qaul's delay-tolerant layer, version 2.
+
+Code: `rust/libqaul/src/services/dtn/mod.rs`; wire messages under
+`protobuf/proto_definitions/services/messaging/`.
+
+## Model
+
+Three roles, all PeerIds: the **sender**, one or more **custodians** (opt-in
+nodes that store-and-forward for others), and the **recipient**. A message
+travels a **custody route** — an ordered list of custodian hops toward the
+recipient. Each custodian holds the still-encrypted message and forwards it to
+the next reachable hop, or delivers directly if the recipient is reachable. The
+body stays sealed end to end; custodians store ciphertext and see only routing
+headers.
+
+## Lifecycle
+
+1. **Send** — sender wraps its signed container in a `DtnRoutedV2` envelope
+   (route + sender public key) and hands it to the first reachable custodian.
+2. **Accept** — the custodian checks admission (custody enabled? signature
+   valid? sender not blocked? within quota?) and stores + accepts, or rejects
+   with a reason. Duplicates (same signature) are accepted silently.
+3. **Forward** — try the recipient directly, else the next reachable custodian.
+4. **Confirm** — once the next hop accepts, the holder releases its copy; the
+   recipient's receipt unwinds the chain.
+
+A periodic sweep re-attempts forwarding and garbage-collects expired entries.
+
+## Storage, quota, retention
+
+- **Per-account total** — `storage.size_total` (default 1024 MB).
+- **Per-sender quota** — one sender can hold at most a fixed slice (currently
+  10 MB), so no sender crowds out others.
+- **Retention** — kept until delivered or aged out, measured from the
+  custodian's **own receive time** (`accepted_at`), not a sender timestamp; even
+  a no-expiry message is bounded by a max retention (currently 7 days). This is
+  deliberate — a sender-supplied absolute expiry breaks on a wrong clock (expiry
+  in the past → rejected everywhere; far future → never clears). Measuring from
+  receipt is clock-independent.
+
+Quota accounting self-heals: the entry and its counter are separate writes, so
+the counter is recomputed from stored entries on startup.
+
+## Rejections
+
+Custodians decline with a reason so the sender can react instead of blind-retry:
+
+- **`USER_NOT_ACCEPTED`** — custody off, sender blocked, or account unknown.
+- **`OVERALL_QUOTA`** — account storage full.
+- **`USER_QUOTA`** — this sender's slice full.
+
+Intended sender-side handling (direction, not fully built): retry transient
+reasons (full/error) with backoff; drop and surface hard denials (blocked).
+
+## Operation
+
+Custody is **opt-in** — a fresh node stores nothing for others until enabled.
+
+```sh
+qauld-ctl dtn custody enable      # become a custodian
+qauld-ctl dtn state               # storage used, message + unconfirmed counts
+qauld-ctl dtn config              # max size + allowed custodian users
+qauld-ctl dtn add  -u <peer-id>   # allow a user to deposit here
+qauld-ctl dtn size -s <MB>        # set the account storage cap
+```
+
+## Rationale
+
+- **Opt-in, admission keyed on the signed sender** — identity is unforgeable, so
+  admission/quota can trust "who sent this." (Per-sender quota alone doesn't
+  stop a Sybil flood of many cheap identities — that needs an aggregate cap on
+  the untrusted tier, a design direction, not yet built.)
+- **Custodian-local retention, not a sender TTL** — clock-independent; hence the
+  max-retention safety net even without a declared expiry.
+- **Body never decrypted in transit** — custodians route ciphertext;
+  confidentiality doesn't rely on trusting them.
+
+## Route format — in flux
+
+The custody-route wire structure is under active redesign (hop numbering, route
+signing, stateless vs. cursor traversal). The mechanics above are the stable
+core; the route message shape is expected to change. See the DTN structures
+feedback thread.

--- a/docs/protocols/groups.md
+++ b/docs/protocols/groups.md
@@ -1,0 +1,38 @@
+# Groups — Membership and File Encryption
+
+Two changes to how group chats manage state and encrypt files.
+
+Code: `rust/libqaul/src/services/group/`, `rust/libqaul/src/services/chat/file.rs`.
+
+## Membership CRDT
+
+Group membership and metadata converge through a CRDT instead of a
+revision-counter merge, so concurrent changes on different nodes reconcile
+without a coordinator.
+
+- **Membership** is an OR-Set: adds and removes are independent operations, so a
+  member added on one node and removed on another converge deterministically
+  rather than depending on which revision number won.
+- **Metadata** (name, etc.) is last-writer-wins.
+- Every operation is **signed**, so membership changes are attributable and
+  can't be forged.
+- **Epoch compaction** collapses old tombstone history periodically, bounding
+  how large the op set grows.
+
+The CRDT is the source of truth for membership; the live group state is derived
+from it.
+
+```sh
+qauld-ctl group crdt-view      # inspect the derived membership/metadata state
+qauld-ctl group crdt-compact   # collapse tombstone history (admin)
+```
+
+## File envelope encryption
+
+Reduces the cost of sending a file to a group. Instead of encrypting the whole
+file body once per recipient (N× the work for N members), the body is encrypted
+**once** under a per-file content key, and only that small key is wrapped per
+recipient. Each member unwraps the key and decrypts the shared body.
+
+> **Status:** in progress — the primitives, wire format, and key store are in
+> place, but end-to-end send/receive is not yet working. Not ready for use.

--- a/docs/protocols/tooling.md
+++ b/docs/protocols/tooling.md
@@ -1,0 +1,63 @@
+# Operator Tooling — qauld & qauld-ctl
+
+Running a node and inspecting/controlling it from the terminal.
+
+## qauld: run detached
+
+`qauld -d` / `--daemonize` forks the daemon into the background at startup and
+returns the shell immediately. It keeps the storage directory as its working
+directory, writes a pidfile there, and redirects stdout/stderr to log files.
+
+```sh
+qauld -d --name alice --port 9229   # start detached
+```
+
+The fork happens before the async runtime starts (forking a running
+multithreaded process is unsafe), so `main` parses args, daemonizes, then builds
+the runtime.
+
+Code: `rust/clients/qauld/src/main.rs`.
+
+## qauld-ctl: interactive shell
+
+`qauld-ctl shell` runs commands against the daemon in a loop without re-typing
+the binary name. It has line editing and history (↑/↓, ←/→ via rustyline) and
+shell-style quoting (via shlex), so `feed send -m "hello there"` is a single
+argument. `help` shows the command list; `quit` / `exit` / Ctrl-D leave.
+
+Code: `rust/clients/qauld-ctl/src/shell/`.
+
+## qauld-ctl: TUI dashboard
+
+`qauld-ctl tui` is a live terminal dashboard, five tabs:
+
+- **Users / Feed** — known users; feed messages (compose from the Feed tab).
+- **DTN** — storage state, an unconfirmed-count sparkline, allowed custodians,
+  and a live delivery-response feed.
+- **Network** — per-module (LAN / Internet / BLE) peer counts with trend
+  sparklines, a peers table, and a live connect/disconnect feed.
+- **Crypto** — rotation config, event counts, and a live rotation-event table.
+
+Keys: `Tab`/`BackTab` switch tabs, `↑/↓` move, `Enter` detail, `/` filter,
+`r` refresh, `q` quit.
+
+Fetching runs in a background task off the render loop, so input stays
+responsive even if the daemon is slow or unreachable — the UI keeps painting the
+last snapshot instead of freezing.
+
+Code: `rust/clients/qauld-ctl/src/tui/`.
+
+## qauld-ctl: transport switch
+
+Enable or disable network transports (LAN / Internet / BLE) at runtime. This
+actually starts/stops the transport and persists the choice, not just a flag.
+
+```sh
+qauld-ctl transports list
+qauld-ctl transports disable -i lan
+qauld-ctl transports enable  -i lan
+```
+
+Disabling a transport stops it carrying data. Note the routing view
+(`router neighbours`) can lag behind — a peer may still appear for a while after
+its transport is disabled, until the routing table's maintenance ages it out.


### PR DESCRIPTION
Explanatory docs (how each subsystem works + rationale, not status) under `docs/protocols/`, matching `Noise-Session-Rotation.md`.

- `dtn-v2.md` — custody model, lifecycle, storage/quota/retention (route wire-format flagged as under redesign)
- `crypto-sessions.md` — handshake extras, cold re-key
- `groups.md` — membership CRDT, file envelope (marked in-progress)
- `tooling.md` — daemonize, shell, TUI, transport switch