### PR TITLE
Fix splash screen behavior and tests

### DIFF
--- a/qaul_ui/lib/screens/splash_screen.dart
+++ b/qaul_ui/lib/screens/splash_screen.dart
@@ -17,11 +17,14 @@ class SplashScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen(accountSessionProvider, (_, snapshot) {
+      if (snapshot.isLoading || snapshot.hasError) return;
       if (snapshot.value != QaulAccountSessionState.signedIn) return;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted) return;
-        Navigator.of(context, rootNavigator: true)
-            .pushReplacementNamed(NavigationHelper.home);
+        Navigator.of(
+          context,
+          rootNavigator: true,
+        ).pushReplacementNamed(NavigationHelper.home);
       });
     });
 
@@ -43,7 +46,8 @@ class SplashScreen extends ConsumerWidget {
           ),
           onRestoreAccount: () =>
               AccountManagementCoordinator.showRestoreFlow(context, ref),
-          onLogin: () => AccountManagementCoordinator.showLoginFlow(context, ref),
+          onLogin: () =>
+              AccountManagementCoordinator.showLoginFlow(context, ref),
           onLearnMore: () =>
               launchUrl(Uri.parse('https://qaul.net/tutorials/onboarding/')),
         );

--- a/qaul_ui/test/splash_screen_test.dart
+++ b/qaul_ui/test/splash_screen_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/legacy.dart';
 import 'package:qaul_components/qaul_components.dart';
 import 'package:qaul_ui/helpers/navigation_helper.dart';
 import 'package:qaul_ui/providers/account_session_provider.dart';
@@ -34,14 +37,30 @@ void main() {
   testWidgets(
     'does not redirect while refreshing a previous signed-in session',
     (tester) async {
-      final refreshingSignedIn = const AsyncLoading<QaulAccountSessionState>()
-          .copyWithPrevious(const AsyncData(QaulAccountSessionState.signedIn));
+      final refreshTriggerProvider = StateProvider((_) => false);
+      final pendingRefresh = Completer<QaulAccountSessionState>();
+      final container = ProviderContainer(
+        overrides: [
+          accountSessionProvider.overrideWith((ref) {
+            final refreshing = ref.watch(refreshTriggerProvider);
+            if (refreshing) return pendingRefresh.future;
+            return QaulAccountSessionState.signedIn;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        await container.read(accountSessionProvider.future),
+        QaulAccountSessionState.signedIn,
+      );
+      container.read(refreshTriggerProvider.notifier).state = true;
+      container.read(accountSessionProvider);
+      await Future<void>.delayed(Duration.zero);
 
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            accountSessionProvider.overrideWithValue(refreshingSignedIn),
-          ],
+        UncontrolledProviderScope(
+          container: container,
           child: MaterialApp(
             routes: {
               NavigationHelper.initial: (_) => const SplashScreen(),

--- a/qaul_ui/test/splash_screen_test.dart
+++ b/qaul_ui/test/splash_screen_test.dart
@@ -1,9 +1,6 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:hooks_riverpod/legacy.dart';
 import 'package:qaul_components/qaul_components.dart';
 import 'package:qaul_ui/helpers/navigation_helper.dart';
 import 'package:qaul_ui/providers/account_session_provider.dart';
@@ -35,32 +32,15 @@ void main() {
   );
 
   testWidgets(
-    'does not redirect while refreshing a previous signed-in session',
+    'does not redirect while the session is loading',
     (tester) async {
-      final refreshTriggerProvider = StateProvider((_) => false);
-      final pendingRefresh = Completer<QaulAccountSessionState>();
-      final container = ProviderContainer(
-        overrides: [
-          accountSessionProvider.overrideWith((ref) {
-            final refreshing = ref.watch(refreshTriggerProvider);
-            if (refreshing) return pendingRefresh.future;
-            return QaulAccountSessionState.signedIn;
-          }),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      expect(
-        await container.read(accountSessionProvider.future),
-        QaulAccountSessionState.signedIn,
-      );
-      container.read(refreshTriggerProvider.notifier).state = true;
-      container.read(accountSessionProvider);
-      await Future<void>.delayed(Duration.zero);
-
       await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
+        ProviderScope(
+          overrides: [
+            accountSessionProvider.overrideWithValue(
+              const AsyncLoading<QaulAccountSessionState>(),
+            ),
+          ],
           child: MaterialApp(
             routes: {
               NavigationHelper.initial: (_) => const SplashScreen(),
@@ -74,9 +54,6 @@ void main() {
 
       expect(find.byType(SplashScreen), findsOneWidget);
       expect(find.text('home'), findsNothing);
-
-      pendingRefresh.complete(QaulAccountSessionState.signedOut);
-      await tester.pump();
     },
   );
 }

--- a/qaul_ui/test/splash_screen_test.dart
+++ b/qaul_ui/test/splash_screen_test.dart
@@ -74,6 +74,9 @@ void main() {
 
       expect(find.byType(SplashScreen), findsOneWidget);
       expect(find.text('home'), findsNothing);
+
+      pendingRefresh.complete(QaulAccountSessionState.signedOut);
+      await tester.pump();
     },
   );
 }

--- a/qaul_ui/test/splash_screen_test.dart
+++ b/qaul_ui/test/splash_screen_test.dart
@@ -7,25 +7,54 @@ import 'package:qaul_ui/providers/account_session_provider.dart';
 import 'package:qaul_ui/screens/splash_screen.dart';
 
 void main() {
-  testWidgets('keeps the splash loading state while redirecting signed in users',
-      (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          accountSessionProvider.overrideWith(
-            (ref) => QaulAccountSessionState.signedIn,
+  testWidgets(
+    'keeps the splash loading state while redirecting signed in users',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            accountSessionProvider.overrideWith(
+              (ref) => QaulAccountSessionState.signedIn,
+            ),
+          ],
+          child: MaterialApp(
+            routes: {
+              NavigationHelper.initial: (_) => const SplashScreen(),
+              NavigationHelper.home: (_) => const Text('home'),
+            },
           ),
-        ],
-        child: MaterialApp(
-          routes: {
-            NavigationHelper.initial: (_) => const SplashScreen(),
-            NavigationHelper.home: (_) => const Text('home'),
-          },
         ),
-      ),
-    );
+      );
 
-    expect(find.byType(QaulLoadingIndicator), findsOneWidget);
-    expect(find.byKey(SplashScreen.createUserButtonKey), findsNothing);
-  });
+      expect(find.byType(QaulLoadingIndicator), findsOneWidget);
+      expect(find.byKey(SplashScreen.createUserButtonKey), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'does not redirect while refreshing a previous signed-in session',
+    (tester) async {
+      final refreshingSignedIn = const AsyncLoading<QaulAccountSessionState>()
+          .copyWithPrevious(const AsyncData(QaulAccountSessionState.signedIn));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            accountSessionProvider.overrideWithValue(refreshingSignedIn),
+          ],
+          child: MaterialApp(
+            routes: {
+              NavigationHelper.initial: (_) => const SplashScreen(),
+              NavigationHelper.home: (_) => const Text('home'),
+            },
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.byType(SplashScreen), findsOneWidget);
+      expect(find.text('home'), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## Description

Fixes the blank screen that could happen after logging out from an auto-restored session.

When the app started already authenticated, `accountSessionProvider` could keep a previous `signedIn` value while refreshing. During logout, the splash screen listened to that stale value and could redirect back to `/home` before the session key was fully cleared. That left `HomeScreen` mounted without a valid `defaultUserProvider`, resulting in a blank screen and broken session-dependent flows.

The splash screen now only redirects to `/home` when the session provider is resolved and stable, avoiding navigation from stale loading/error states.

### Bug 

https://github.com/user-attachments/assets/13bd86cf-2caf-4958-9a0c-4feea93cd181





### Changes

- Prevent `SplashScreen` from redirecting while `accountSessionProvider` is loading or errored.
- Add a regression test for refreshing a previous signed-in session so it does not navigate back to home.
