### PR TITLE
Apply header on main

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -216,6 +216,51 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
   }
 
+  Widget _buildChatHeader({
+    required ChatRoom room,
+    required AppLocalizations l10n,
+    required User? directPeer,
+    required VoidCallback closeChat,
+    required bool showBackButton,
+  }) {
+    final menuEntries = [
+      for (final option in _overflowMenuOptions.entries)
+        ChatHeaderMenuEntry(id: option.key, label: option.value),
+    ];
+
+    if (_chatRenderMode == ChatRenderMode.group) {
+      return ChatHeader.group(
+        onBackPressed: closeChat,
+        backButtonTooltip: l10n.backButtonTooltip,
+        avatar: QaulAvatar.groupSmall(),
+        groupName: room.name ?? 'Group',
+        membersCount: room.members.length,
+        showBackButton: showBackButton,
+        menuEntries: menuEntries,
+        onMenuSelected: _handleClick,
+      );
+    }
+
+    return ChatHeader(
+      onBackPressed: closeChat,
+      backButtonTooltip: l10n.backButtonTooltip,
+      showBackButton: showBackButton,
+      avatar: Semantics(
+        button: directPeer != null,
+        label: directPeer?.name,
+        child: InkResponse(
+          onTap: directPeer == null ? null : () => _openUserDetails(directPeer),
+          radius: 24,
+          child: QaulAvatar.small(user: directPeer),
+        ),
+      ),
+      displayName: directPeer?.name ?? room.name ?? l10n.unknown,
+      isOnline: false,
+      onlineLabel: '',
+      lastSeenLabel: '',
+    );
+  }
+
   void _scheduleUpdateCurrentOpenChat() =>
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ref.read(currentOpenChatRoom.notifier).state = room;
@@ -278,309 +323,296 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final chatBackgroundColor = QaulColorSheet(
       Theme.of(context).brightness,
     ).background;
+    final showBackButton =
+        MediaQuery.of(context).size.width < Responsiveness.kTabletBreakpoint;
     _chatRenderMode = resolveChatRenderMode(room);
 
     return Scaffold(
       backgroundColor: chatBackgroundColor,
       resizeToAvoidBottomInset: true,
-      appBar: AppBar(
-        backgroundColor: chatBackgroundColor,
-        leading: IconButtonFactory(onPressed: closeChat),
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _chatRenderMode == ChatRenderMode.group
-                ? QaulAvatar.groupSmall()
-                : Semantics(
-                    button: directPeer != null,
-                    label: directPeer?.name,
-                    child: InkResponse(
-                      onTap: directPeer == null
-                          ? null
-                          : () => _openUserDetails(directPeer),
-                      radius: 24,
-                      child: QaulAvatar.small(user: directPeer),
-                    ),
-                  ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                directPeer?.name ?? room.name ?? 'Group',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-        titleSpacing: 0,
-        actions: [
-          if (_overflowMenuOptions.isNotEmpty)
-            PopupMenuButton<String>(
-              onSelected: _handleClick,
-              iconSize: 36,
-              splashRadius: 20,
-              icon: const Icon(Icons.more_vert),
-              itemBuilder: (BuildContext context) {
-                return _overflowMenuOptions.keys.map((String key) {
-                  return PopupMenuItem<String>(
-                    value: key,
-                    child: Text(_overflowMenuOptions[key]!),
-                  );
-                }).toList();
-              },
-            ),
-        ],
-      ),
-      body: CronTaskDecorator(
-        callback: () => refreshCurrentRoom(),
-        schedule: const Duration(milliseconds: 300),
-        child: SafeArea(
-          bottom: false,
-          child: Chat(
-          showUserAvatars: false,
-          showUserNames: false,
-          user: user.toInternalUser(),
-          useTopSafeAreaInset: false,
-          dateHeaderThreshold: const Duration(days: 365).inMilliseconds,
-          groupMessagesThreshold: const Duration(days: 365).inMilliseconds,
-          messages: messages(
-                room,
-                l10n: l10n,
-                renderMode: _chatRenderMode,
-              ) ??
-              [],
-          onSendPressed: sendMessage,
-          inputOptions: const InputOptions(
-            sendButtonVisibilityMode: SendButtonVisibilityMode.always,
+      body: Column(
+        children: [
+          _buildChatHeader(
+            room: room,
+            l10n: l10n,
+            directPeer: directPeer,
+            closeChat: closeChat,
+            showBackButton: showBackButton,
           ),
-          avatarBuilder: (id) {
-            var user = room.members.firstWhereOrNull(
-              (u) => id.id == u.idBase58,
-            );
-            if (user == null) return const SizedBox();
-            return QaulAvatar.small(user: user, badgeEnabled: false);
-          },
-          emptyState: Center(child: Text(l10n.chatEmptyState)),
-          bubbleBuilder: _bubbleBuilder,
-          systemMessageBuilder: _buildSystemMessage,
-          customBottomWidget: _CustomInput(
-            isDisabled: room.status != ChatRoomStatus.active,
-            disabledMessage: room.status != ChatRoomStatus.inviteAccepted
-                ? null
-                : 'Please wait for the admin to confirm your acceptance to send messages',
-            sendButtonVisibilityMode: SendButtonVisibilityMode.editing,
-            hintText: _chatRenderMode == ChatRenderMode.group
-                ? l10n.groupChatMessageHint
-                : l10n.securePrivateMessageHint,
-            onSendPressed: sendMessage,
-            onAttachmentPressed: (room.messages?.isEmpty ?? true)
-                ? null
-                : ({types.PartialText? text}) async {
-                    FilePickerResult? result;
-                    try {
-                      result = await FilePicker.platform.pickFiles();
-                    } catch (e) {
-                      debugPrint(e.toString());
-                    }
-
-                    if (result != null && result.files.single.path != null) {
-                      File file = File(result.files.single.path!);
-
-                      if (!context.mounted) return;
-                      showModalBottomSheet(
-                        context: context,
-                        useSafeArea: true,
-                        isScrollControlled: true,
-                        builder: (context) {
-                          final dialog = _SendFileDialog(
-                            file,
-                            room: room,
-                            partialMessage: text?.text,
-                            onSendPressed: (description) {
-                              final worker = ref.read(qaulWorkerProvider);
-                              worker.sendFile(
-                                pathName: file.path,
-                                conversationId: room.conversationId,
-                                description: description.text,
-                              );
-                            },
-                          );
-                          if (!Platform.isIOS) {
-                            return dialog;
-                          }
-
-                          final bottomPadding = MediaQuery.of(
-                            context,
-                          ).viewInsets.bottom;
-                          return SingleChildScrollView(
-                            child: Container(
-                              padding: EdgeInsets.only(bottom: bottomPadding),
-                              child: dialog,
-                            ),
-                          );
-                        },
-                      );
-                    }
-                  },
-            onPickImagePressed: !(Platform.isAndroid || Platform.isIOS)
-                ? null
-                : (room.messages?.isEmpty ?? true)
-                ? null
-                : ({types.PartialText? text}) async {
-                    final result = await ImagePicker().pickImage(
-                      source: ImageSource.camera,
+          Expanded(
+            child: CronTaskDecorator(
+              callback: () => refreshCurrentRoom(),
+              schedule: const Duration(milliseconds: 300),
+              child: SafeArea(
+                top: false,
+                bottom: false,
+                child: Chat(
+                  showUserAvatars: false,
+                  showUserNames: false,
+                  user: user.toInternalUser(),
+                  useTopSafeAreaInset: false,
+                  dateHeaderThreshold: const Duration(days: 365).inMilliseconds,
+                  groupMessagesThreshold: const Duration(
+                    days: 365,
+                  ).inMilliseconds,
+                  messages:
+                      messages(room, l10n: l10n, renderMode: _chatRenderMode) ??
+                      [],
+                  onSendPressed: sendMessage,
+                  inputOptions: const InputOptions(
+                    sendButtonVisibilityMode: SendButtonVisibilityMode.always,
+                  ),
+                  avatarBuilder: (id) {
+                    var user = room.members.firstWhereOrNull(
+                      (u) => id.id == u.idBase58,
                     );
-
-                    if (result != null) {
-                      File file = File(result.path);
-
-                      if (!context.mounted) return;
-                      showModalBottomSheet(
-                        context: context,
-                        useSafeArea: true,
-                        isScrollControlled: true,
-                        builder: (context) {
-                          final dialog = _SendFileDialog(
-                            file,
-                            room: room,
-                            partialMessage: text?.text,
-                            onSendPressed: (description) {
-                              final worker = ref.read(qaulWorkerProvider);
-                              worker.sendFile(
-                                pathName: file.path,
-                                conversationId: room.conversationId,
-                                description: description.text,
-                              );
-                            },
-                          );
-                          if (!Platform.isIOS) {
-                            return dialog;
-                          }
-
-                          final bottomPadding = MediaQuery.of(
-                            context,
-                          ).viewInsets.bottom;
-                          return SingleChildScrollView(
-                            child: Container(
-                              padding: EdgeInsets.only(bottom: bottomPadding),
-                              child: dialog,
-                            ),
-                          );
-                        },
-                      );
-                    }
+                    if (user == null) return const SizedBox();
+                    return QaulAvatar.small(user: user, badgeEnabled: false);
                   },
-            // the record package is not supported on Linux
-            onSendAudioPressed: Platform.isLinux
-                ? null
-                : (room.messages?.isEmpty ?? true)
-                ? null
-                : ({types.PartialText? text}) async {
-                    // ignore: use_build_context_synchronously
-                    if (!context.mounted) return;
-                    showModalBottomSheet(
-                      context: context,
-                      enableDrag: false,
-                      isDismissible: false,
-                      builder: (_) {
-                        return _RecordAudioDialog(
-                          room: room,
-                          partialMessage: text?.text,
-                          onSendPressed: (file, description) {
-                            final worker = ref.read(qaulWorkerProvider);
-                            worker.sendFile(
-                              pathName: file.path,
-                              conversationId: room.conversationId,
-                              description: description.text,
+                  emptyState: Center(child: Text(l10n.chatEmptyState)),
+                  bubbleBuilder: _bubbleBuilder,
+                  systemMessageBuilder: _buildSystemMessage,
+                  customBottomWidget: _CustomInput(
+                    isDisabled: room.status != ChatRoomStatus.active,
+                    disabledMessage:
+                        room.status != ChatRoomStatus.inviteAccepted
+                        ? null
+                        : 'Please wait for the admin to confirm your acceptance to send messages',
+                    sendButtonVisibilityMode: SendButtonVisibilityMode.editing,
+                    hintText: _chatRenderMode == ChatRenderMode.group
+                        ? l10n.groupChatMessageHint
+                        : l10n.securePrivateMessageHint,
+                    onSendPressed: sendMessage,
+                    onAttachmentPressed: (room.messages?.isEmpty ?? true)
+                        ? null
+                        : ({types.PartialText? text}) async {
+                            FilePickerResult? result;
+                            try {
+                              result = await FilePicker.platform.pickFiles();
+                            } catch (e) {
+                              debugPrint(e.toString());
+                            }
+
+                            if (result != null &&
+                                result.files.single.path != null) {
+                              File file = File(result.files.single.path!);
+
+                              if (!context.mounted) return;
+                              showModalBottomSheet(
+                                context: context,
+                                useSafeArea: true,
+                                isScrollControlled: true,
+                                builder: (context) {
+                                  final dialog = _SendFileDialog(
+                                    file,
+                                    room: room,
+                                    partialMessage: text?.text,
+                                    onSendPressed: (description) {
+                                      final worker = ref.read(
+                                        qaulWorkerProvider,
+                                      );
+                                      worker.sendFile(
+                                        pathName: file.path,
+                                        conversationId: room.conversationId,
+                                        description: description.text,
+                                      );
+                                    },
+                                  );
+                                  if (!Platform.isIOS) {
+                                    return dialog;
+                                  }
+
+                                  final bottomPadding = MediaQuery.of(
+                                    context,
+                                  ).viewInsets.bottom;
+                                  return SingleChildScrollView(
+                                    child: Container(
+                                      padding: EdgeInsets.only(
+                                        bottom: bottomPadding,
+                                      ),
+                                      child: dialog,
+                                    ),
+                                  );
+                                },
+                              );
+                            }
+                          },
+                    onPickImagePressed: !(Platform.isAndroid || Platform.isIOS)
+                        ? null
+                        : (room.messages?.isEmpty ?? true)
+                        ? null
+                        : ({types.PartialText? text}) async {
+                            final result = await ImagePicker().pickImage(
+                              source: ImageSource.camera,
+                            );
+
+                            if (result != null) {
+                              File file = File(result.path);
+
+                              if (!context.mounted) return;
+                              showModalBottomSheet(
+                                context: context,
+                                useSafeArea: true,
+                                isScrollControlled: true,
+                                builder: (context) {
+                                  final dialog = _SendFileDialog(
+                                    file,
+                                    room: room,
+                                    partialMessage: text?.text,
+                                    onSendPressed: (description) {
+                                      final worker = ref.read(
+                                        qaulWorkerProvider,
+                                      );
+                                      worker.sendFile(
+                                        pathName: file.path,
+                                        conversationId: room.conversationId,
+                                        description: description.text,
+                                      );
+                                    },
+                                  );
+                                  if (!Platform.isIOS) {
+                                    return dialog;
+                                  }
+
+                                  final bottomPadding = MediaQuery.of(
+                                    context,
+                                  ).viewInsets.bottom;
+                                  return SingleChildScrollView(
+                                    child: Container(
+                                      padding: EdgeInsets.only(
+                                        bottom: bottomPadding,
+                                      ),
+                                      child: dialog,
+                                    ),
+                                  );
+                                },
+                              );
+                            }
+                          },
+                    // the record package is not supported on Linux
+                    onSendAudioPressed: Platform.isLinux
+                        ? null
+                        : (room.messages?.isEmpty ?? true)
+                        ? null
+                        : ({types.PartialText? text}) async {
+                            // ignore: use_build_context_synchronously
+                            if (!context.mounted) return;
+                            showModalBottomSheet(
+                              context: context,
+                              enableDrag: false,
+                              isDismissible: false,
+                              builder: (_) {
+                                return _RecordAudioDialog(
+                                  room: room,
+                                  partialMessage: text?.text,
+                                  onSendPressed: (file, description) {
+                                    final worker = ref.read(qaulWorkerProvider);
+                                    worker.sendFile(
+                                      pathName: file.path,
+                                      conversationId: room.conversationId,
+                                      description: description.text,
+                                    );
+                                  },
+                                );
+                              },
                             );
                           },
+                  ),
+                  onMessageTap: (context, message) async {
+                    if (message is! types.FileMessage ||
+                        _isReceivingFile(message)) {
+                      return;
+                    }
+                    if (Platform.isIOS || Platform.isAndroid) {
+                      OpenFilex.open(message.uri);
+                      return;
+                    }
+
+                    final file = Uri.file(message.uri);
+
+                    final parentDirectory = File.fromUri(file).parent.uri;
+
+                    for (final uri in [file, parentDirectory]) {
+                      if (await canLaunchUrl(uri)) {
+                        launchUrl(uri);
+                        return;
+                      }
+                    }
+                  },
+                  textMessageBuilder:
+                      (
+                        message, {
+                        required int messageWidth,
+                        required bool showName,
+                      }) {
+                        return TextMessage(
+                          message: message,
+                          usePreviewData: true,
+                          hideBackgroundOnEmojiMessages: true,
+                          showName: false,
+                          emojiEnlargementBehavior:
+                              EmojiEnlargementBehavior.multi,
                         );
                       },
+                  fileMessageBuilder: (message, {required int messageWidth}) {
+                    return SizedBox(
+                      width: messageWidth.toDouble(),
+                      child: FileMessageWidget(
+                        message: message,
+                        isDefaultUser: message.author.id == user.idBase58,
+                      ),
                     );
                   },
-          ),
-          onMessageTap: (context, message) async {
-            if (message is! types.FileMessage || _isReceivingFile(message)) {
-              return;
-            }
-            if (Platform.isIOS || Platform.isAndroid) {
-              OpenFilex.open(message.uri);
-              return;
-            }
-
-            final file = Uri.file(message.uri);
-
-            final parentDirectory = File.fromUri(file).parent.uri;
-
-            for (final uri in [file, parentDirectory]) {
-              if (await canLaunchUrl(uri)) {
-                launchUrl(uri);
-                return;
-              }
-            }
-          },
-          textMessageBuilder:
-              (message, {required int messageWidth, required bool showName}) {
-                return TextMessage(
-                  message: message,
-                  usePreviewData: true,
-                  hideBackgroundOnEmojiMessages: true,
-                  showName: false,
-                  emojiEnlargementBehavior: EmojiEnlargementBehavior.multi,
-                );
-              },
-          fileMessageBuilder: (message, {required int messageWidth}) {
-            return SizedBox(
-              width: messageWidth.toDouble(),
-              child: FileMessageWidget(
-                message: message,
-                isDefaultUser: message.author.id == user.idBase58,
+                  imageMessageBuilder: (message, {required int messageWidth}) {
+                    return ImageMessageWidget(
+                      message: message,
+                      messageWidth: messageWidth,
+                      isDefaultUser: message.author.id == user.idBase58,
+                    );
+                  },
+                  audioMessageBuilder: (message, {required int messageWidth}) {
+                    return AudioMessageWidget(
+                      message: message,
+                      messageWidth: messageWidth,
+                      isDefaultUser: message.author.id == user.idBase58,
+                    );
+                  },
+                  customDateHeaderText: (dt) => DateFormat(
+                    'EEEE, MMMM d, yyyy',
+                    'en',
+                  ).format(dt.toLocal()),
+                  theme: DefaultChatTheme(
+                    userAvatarNameColors: [
+                      colorGenerationStrategy(
+                        directPeer?.idBase58 ??
+                            otherUser?.idBase58 ??
+                            room.idBase58,
+                      ),
+                    ],
+                    backgroundColor: chatBackgroundColor,
+                    messageInsetsVertical: 0,
+                    messageInsetsHorizontal: 0,
+                    dateDividerTextStyle: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w300,
+                      height: 1.2,
+                      color: Colors.white,
+                    ),
+                    bubbleMargin: EdgeInsets.zero,
+                    sentMessageBodyTextStyle: const TextStyle(
+                      fontSize: 17,
+                      color: Colors.white,
+                    ),
+                    receivedMessageBodyTextStyle: const TextStyle(
+                      fontSize: 17,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
               ),
-            );
-          },
-          imageMessageBuilder: (message, {required int messageWidth}) {
-            return ImageMessageWidget(
-              message: message,
-              messageWidth: messageWidth,
-              isDefaultUser: message.author.id == user.idBase58,
-            );
-          },
-          audioMessageBuilder: (message, {required int messageWidth}) {
-            return AudioMessageWidget(
-              message: message,
-              messageWidth: messageWidth,
-              isDefaultUser: message.author.id == user.idBase58,
-            );
-          },
-          customDateHeaderText: (dt) =>
-              DateFormat('EEEE, MMMM d, yyyy', 'en').format(dt.toLocal()),
-          theme: DefaultChatTheme(
-            userAvatarNameColors: [
-              colorGenerationStrategy(
-                directPeer?.idBase58 ?? otherUser?.idBase58 ?? room.idBase58,
-              ),
-            ],
-            backgroundColor: chatBackgroundColor,
-            messageInsetsVertical: 0,
-            messageInsetsHorizontal: 0,
-            dateDividerTextStyle: const TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w300,
-              height: 1.2,
-              color: Colors.white,
-            ),
-            bubbleMargin: EdgeInsets.zero,
-            sentMessageBodyTextStyle: const TextStyle(
-              fontSize: 17,
-              color: Colors.white,
-            ),
-            receivedMessageBodyTextStyle: const TextStyle(
-              fontSize: 17,
-              color: Colors.black,
             ),
           ),
-        ),
-        ),
+        ],
       ),
     );
   }

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_header.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_header.dart
@@ -96,6 +96,7 @@ class ChatHeader extends StatelessWidget {
     required this.onlineLabel,
     required this.lastSeenLabel,
     this.showOnlineIndicatorWhenOnline = true,
+    this.showBackButton = true,
     this.applyTopSafeArea = true,
     this.extraTopPadding = 0,
     this.menuEntries = const [],
@@ -113,6 +114,7 @@ class ChatHeader extends StatelessWidget {
     required String groupName,
     required int membersCount,
     String Function(int count)? formatMembersCount,
+    this.showBackButton = true,
     this.applyTopSafeArea = true,
     this.extraTopPadding = 0,
     this.menuEntries = const [],
@@ -137,6 +139,7 @@ class ChatHeader extends StatelessWidget {
   final String onlineLabel;
   final String lastSeenLabel;
   final bool showOnlineIndicatorWhenOnline;
+  final bool showBackButton;
   final bool applyTopSafeArea;
   final double extraTopPadding;
   final List<ChatHeaderMenuEntry> menuEntries;
@@ -168,6 +171,8 @@ class ChatHeader extends StatelessWidget {
       base: theme.textTheme.bodySmall,
       fontSize: 11,
     );
+    final subtitle = _subtitle(context);
+    final hasSubtitle = subtitle.isNotEmpty;
 
     final menu = menuEntries.isNotEmpty && onMenuSelected != null
         ? _ChatHeaderOverflowMenuButton(
@@ -182,18 +187,20 @@ class ChatHeader extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: _kHorizontalPadding),
         child: Row(
           children: [
-            IconButton(
-              tooltip:
-                  backButtonTooltip ??
-                  MaterialLocalizations.of(context).backButtonTooltip,
-              onPressed: onBackPressed,
-              icon: const Icon(
-                Icons.arrow_back_rounded,
-                size: _kHeaderControlIconSize,
-                color: _kChatHeaderControlColor,
+            if (showBackButton) ...[
+              IconButton(
+                tooltip:
+                    backButtonTooltip ??
+                    MaterialLocalizations.of(context).backButtonTooltip,
+                onPressed: onBackPressed,
+                icon: const Icon(
+                  Icons.arrow_back_rounded,
+                  size: _kHeaderControlIconSize,
+                  color: _kChatHeaderControlColor,
+                ),
               ),
-            ),
-            const SizedBox(width: _kBackAvatarGap),
+              const SizedBox(width: _kBackAvatarGap),
+            ],
             _AvatarWithOnlineBadge(
               showOnline: _showOnlineDot,
               child: SizedBox.square(
@@ -213,13 +220,15 @@ class ChatHeader extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                     style: primaryStyle,
                   ),
-                  const SizedBox(height: _kTitleSubtitleGap),
-                  Text(
-                    _subtitle(context),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: secondaryStyle,
-                  ),
+                  if (hasSubtitle) ...[
+                    const SizedBox(height: _kTitleSubtitleGap),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: secondaryStyle,
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/qaul_ui/packages/qaul_components/test/chat_header_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_header_test.dart
@@ -48,4 +48,31 @@ void main() {
       const QaulColorSheet(Brightness.dark).chatHeaderDivider,
     );
   });
+
+  testWidgets('can hide back button and center title without subtitle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ChatHeader(
+            applyTopSafeArea: false,
+            showBackButton: false,
+            onBackPressed: () {},
+            avatar: const CircleAvatar(child: Text('M')),
+            displayName: 'MaxX',
+            isOnline: false,
+            onlineLabel: '',
+            lastSeenLabel: '',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.arrow_back_rounded), findsNothing);
+    expect(
+      tester.getCenter(find.text('MaxX')).dy,
+      closeTo(tester.getCenter(find.byType(CircleAvatar)).dy, 1),
+    );
+  });
 }

--- a/qaul_ui/test/chat_tab/chat_tab_test.dart
+++ b/qaul_ui/test/chat_tab/chat_tab_test.dart
@@ -6,11 +6,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:local_notifications/src/local_notifications.dart';
 import 'package:logging/logging.dart';
+import 'package:qaul_components/qaul_components.dart'
+    show ChatHeader, QaulComponentsLocalizations;
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:qaul_rpc/src/generated/services/chat/chat.pb.dart';
+import 'package:qaul_ui/l10n/app_localizations.dart';
 import 'package:qaul_ui/providers/providers.dart';
 import 'package:qaul_ui/screens/home/tabs/chat/widgets/chat.dart';
 import 'package:qaul_ui/screens/home/tabs/tab.dart';
+import 'package:qaul_ui/screens/home/user_details_screen.dart';
 import 'package:qaul_ui/widgets/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -42,221 +46,281 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testResponsiveWidgets('empty state chat tab', (tester) async {
+  Future<void> pumpChatScreen(
+    WidgetTester tester,
+    ChatRoom room, {
+    User? otherUser,
+  }) async {
     final wut = ProviderScope(
       overrides: [
-        defaultUserProvider.overrideWith(
-          (_) => defaultUser,
-        ),
-        chatNotificationControllerProvider.overrideWithValue(
-          NullChatNotificationController(),
-        )
-      ],
-      child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
-    );
-
-    await tester.pumpWidget(wut);
-    expect(find.byKey(chatKey), findsOneWidget);
-  }, goldenCallback: (sizeName, tester) async {
-    await expectGoldenMatches(
-      find.byKey(chatKey),
-      '$sizeName.png',
-      subPath: 'emptyState',
-    );
-  }, skip: shouldSkip);
-
-  testResponsiveWidgets('chat tab with group chat', (tester) async {
-    final wut = ProviderScope(
-      overrides: [
-        defaultUserProvider.overrideWith(
-          (_) => defaultUser,
-        ),
+        defaultUserProvider.overrideWith((_) => defaultUser),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
         ),
-        chatRoomsProvider.overrideWith(
-          TestChatRoomListNotifier.new,
-        ),
-        qaulWorkerProvider.overrideWith(
-          (ref) => StubLibqaulWorker(ref),
-        ),
+        chatRoomsProvider.overrideWith(TestChatRoomListNotifier.new),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
       ],
-      child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+      child: materialAppWithLocalizations(
+        ChatScreen(room, defaultUser, otherUser: otherUser),
+      ),
     );
 
     await tester.pumpWidget(wut);
-
-    var chatRoomTileFinder = find.byType(QaulListTile);
-    expect(
-      chatRoomTileFinder,
-      findsOneWidget,
-      reason: 'one chat room available',
-    );
-  }, goldenCallback: (sizeName, tester) async {
-    await expectGoldenMatches(
-      find.byKey(chatKey),
-      '$sizeName.png',
-      subPath: 'tabWithGroupTile',
-    );
-  }, skip: shouldSkip);
-
-  testResponsiveWidgets('opening a group chat', (tester) async {
-    final wut = ProviderScope(
-      overrides: [
-        defaultUserProvider.overrideWith(
-          (_) => defaultUser,
-        ),
-        chatNotificationControllerProvider.overrideWithValue(
-          NullChatNotificationController(),
-        ),
-        chatRoomsProvider.overrideWith(
-          TestChatRoomListNotifier.new,
-        ),
-        qaulWorkerProvider.overrideWith(
-          (ref) => StubLibqaulWorker(ref),
-        ),
-      ],
-      child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
-    );
-
-    await tester.pumpWidget(wut);
-
-    var chatRoomTileFinder = find.byType(QaulListTile);
-    expect(
-      chatRoomTileFinder,
-      findsOneWidget,
-      reason: 'one chat room available',
-    );
-
-    expect(find.byType(ChatScreen), findsNothing, reason: 'no open chats');
-    await tester.tap(chatRoomTileFinder);
-    await tester.pumpAndSettle();
-    expect(find.byType(ChatScreen), findsOneWidget, reason: 'one open chat');
-  }, goldenCallback: (sizeName, tester) async {
-    await expectGoldenMatches(
-      find.byType(ChatScreen),
-      '$sizeName.png',
-      subPath: 'openEmptyChat',
-    );
-  }, skip: shouldSkip);
-
-  testResponsiveWidgets('sending a message to an open group chat',
-      (tester) async {
-    final wut = ProviderScope(
-      overrides: [
-        defaultUserProvider.overrideWith(
-          (_) => defaultUser,
-        ),
-        chatNotificationControllerProvider.overrideWithValue(
-          NullChatNotificationController(),
-        ),
-        chatRoomsProvider.overrideWith(
-          TestChatRoomListNotifier.new,
-        ),
-        qaulWorkerProvider.overrideWith(
-          (ref) => StubLibqaulWorker(ref),
-        ),
-      ],
-      child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
-    );
-
-    await tester.pumpWidget(wut);
-
-    var chatRoomTileFinder = find.byType(QaulListTile);
-    expect(
-      chatRoomTileFinder,
-      findsOneWidget,
-      reason: 'one chat room available',
-    );
-
-    expect(find.byType(ChatScreen), findsNothing, reason: 'no open chats');
-    await tester.tap(chatRoomTileFinder);
-    await tester.pumpAndSettle();
-    expect(find.byType(ChatScreen), findsOneWidget, reason: 'one open chat');
-
-    final sendMessageButtonFinder = find.byType(SendMessageButton);
-
-    await tester.enterText(find.byType(TextField), 'text');
     await tester.pump();
+  }
 
-    expect(sendMessageButtonFinder, findsOneWidget);
-    await tester.tap(sendMessageButtonFinder);
-    await tester.pumpAndSettle();
-  }, goldenCallback: (sizeName, tester) async {
-    await expectGoldenMatches(
-      find.byType(ChatScreen),
-      '$sizeName.png',
-      subPath: 'singleMessage',
+  testWidgets('direct chat renders ChatHeader and opens peer details', (
+    tester,
+  ) async {
+    await pumpChatScreen(tester, buildDirectChat(), otherUser: otherUser);
+
+    expect(find.byType(ChatHeader), findsOneWidget);
+    expect(find.text(otherUser.name), findsOneWidget);
+    expect(find.byTooltip('Back'), findsNothing);
+
+    final avatarTapTarget = find.descendant(
+      of: find.byType(ChatHeader),
+      matching: find.byType(InkResponse),
     );
-  }, skip: shouldSkip);
+    expect(avatarTapTarget, findsOneWidget);
 
-  testResponsiveWidgets('sending multiple messages to an open group chat',
-      (tester) async {
+    await tester.tap(avatarTapTarget);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(UserDetailsScreen), findsOneWidget);
+  });
+
+  testWidgets('group chat renders ChatHeader with menu', (tester) async {
+    await pumpChatScreen(tester, buildGroupChat());
+
+    expect(find.byType(ChatHeader), findsOneWidget);
+    expect(find.text('Group Chat'), findsOneWidget);
+    expect(find.text('2 members'), findsOneWidget);
+    expect(find.byIcon(Icons.more_vert), findsOneWidget);
+    expect(find.byTooltip('Back'), findsNothing);
+  });
+
+  testWidgets('group header menu opens group settings', (tester) async {
+    await pumpChatScreen(tester, buildGroupChat());
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Group Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Members'), findsOneWidget);
+  });
+
+  testWidgets('chat header close pops the mobile chat route', (tester) async {
+    tester.view.physicalSize = const Size(414, 736);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final room = buildDirectChat();
     final wut = ProviderScope(
       overrides: [
-        defaultUserProvider.overrideWith(
-          (_) => defaultUser,
-        ),
+        defaultUserProvider.overrideWith((_) => defaultUser),
         chatNotificationControllerProvider.overrideWithValue(
           NullChatNotificationController(),
         ),
-        chatRoomsProvider.overrideWith(
-          TestChatRoomListNotifier.new,
-        ),
-        qaulWorkerProvider.overrideWith(
-          (ref) => StubLibqaulWorker(ref),
-        ),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
       ],
-      child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+      child: MaterialApp(
+        localizationsDelegates: [
+          ...AppLocalizations.localizationsDelegates,
+          QaulComponentsLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) =>
+                      ChatScreen(room, defaultUser, otherUser: otherUser),
+                  settings: const RouteSettings(name: '/chat'),
+                ),
+              );
+            },
+            child: const Text('Open chat'),
+          ),
+        ),
+      ),
     );
 
     await tester.pumpWidget(wut);
+    await tester.tap(find.text('Open chat'));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(ChatHeader), findsOneWidget);
 
-    var chatRoomTileFinder = find.byType(QaulListTile);
-    expect(
-      chatRoomTileFinder,
-      findsOneWidget,
-      reason: 'one chat room available',
-    );
-
-    expect(find.byType(ChatScreen), findsNothing, reason: 'no open chats');
-    await tester.tap(chatRoomTileFinder);
+    await tester.tap(find.byTooltip('Back'));
     await tester.pumpAndSettle();
-    expect(find.byType(ChatScreen), findsOneWidget, reason: 'one open chat');
 
-    final sendMessageButtonFinder = find.byType(SendMessageButton);
-
-    for (var i = 0; i < 10; i++) {
-      await tester.enterText(find.byType(TextField), 'text$i');
-      await tester.pump();
-      await tester.tap(sendMessageButtonFinder);
-      await tester.pumpAndSettle();
-    }
-  }, goldenCallback: (sizeName, tester) async {
-    await expectGoldenMatches(
-      find.byType(ChatScreen),
-      '$sizeName.png',
-      subPath: 'multipleMessages',
-    );
-  }, skip: shouldSkip);
+    expect(find.byType(ChatHeader), findsNothing);
+    expect(find.text('Open chat'), findsOneWidget);
+  });
 
   testResponsiveWidgets(
-    'sending 10 messages and then close the group chat',
+    'empty state chat tab',
     (tester) async {
       final wut = ProviderScope(
         overrides: [
-          defaultUserProvider.overrideWith(
-            (_) => defaultUser,
-          ),
+          defaultUserProvider.overrideWith((_) => defaultUser),
           chatNotificationControllerProvider.overrideWithValue(
             NullChatNotificationController(),
           ),
-          chatRoomsProvider.overrideWith(
-            TestChatRoomListNotifier.new,
+        ],
+        child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+      );
+
+      await tester.pumpWidget(wut);
+      expect(find.byKey(chatKey), findsOneWidget);
+    },
+    goldenCallback: (sizeName, tester) async {
+      await expectGoldenMatches(
+        find.byKey(chatKey),
+        '$sizeName.png',
+        subPath: 'emptyState',
+      );
+    },
+    skip: shouldSkip,
+  );
+
+  testResponsiveWidgets(
+    'chat tab with group chat',
+    (tester) async {
+      final wut = ProviderScope(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          chatNotificationControllerProvider.overrideWithValue(
+            NullChatNotificationController(),
           ),
-          qaulWorkerProvider.overrideWith(
-            (ref) => StubLibqaulWorker(ref),
+          chatRoomsProvider.overrideWith(TestChatRoomListNotifier.new),
+          qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+        ],
+        child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+      );
+
+      await tester.pumpWidget(wut);
+
+      var chatRoomTileFinder = find.byType(QaulListTile);
+      expect(
+        chatRoomTileFinder,
+        findsOneWidget,
+        reason: 'one chat room available',
+      );
+    },
+    goldenCallback: (sizeName, tester) async {
+      await expectGoldenMatches(
+        find.byKey(chatKey),
+        '$sizeName.png',
+        subPath: 'tabWithGroupTile',
+      );
+    },
+    skip: shouldSkip,
+  );
+
+  testResponsiveWidgets(
+    'opening a group chat',
+    (tester) async {
+      final wut = ProviderScope(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          chatNotificationControllerProvider.overrideWithValue(
+            NullChatNotificationController(),
           ),
+          chatRoomsProvider.overrideWith(TestChatRoomListNotifier.new),
+          qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+        ],
+        child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+      );
+
+      await tester.pumpWidget(wut);
+
+      var chatRoomTileFinder = find.byType(QaulListTile);
+      expect(
+        chatRoomTileFinder,
+        findsOneWidget,
+        reason: 'one chat room available',
+      );
+
+      expect(find.byType(ChatScreen), findsNothing, reason: 'no open chats');
+      await tester.tap(chatRoomTileFinder);
+      await tester.pumpAndSettle();
+      expect(find.byType(ChatScreen), findsOneWidget, reason: 'one open chat');
+    },
+    goldenCallback: (sizeName, tester) async {
+      await expectGoldenMatches(
+        find.byType(ChatScreen),
+        '$sizeName.png',
+        subPath: 'openEmptyChat',
+      );
+    },
+    skip: shouldSkip,
+  );
+
+  testResponsiveWidgets(
+    'sending a message to an open group chat',
+    (tester) async {
+      final wut = ProviderScope(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          chatNotificationControllerProvider.overrideWithValue(
+            NullChatNotificationController(),
+          ),
+          chatRoomsProvider.overrideWith(TestChatRoomListNotifier.new),
+          qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+        ],
+        child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+      );
+
+      await tester.pumpWidget(wut);
+
+      var chatRoomTileFinder = find.byType(QaulListTile);
+      expect(
+        chatRoomTileFinder,
+        findsOneWidget,
+        reason: 'one chat room available',
+      );
+
+      expect(find.byType(ChatScreen), findsNothing, reason: 'no open chats');
+      await tester.tap(chatRoomTileFinder);
+      await tester.pumpAndSettle();
+      expect(find.byType(ChatScreen), findsOneWidget, reason: 'one open chat');
+
+      final sendMessageButtonFinder = find.byType(SendMessageButton);
+
+      await tester.enterText(find.byType(TextField), 'text');
+      await tester.pump();
+
+      expect(sendMessageButtonFinder, findsOneWidget);
+      await tester.tap(sendMessageButtonFinder);
+      await tester.pumpAndSettle();
+    },
+    goldenCallback: (sizeName, tester) async {
+      await expectGoldenMatches(
+        find.byType(ChatScreen),
+        '$sizeName.png',
+        subPath: 'singleMessage',
+      );
+    },
+    skip: shouldSkip,
+  );
+
+  testResponsiveWidgets(
+    'sending multiple messages to an open group chat',
+    (tester) async {
+      final wut = ProviderScope(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => defaultUser),
+          chatNotificationControllerProvider.overrideWithValue(
+            NullChatNotificationController(),
+          ),
+          chatRoomsProvider.overrideWith(TestChatRoomListNotifier.new),
+          qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
         ],
         child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
       );
@@ -283,11 +347,57 @@ void main() {
         await tester.tap(sendMessageButtonFinder);
         await tester.pumpAndSettle();
       }
-
-      await tester.tap(find.byType(IconButtonFactory));
-      await tester.pumpAndSettle();
-      expect(find.byType(ChatScreen), findsNothing, reason: 'chat was closed');
+    },
+    goldenCallback: (sizeName, tester) async {
+      await expectGoldenMatches(
+        find.byType(ChatScreen),
+        '$sizeName.png',
+        subPath: 'multipleMessages',
+      );
     },
     skip: shouldSkip,
   );
+
+  testResponsiveWidgets('sending 10 messages and then close the group chat', (
+    tester,
+  ) async {
+    final wut = ProviderScope(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        chatNotificationControllerProvider.overrideWithValue(
+          NullChatNotificationController(),
+        ),
+        chatRoomsProvider.overrideWith(TestChatRoomListNotifier.new),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+      ],
+      child: materialAppWithLocalizations(BaseTab.chat(key: chatKey)),
+    );
+
+    await tester.pumpWidget(wut);
+
+    var chatRoomTileFinder = find.byType(QaulListTile);
+    expect(
+      chatRoomTileFinder,
+      findsOneWidget,
+      reason: 'one chat room available',
+    );
+
+    expect(find.byType(ChatScreen), findsNothing, reason: 'no open chats');
+    await tester.tap(chatRoomTileFinder);
+    await tester.pumpAndSettle();
+    expect(find.byType(ChatScreen), findsOneWidget, reason: 'one open chat');
+
+    final sendMessageButtonFinder = find.byType(SendMessageButton);
+
+    for (var i = 0; i < 10; i++) {
+      await tester.enterText(find.byType(TextField), 'text$i');
+      await tester.pump();
+      await tester.tap(sendMessageButtonFinder);
+      await tester.pumpAndSettle();
+    }
+
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ChatScreen), findsNothing, reason: 'chat was closed');
+  }, skip: shouldSkip);
 }

--- a/qaul_ui/test/chat_tab/fixtures.dart
+++ b/qaul_ui/test/chat_tab/fixtures.dart
@@ -17,6 +17,17 @@ ChatRoom buildGroupChat({List<Message>? messages}) => ChatRoom(
   isDirectChat: false,
   members: [
     ChatRoomUser(defaultUser, joinedAt: DateTime(2000)),
+    ChatRoomUser(otherUser, joinedAt: DateTime(2000)),
+  ],
+);
+
+ChatRoom buildDirectChat({List<Message>? messages}) => ChatRoom(
+  name: otherUser.name,
+  messages: messages,
+  conversationId: Uint8List.fromList('directId'.codeUnits),
+  isDirectChat: true,
+  members: [
     ChatRoomUser(defaultUser, joinedAt: DateTime(2000)),
+    ChatRoomUser(otherUser, joinedAt: DateTime(2000)),
   ],
 );

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -158,7 +158,21 @@ class StubLibqaulWorker implements LibqaulWorker {
   }) => throw UnimplementedError();
 
   @override
-  Future<ChatRoom?> getGroupInfo(Uint8List id) => throw UnimplementedError();
+  Future<ChatRoom?> getGroupInfo(Uint8List id) async {
+    _logger.info('requested group info fetch; ignoring...');
+    for (final room in ref.read(chatRoomsProvider)) {
+      if (_bytesEqual(room.conversationId, id)) return room;
+    }
+    return null;
+  }
+
+  bool _bytesEqual(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
 
   @override
   Future<PaginatedUsers?> getOnlineUsers({int? offset, int? limit}) =>

--- a/qaul_ui/test/test_utils/test_utils.dart
+++ b/qaul_ui/test/test_utils/test_utils.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+import 'package:qaul_components/qaul_components.dart';
 import 'package:qaul_ui/l10n/app_localizations.dart';
 
 part 'screenshot_comparator.dart';
@@ -13,7 +14,10 @@ part 'test_responsive_widgets.dart';
 
 Widget materialAppWithLocalizations(Widget wut) {
   return MaterialApp(
-    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    localizationsDelegates: [
+      ...AppLocalizations.localizationsDelegates,
+      QaulComponentsLocalizations.delegate,
+    ],
     supportedLocales: AppLocalizations.supportedLocales,
     home: Material(child: Builder(builder: (context) => wut)),
   );


### PR DESCRIPTION
## Description
Replaced the chat screen’s inline AppBar with the Widgetbook-backed ChatHeader from qaul_components.

This wires the real chat screen to the design-system header for both direct and group chats, preserving the existing mobile close/back behavior, direct chat avatar tap behavior, and group settings overflow menu. Desktop/tablet layouts now hide the back arrow, while mobile keeps it for returning to the previous screen.

Also added focused widget coverage for direct headers, group headers, menu selection, mobile close behavior, and the compact header layout without a subtitle.

## Evidence

### Before
<img width="250" alt="Screenshot 2026-08-13 at 10 50 17" src="https://github.com/user-attachments/assets/b80c4691-bb9a-49ab-b9c5-3fbe96e4bca1" />

### After
<img width="250" alt="Screenshot 2026-08-13 at 10 39 47" src="https://github.com/user-attachments/assets/80d47b29-91a0-4896-bee6-3dda60fd2661" />

