### PR TITLE
Apply chat footer on main

### DIFF
--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/audio_recording.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/audio_recording.dart
@@ -4,10 +4,8 @@ class _RecordAudioDialog extends StatefulHookConsumerWidget {
   const _RecordAudioDialog({
     required this.room,
     required this.onSendPressed,
-    this.partialMessage,
   });
   final ChatRoom room;
-  final String? partialMessage;
   final Function(File f, types.PartialText desc) onSendPressed;
 
   @override

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -263,6 +263,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     _openSendFileDialog(file, room);
   }
 
+  Future<void> _openAttachmentPicker(ChatRoom room) async {
+    final result = await FilePicker.platform.pickFiles();
+    if (result?.files.single.path == null || !mounted) return;
+    _openSendFileDialog(File(result!.files.single.path!), room);
+  }
+
   void _openAudioRecorder(ChatRoom room) {
     showModalBottomSheet(
       context: context,
@@ -454,6 +460,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                         ? null
                         : () => _openAudioRecorder(room),
                     onPickImagePressed: () => _openPhotoPicker(room),
+                    onAttachmentPressed: () => _openAttachmentPicker(room),
                   ),
                   onMessageTap: (context, message) async {
                     if (message is! types.FileMessage ||

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -216,6 +216,74 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
   }
 
+  void _openSendFileDialog(File file, ChatRoom room) {
+    showModalBottomSheet(
+      context: context,
+      useSafeArea: true,
+      isScrollControlled: true,
+      builder: (context) {
+        final dialog = _SendFileDialog(
+          file,
+          room: room,
+          onSendPressed: (description) {
+            final worker = ref.read(qaulWorkerProvider);
+            worker.sendFile(
+              pathName: file.path,
+              conversationId: room.conversationId,
+              description: description.text,
+            );
+          },
+        );
+        if (!Platform.isIOS) return dialog;
+
+        final bottomPadding = MediaQuery.of(context).viewInsets.bottom;
+        return SingleChildScrollView(
+          child: Container(
+            padding: EdgeInsets.only(bottom: bottomPadding),
+            child: dialog,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _openPhotoPicker(ChatRoom room) async {
+    File? file;
+    if (Platform.isAndroid || Platform.isIOS) {
+      final result = await ImagePicker().pickImage(source: ImageSource.camera);
+      if (result != null) file = File(result.path);
+    } else {
+      final result = await FilePicker.platform.pickFiles(type: FileType.image);
+      if (result?.files.single.path != null) {
+        file = File(result!.files.single.path!);
+      }
+    }
+
+    if (file == null || !mounted) return;
+    _openSendFileDialog(file, room);
+  }
+
+  void _openAudioRecorder(ChatRoom room) {
+    showModalBottomSheet(
+      context: context,
+      enableDrag: false,
+      isDismissible: false,
+      builder: (_) {
+        return _RecordAudioDialog(
+          room: room,
+          onSendPressed: (file, description) {
+            final worker = ref.read(qaulWorkerProvider);
+            worker.sendFile(
+              pathName: file.path,
+              conversationId: room.conversationId,
+              description: description.text,
+            );
+          },
+        );
+      },
+    );
+  }
+
   Widget _buildChatHeader({
     required ChatRoom room,
     required AppLocalizations l10n,
@@ -372,151 +440,20 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   emptyState: Center(child: Text(l10n.chatEmptyState)),
                   bubbleBuilder: _bubbleBuilder,
                   systemMessageBuilder: _buildSystemMessage,
-                  customBottomWidget: _CustomInput(
+                  customBottomWidget: _ChatTextFooter(
                     isDisabled: room.status != ChatRoomStatus.active,
                     disabledMessage:
                         room.status != ChatRoomStatus.inviteAccepted
                         ? null
                         : 'Please wait for the admin to confirm your acceptance to send messages',
-                    sendButtonVisibilityMode: SendButtonVisibilityMode.editing,
                     hintText: _chatRenderMode == ChatRenderMode.group
                         ? l10n.groupChatMessageHint
                         : l10n.securePrivateMessageHint,
                     onSendPressed: sendMessage,
-                    onAttachmentPressed: (room.messages?.isEmpty ?? true)
-                        ? null
-                        : ({types.PartialText? text}) async {
-                            FilePickerResult? result;
-                            try {
-                              result = await FilePicker.platform.pickFiles();
-                            } catch (e) {
-                              debugPrint(e.toString());
-                            }
-
-                            if (result != null &&
-                                result.files.single.path != null) {
-                              File file = File(result.files.single.path!);
-
-                              if (!context.mounted) return;
-                              showModalBottomSheet(
-                                context: context,
-                                useSafeArea: true,
-                                isScrollControlled: true,
-                                builder: (context) {
-                                  final dialog = _SendFileDialog(
-                                    file,
-                                    room: room,
-                                    partialMessage: text?.text,
-                                    onSendPressed: (description) {
-                                      final worker = ref.read(
-                                        qaulWorkerProvider,
-                                      );
-                                      worker.sendFile(
-                                        pathName: file.path,
-                                        conversationId: room.conversationId,
-                                        description: description.text,
-                                      );
-                                    },
-                                  );
-                                  if (!Platform.isIOS) {
-                                    return dialog;
-                                  }
-
-                                  final bottomPadding = MediaQuery.of(
-                                    context,
-                                  ).viewInsets.bottom;
-                                  return SingleChildScrollView(
-                                    child: Container(
-                                      padding: EdgeInsets.only(
-                                        bottom: bottomPadding,
-                                      ),
-                                      child: dialog,
-                                    ),
-                                  );
-                                },
-                              );
-                            }
-                          },
-                    onPickImagePressed: !(Platform.isAndroid || Platform.isIOS)
-                        ? null
-                        : (room.messages?.isEmpty ?? true)
-                        ? null
-                        : ({types.PartialText? text}) async {
-                            final result = await ImagePicker().pickImage(
-                              source: ImageSource.camera,
-                            );
-
-                            if (result != null) {
-                              File file = File(result.path);
-
-                              if (!context.mounted) return;
-                              showModalBottomSheet(
-                                context: context,
-                                useSafeArea: true,
-                                isScrollControlled: true,
-                                builder: (context) {
-                                  final dialog = _SendFileDialog(
-                                    file,
-                                    room: room,
-                                    partialMessage: text?.text,
-                                    onSendPressed: (description) {
-                                      final worker = ref.read(
-                                        qaulWorkerProvider,
-                                      );
-                                      worker.sendFile(
-                                        pathName: file.path,
-                                        conversationId: room.conversationId,
-                                        description: description.text,
-                                      );
-                                    },
-                                  );
-                                  if (!Platform.isIOS) {
-                                    return dialog;
-                                  }
-
-                                  final bottomPadding = MediaQuery.of(
-                                    context,
-                                  ).viewInsets.bottom;
-                                  return SingleChildScrollView(
-                                    child: Container(
-                                      padding: EdgeInsets.only(
-                                        bottom: bottomPadding,
-                                      ),
-                                      child: dialog,
-                                    ),
-                                  );
-                                },
-                              );
-                            }
-                          },
-                    // the record package is not supported on Linux
                     onSendAudioPressed: Platform.isLinux
                         ? null
-                        : (room.messages?.isEmpty ?? true)
-                        ? null
-                        : ({types.PartialText? text}) async {
-                            // ignore: use_build_context_synchronously
-                            if (!context.mounted) return;
-                            showModalBottomSheet(
-                              context: context,
-                              enableDrag: false,
-                              isDismissible: false,
-                              builder: (_) {
-                                return _RecordAudioDialog(
-                                  room: room,
-                                  partialMessage: text?.text,
-                                  onSendPressed: (file, description) {
-                                    final worker = ref.read(qaulWorkerProvider);
-                                    worker.sendFile(
-                                      pathName: file.path,
-                                      conversationId: room.conversationId,
-                                      description: description.text,
-                                    );
-                                  },
-                                );
-                              },
-                            );
-                          },
+                        : () => _openAudioRecorder(room),
+                    onPickImagePressed: () => _openPhotoPicker(room),
                   ),
                   onMessageTap: (context, message) async {
                     if (message is! types.FileMessage ||

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/custom_input.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/custom_input.dart
@@ -12,6 +12,7 @@ class _ChatTextFooter extends StatefulWidget {
   const _ChatTextFooter({
     required this.onSendPressed,
     required this.hintText,
+    this.onAttachmentPressed,
     this.onPickImagePressed,
     this.onSendAudioPressed,
     this.disabledMessage,
@@ -19,6 +20,7 @@ class _ChatTextFooter extends StatefulWidget {
   });
 
   final void Function(types.PartialText) onSendPressed;
+  final VoidCallback? onAttachmentPressed;
   final VoidCallback? onPickImagePressed;
   final VoidCallback? onSendAudioPressed;
   final bool isDisabled;
@@ -58,9 +60,11 @@ class _ChatTextFooterState extends State<_ChatTextFooter> {
       onSend: _handleSend,
       onVoicePressed: widget.isDisabled ? null : widget.onSendAudioPressed,
       onCameraPressed: widget.isDisabled ? null : widget.onPickImagePressed,
+      onAttachmentPressed: widget.isDisabled ? null : widget.onAttachmentPressed,
       sendTooltip: AppLocalizations.of(context)!.sendTooltip,
       voiceTooltip: AppLocalizations.of(context)!.sendAudioTooltip,
       cameraTooltip: AppLocalizations.of(context)!.sendFileTooltip,
+      attachmentsTooltip: AppLocalizations.of(context)!.sendFileTooltip,
     );
 
     return Stack(

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/custom_input.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/custom_input.dart
@@ -98,15 +98,12 @@ class _CustomInput extends StatefulWidget {
     required this.onSendPressed,
     required this.sendButtonVisibilityMode,
     required this.hintText,
-    this.initialText,
     this.isTextRequired = true,
   });
 
   final void Function(types.PartialText) onSendPressed;
 
   final SendButtonVisibilityMode sendButtonVisibilityMode;
-
-  final String? initialText;
 
   final String hintText;
 
@@ -126,7 +123,7 @@ class _CustomInputState extends State<_CustomInput> {
   void initState() {
     super.initState();
 
-    _textController = TextEditingController(text: widget.initialText);
+    _textController = TextEditingController();
 
     if (widget.sendButtonVisibilityMode == SendButtonVisibilityMode.editing) {
       _sendButtonVisible = _textController.text.trim() != '';

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/custom_input.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/custom_input.dart
@@ -8,6 +8,86 @@ class SendMessageIntent extends Intent {
   const SendMessageIntent();
 }
 
+class _ChatTextFooter extends StatefulWidget {
+  const _ChatTextFooter({
+    required this.onSendPressed,
+    required this.hintText,
+    this.onPickImagePressed,
+    this.onSendAudioPressed,
+    this.disabledMessage,
+    this.isDisabled = false,
+  });
+
+  final void Function(types.PartialText) onSendPressed;
+  final VoidCallback? onPickImagePressed;
+  final VoidCallback? onSendAudioPressed;
+  final bool isDisabled;
+  final String? disabledMessage;
+  final String hintText;
+
+  @override
+  State<_ChatTextFooter> createState() => _ChatTextFooterState();
+}
+
+class _ChatTextFooterState extends State<_ChatTextFooter> {
+  late final TextEditingController _textController;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  void _handleSend(String text) {
+    if (widget.isDisabled) return;
+    widget.onSendPressed(types.PartialText(text: text));
+    _textController.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final footer = ChatFooter(
+      controller: _textController,
+      placeholder: widget.hintText,
+      onSend: _handleSend,
+      onVoicePressed: widget.isDisabled ? null : widget.onSendAudioPressed,
+      onCameraPressed: widget.isDisabled ? null : widget.onPickImagePressed,
+      sendTooltip: AppLocalizations.of(context)!.sendTooltip,
+      voiceTooltip: AppLocalizations.of(context)!.sendAudioTooltip,
+      cameraTooltip: AppLocalizations.of(context)!.sendFileTooltip,
+    );
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Opacity(
+          opacity: widget.isDisabled ? 0.3 : 1,
+          child: footer,
+        ),
+        if (widget.isDisabled && widget.disabledMessage != null)
+          Container(
+            color: Colors.black54,
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 20),
+            child: Text(
+              widget.disabledMessage!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
 /// The original [Input] class from flutter_chat_ui provided no customization for
 /// the spacing of the Send button spacing.
 ///
@@ -18,30 +98,15 @@ class _CustomInput extends StatefulWidget {
     required this.onSendPressed,
     required this.sendButtonVisibilityMode,
     required this.hintText,
-    this.onAttachmentPressed,
-    this.onPickImagePressed,
-    this.onSendAudioPressed,
     this.initialText,
-    this.disabledMessage,
-    this.isDisabled = false,
     this.isTextRequired = true,
   });
 
   final void Function(types.PartialText) onSendPressed;
 
-  final Function({types.PartialText? text})? onAttachmentPressed;
-
-  final Function({types.PartialText? text})? onPickImagePressed;
-
-  final Function({types.PartialText? text})? onSendAudioPressed;
-
   final SendButtonVisibilityMode sendButtonVisibilityMode;
 
   final String? initialText;
-
-  final bool isDisabled;
-
-  final String? disabledMessage;
 
   final String hintText;
 
@@ -87,20 +152,6 @@ class _CustomInputState extends State<_CustomInput> {
     }
   }
 
-  void _sendFilePressed(Function({types.PartialText? text})? callback) {
-    if (callback == null) return;
-
-    final trimmedText = _textController.text.trim();
-    if (trimmedText == '') {
-      callback();
-      return;
-    }
-
-    final partialText = types.PartialText(text: trimmedText);
-    callback(text: partialText);
-    _textController.clear();
-  }
-
   void _handleTextControllerChange() {
     setState(() {
       _sendButtonVisible = _textController.text.trim() != '';
@@ -111,128 +162,74 @@ class _CustomInputState extends State<_CustomInput> {
   Widget build(BuildContext context) {
     final query = MediaQuery.of(context);
 
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        Opacity(
-          opacity: widget.isDisabled ? 0.3 : 1,
-          child: IgnorePointer(
-            ignoring: widget.isDisabled,
-            child: GestureDetector(
-              onTap: () => _inputFocusNode.requestFocus(),
-              child: Shortcuts(
-                shortcuts: {
-                  LogicalKeySet(LogicalKeyboardKey.enter):
-                      const SendMessageIntent(),
-                  LogicalKeySet(
-                          LogicalKeyboardKey.enter, LogicalKeyboardKey.alt):
-                      const NewLineIntent(),
-                  LogicalKeySet(
-                          LogicalKeyboardKey.enter, LogicalKeyboardKey.shift):
-                      const NewLineIntent(),
-                },
-                child: Actions(
-                  actions: {
-                    SendMessageIntent: CallbackAction<SendMessageIntent>(
-                      onInvoke: (SendMessageIntent intent) =>
-                          _handleSendPressed(),
-                    ),
-                    NewLineIntent: CallbackAction<NewLineIntent>(
-                      onInvoke: (NewLineIntent intent) {
-                        final newValue = '${_textController.text}\r\n';
-                        _textController.value = TextEditingValue(
-                          text: newValue,
-                          selection: TextSelection.fromPosition(
-                            TextPosition(offset: newValue.length),
-                          ),
-                        );
-                        return null;
-                      },
-                    ),
-                  },
-                  child: Focus(
-                    autofocus: true,
-                    child: Material(
-                      borderRadius: BorderRadius.circular(20),
-                      color: Colors.transparent,
-                      child: Container(
-                        padding: EdgeInsets.fromLTRB(
-                          24 + query.padding.left,
-                          20,
-                          24 + query.padding.right,
-                          20 + query.viewInsets.bottom + query.padding.bottom,
+    return GestureDetector(
+      onTap: () => _inputFocusNode.requestFocus(),
+      child: Shortcuts(
+        shortcuts: {
+          LogicalKeySet(LogicalKeyboardKey.enter): const SendMessageIntent(),
+          LogicalKeySet(LogicalKeyboardKey.enter, LogicalKeyboardKey.alt):
+              const NewLineIntent(),
+          LogicalKeySet(LogicalKeyboardKey.enter, LogicalKeyboardKey.shift):
+              const NewLineIntent(),
+        },
+        child: Actions(
+          actions: {
+            SendMessageIntent: CallbackAction<SendMessageIntent>(
+              onInvoke: (SendMessageIntent intent) => _handleSendPressed(),
+            ),
+            NewLineIntent: CallbackAction<NewLineIntent>(
+              onInvoke: (NewLineIntent intent) {
+                final newValue = '${_textController.text}\r\n';
+                _textController.value = TextEditingValue(
+                  text: newValue,
+                  selection: TextSelection.fromPosition(
+                    TextPosition(offset: newValue.length),
+                  ),
+                );
+                return null;
+              },
+            ),
+          },
+          child: Focus(
+            autofocus: true,
+            child: Material(
+              borderRadius: BorderRadius.circular(20),
+              color: Colors.transparent,
+              child: Container(
+                padding: EdgeInsets.fromLTRB(
+                  24 + query.padding.left,
+                  20,
+                  24 + query.padding.right,
+                  20 + query.viewInsets.bottom + query.padding.bottom,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: _textController,
+                        style: const TextStyle(fontSize: 17),
+                        decoration: InputDecoration(
+                          labelText: widget.hintText,
                         ),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: TextField(
-                                controller: _textController,
-                                style: const TextStyle(fontSize: 17),
-                                decoration: InputDecoration(
-                                  labelText: widget.hintText,
-                                  suffixIcon: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      if (widget.onAttachmentPressed != null)
-                                        _AttachmentButton(
-                                          onPressed: () => _sendFilePressed(
-                                              widget.onAttachmentPressed),
-                                          tooltip: AppLocalizations.of(context)!.sendFileTooltip,    
-                                        ),
-                                      if (widget.onPickImagePressed != null)
-                                        _AttachmentButton(
-                                          icon: Icons.add_a_photo,
-                                          onPressed: () => _sendFilePressed(
-                                              widget.onPickImagePressed),
-                                          tooltip: AppLocalizations.of(context)!.sendFileTooltip,    
-                                        ),
-                                      if (widget.onSendAudioPressed != null)
-                                        _AttachmentButton(
-                                          icon: Icons.mic_none,
-                                          onPressed: widget.onSendAudioPressed,
-                                          tooltip: AppLocalizations.of(context)!.sendAudioTooltip,
-                                        ),
-                                    ],
-                                  ),
-                                ),
-                                focusNode: _inputFocusNode,
-                                keyboardType: TextInputType.multiline,
-                                maxLines: 5,
-                                minLines: 1,
-                                textCapitalization:
-                                    TextCapitalization.sentences,
-                              ),
-                            ),
-                            const SizedBox(width: 16.0),
-                            Visibility(
-                              visible: _sendButtonVisible,
-                              child: SendMessageButton(
-                                  onPressed: _handleSendPressed),
-                            ),
-                          ],
-                        ),
+                        focusNode: _inputFocusNode,
+                        keyboardType: TextInputType.multiline,
+                        maxLines: 5,
+                        minLines: 1,
+                        textCapitalization: TextCapitalization.sentences,
                       ),
                     ),
-                  ),
+                    const SizedBox(width: 16.0),
+                    Visibility(
+                      visible: _sendButtonVisible,
+                      child: SendMessageButton(onPressed: _handleSendPressed),
+                    ),
+                  ],
                 ),
               ),
             ),
           ),
         ),
-        if (widget.isDisabled && widget.disabledMessage != null)
-          Container(
-            color: Colors.black54,
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 20),
-            child: Text(
-              widget.disabledMessage!,
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                color: Colors.white,
-                fontStyle: FontStyle.italic,
-              ),
-            ),
-          )
-      ],
+      ),
     );
   }
 }
@@ -253,36 +250,6 @@ class SendMessageButton extends StatelessWidget {
         onPressed: onPressed,
         padding: EdgeInsets.zero,
         tooltip: AppLocalizations.of(context)!.sendTooltip,
-      ),
-    );
-  }
-}
-
-class _AttachmentButton extends StatelessWidget {
-  const _AttachmentButton({
-    this.onPressed,
-    this.icon = Icons.attach_file,
-    this.tooltip,
-  });
-
-  final void Function()? onPressed;
-
-  final IconData icon;
-
-  final String? tooltip;
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 24,
-      height: 24,
-      margin: const EdgeInsets.only(right: 16),
-      child: IconButton(
-        color: Theme.of(context).iconTheme.color,
-        icon: Icon(icon),
-        splashRadius: 24,
-        onPressed: onPressed,
-        padding: EdgeInsets.zero,
-        tooltip: tooltip,
       ),
     );
   }

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/file_sharing.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/file_sharing.dart
@@ -5,11 +5,9 @@ class _SendFileDialog extends HookConsumerWidget {
     this.file, {
     required this.room,
     required this.onSendPressed,
-    this.partialMessage,
   });
   final File file;
   final ChatRoom room;
-  final String? partialMessage;
   final Function(types.PartialText) onSendPressed;
 
   @override
@@ -45,7 +43,6 @@ class _SendFileDialog extends HookConsumerWidget {
         ),
         const SizedBox(height: 8),
         _CustomInput(
-          initialText: partialMessage,
           isTextRequired: false,
           hintText: AppLocalizations.of(context)!.chatEmptyMessageHint,
           onSendPressed: (desc) {

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer/chat_footer.dart
@@ -288,6 +288,7 @@ class _ChatFooterState extends State<ChatFooter> {
   }
 
   void _handleMoreAttachmentsPressed() {
+    if (_attachmentActions().isEmpty) return;
     setState(() {
       final willOpen = !_isAttachmentMenuOpen;
       _isAttachmentMenuOpen = willOpen;
@@ -325,86 +326,38 @@ class _ChatFooterState extends State<ChatFooter> {
 
   List<_FooterAttachmentAction> _attachmentActions() {
     return [
-      _FooterAttachmentAction(
-        id: 'audio',
-        icon: const _ChatFooterSvgIcon(asset: _kMicrophoneSvg),
-        tooltip: widget.voiceTooltip,
-        onPressed: () => _handleAttachmentAction(widget.onVoicePressed),
-      ),
-      _FooterAttachmentAction(
-        id: 'photo',
-        icon: const _ChatFooterSvgIcon(asset: _kPhotosSvg),
-        tooltip: widget.cameraTooltip,
-        onPressed: () => _handleAttachmentAction(widget.onCameraPressed),
-      ),
-      _FooterAttachmentAction(
-        id: 'attachment',
-        icon: const Icon(Icons.attach_file_rounded, color: _kActionIconColor),
-        tooltip: widget.attachmentsTooltip,
-        onPressed: () => _handleAttachmentAction(
-          widget.onAttachmentPressed ?? widget.onMoreAttachmentsPressed,
+      if (widget.onAttachmentPressed != null ||
+          widget.onMoreAttachmentsPressed != null)
+        _FooterAttachmentAction(
+          id: 'attachment',
+          icon: const Icon(Icons.attach_file_rounded, color: _kActionIconColor),
+          tooltip: widget.attachmentsTooltip,
+          onPressed: () => _handleAttachmentAction(
+            widget.onAttachmentPressed ?? widget.onMoreAttachmentsPressed,
+          ),
         ),
-      ),
-      _FooterAttachmentAction(
-        id: 'emoji',
-        icon: const _ChatFooterSvgIcon(
-          asset: _kEmoticonSvg,
-          width: 24,
-          height: 24,
+      if (widget.onEmojiPressed != null)
+        _FooterAttachmentAction(
+          id: 'emoji',
+          icon: const _ChatFooterSvgIcon(
+            asset: _kEmoticonSvg,
+            width: 24,
+            height: 24,
+          ),
+          tooltip: widget.emojiTooltip,
+          onPressed: () => _handleAttachmentAction(widget.onEmojiPressed),
         ),
-        tooltip: widget.emojiTooltip,
-        onPressed: () => _handleAttachmentAction(widget.onEmojiPressed),
-      ),
-      _FooterAttachmentAction(
-        id: 'location',
-        icon: const _ChatFooterSvgIcon(
-          asset: _kGeolocationSvg,
-          width: 17,
-          height: 25,
+      if (widget.onLocationPressed != null)
+        _FooterAttachmentAction(
+          id: 'location',
+          icon: const _ChatFooterSvgIcon(
+            asset: _kGeolocationSvg,
+            width: 17,
+            height: 25,
+          ),
+          tooltip: widget.locationTooltip,
+          onPressed: () => _handleAttachmentAction(widget.onLocationPressed),
         ),
-        tooltip: widget.locationTooltip,
-        onPressed: () => _handleAttachmentAction(widget.onLocationPressed),
-      ),
-      ..._debugMarkdownPaginationActions(),
-    ];
-  }
-
-  List<_FooterAttachmentAction> _debugMarkdownPaginationActions() {
-    var includeDebugActions = false;
-    assert(() {
-      includeDebugActions = true;
-      return true;
-    }());
-    if (!includeDebugActions) return const [];
-
-    return [
-      _FooterAttachmentAction(
-        id: 'markdown-bold',
-        icon: const Icon(Icons.format_bold_rounded, color: _kActionIconColor),
-        tooltip: 'Bold',
-        onPressed: () => _handleAttachmentAction(null),
-      ),
-      _FooterAttachmentAction(
-        id: 'markdown-italic',
-        icon: const Icon(Icons.format_italic_rounded, color: _kActionIconColor),
-        tooltip: 'Italic',
-        onPressed: () => _handleAttachmentAction(null),
-      ),
-      _FooterAttachmentAction(
-        id: 'markdown-underline',
-        icon: const Icon(
-          Icons.format_underlined_rounded,
-          color: _kActionIconColor,
-        ),
-        tooltip: 'Underline',
-        onPressed: () => _handleAttachmentAction(null),
-      ),
-      _FooterAttachmentAction(
-        id: 'markdown-code',
-        icon: const Icon(Icons.code_rounded, color: _kActionIconColor),
-        tooltip: 'Code',
-        onPressed: () => _handleAttachmentAction(null),
-      ),
     ];
   }
 
@@ -417,6 +370,7 @@ class _ChatFooterState extends State<ChatFooter> {
     final shadows = theme.brightness == Brightness.dark
         ? _kFooterShadowsDark
         : _kFooterShadowsLight;
+    final hasAttachmentMenu = _attachmentActions().isNotEmpty;
 
     final inner = Padding(
       padding: const EdgeInsets.fromLTRB(
@@ -444,7 +398,7 @@ class _ChatFooterState extends State<ChatFooter> {
             focusNode: _inputFocusNode,
             textFieldKey: _composerTextFieldKey,
             onSendPressed: _handleSend,
-            onMorePressed: _handleMoreAttachmentsPressed,
+            onMorePressed: hasAttachmentMenu ? _handleMoreAttachmentsPressed : null,
           ),
           if (_isAttachmentMenuOpen) ...[
             const SizedBox(height: _kAttachmentMenuTopSpacing),
@@ -500,7 +454,7 @@ class _ComposerPill extends StatelessWidget {
   final FocusNode focusNode;
   final GlobalKey textFieldKey;
   final VoidCallback onSendPressed;
-  final VoidCallback onMorePressed;
+  final VoidCallback? onMorePressed;
 
   bool _usesFullWidthTypedLayout(BuildContext context, double maxWidth) {
     if (!maxWidth.isFinite) return true;
@@ -687,11 +641,14 @@ class _TextActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hasMoreAction = onMore != null;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _PlusInCircleButton(onPressed: onMore, tooltip: attachmentsTooltip),
-        const SizedBox(width: _kTextActionSpacing),
+        if (hasMoreAction) ...[
+          _PlusInCircleButton(onPressed: onMore, tooltip: attachmentsTooltip),
+          const SizedBox(width: _kTextActionSpacing),
+        ],
         _SendButton(onPressed: onPressed, tooltip: tooltip),
       ],
     );
@@ -743,24 +700,34 @@ class _AttachmentActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final actions = [
+      if (onVoice != null)
+        _svgIconButton(
+          asset: _kMicrophoneSvg,
+          onPressed: onVoice,
+          tooltip: voiceTooltip,
+        ),
+      if (onCamera != null)
+        _svgIconButton(
+          asset: _kPhotosSvg,
+          onPressed: onCamera,
+          tooltip: cameraTooltip,
+        ),
+      if (onMore != null)
+        _PlusInCircleButton(onPressed: onMore, tooltip: attachmentsTooltip),
+    ];
+
+    if (actions.isEmpty) return const SizedBox.shrink();
+
     return Padding(
       padding: const EdgeInsets.only(right: _kHorizontalPadding),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _svgIconButton(
-            asset: _kMicrophoneSvg,
-            onPressed: onVoice,
-            tooltip: voiceTooltip,
-          ),
-          const SizedBox(width: _kAttachmentIconSpacing),
-          _svgIconButton(
-            asset: _kPhotosSvg,
-            onPressed: onCamera,
-            tooltip: cameraTooltip,
-          ),
-          const SizedBox(width: _kAttachmentIconSpacing),
-          _PlusInCircleButton(onPressed: onMore, tooltip: attachmentsTooltip),
+          for (var index = 0; index < actions.length; index++) ...[
+            if (index > 0) const SizedBox(width: _kAttachmentIconSpacing),
+            actions[index],
+          ],
         ],
       ),
     );

--- a/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer/chat_footer.dart
+++ b/qaul_ui/packages/qaul_components/lib/design_components/chat/chat_footer/chat_footer.dart
@@ -993,6 +993,7 @@ class _PlusInCircleButton extends StatelessWidget {
       Material(
         color: Colors.transparent,
         child: InkWell(
+          key: const ValueKey('chat-footer-more'),
           onTap: onPressed,
           customBorder: const CircleBorder(),
           child: const SizedBox(

--- a/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
@@ -190,4 +190,36 @@ void main() {
     expect(voiceCount, 1);
     expect(cameraCount, 1);
   });
+
+  testWidgets('opens attachment menu from plus action', (tester) async {
+    var attachmentCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: ChatFooter(
+              placeholder: 'Secure private message',
+              onAttachmentPressed: () => attachmentCount++,
+              attachmentsTooltip: 'More',
+              applyBottomSafeArea: false,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('chat-footer-more')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('attachment')), findsOneWidget);
+    expect(find.byKey(const ValueKey('emoji')), findsNothing);
+    expect(find.byKey(const ValueKey('location')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('attachment')));
+    await tester.pumpAndSettle();
+
+    expect(attachmentCount, 1);
+  });
 }

--- a/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
+++ b/qaul_ui/packages/qaul_components/test/chat_footer_reply_preview_test.dart
@@ -140,4 +140,54 @@ void main() {
     expect(await previewColor(ThemeData.dark()), const Color(0xFF2C2C2E));
     expect(await previewColor(ThemeData.light()), const Color(0xFFE5E5EA));
   });
+
+  testWidgets('hides attachment actions without callbacks', (tester) async {
+    await tester.pumpWidget(
+      app(
+        controller: TextEditingController(),
+      ),
+    );
+
+    expect(find.byTooltip('Voice message'), findsNothing);
+    expect(find.byTooltip('Photo'), findsNothing);
+    expect(find.byTooltip('More'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('chat-footer-send')), findsOneWidget);
+    expect(find.byTooltip('More'), findsNothing);
+  });
+
+  testWidgets('runs voice and camera callbacks directly', (tester) async {
+    var voiceCount = 0;
+    var cameraCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: ChatFooter(
+              placeholder: 'Secure private message',
+              onVoicePressed: () => voiceCount++,
+              onCameraPressed: () => cameraCount++,
+              voiceTooltip: 'Voice message',
+              cameraTooltip: 'Photo',
+              attachmentsTooltip: 'More',
+              applyBottomSafeArea: false,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byTooltip('More'), findsNothing);
+
+    await tester.tap(find.byTooltip('Voice message'));
+    await tester.tap(find.byTooltip('Photo'));
+
+    expect(voiceCount, 1);
+    expect(cameraCount, 1);
+  });
 }

--- a/qaul_ui/test/chat_tab/chat_tab_test.dart
+++ b/qaul_ui/test/chat_tab/chat_tab_test.dart
@@ -7,7 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:local_notifications/src/local_notifications.dart';
 import 'package:logging/logging.dart';
 import 'package:qaul_components/qaul_components.dart'
-    show ChatHeader, QaulComponentsLocalizations;
+    show ChatFooter, ChatHeader, QaulComponentsLocalizations;
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:qaul_rpc/src/generated/services/chat/chat.pb.dart';
 import 'package:qaul_ui/l10n/app_localizations.dart';
@@ -43,6 +43,7 @@ void main() {
 
   setUp(() {
     chatKey = UniqueKey();
+    StubLibqaulWorker.sentTexts.clear();
     SharedPreferences.setMockInitialValues({});
   });
 
@@ -75,7 +76,11 @@ void main() {
     await pumpChatScreen(tester, buildDirectChat(), otherUser: otherUser);
 
     expect(find.byType(ChatHeader), findsOneWidget);
+    expect(find.byType(ChatFooter), findsOneWidget);
     expect(find.text(otherUser.name), findsOneWidget);
+    expect(find.text('Secure private message'), findsOneWidget);
+    expect(find.byTooltip('Record audio message'), findsOneWidget);
+    expect(find.byTooltip('Send File'), findsOneWidget);
     expect(find.byTooltip('Back'), findsNothing);
 
     final avatarTapTarget = find.descendant(
@@ -96,8 +101,54 @@ void main() {
     expect(find.byType(ChatHeader), findsOneWidget);
     expect(find.text('Group Chat'), findsOneWidget);
     expect(find.text('2 members'), findsOneWidget);
+    expect(find.text('Group chat message'), findsOneWidget);
     expect(find.byIcon(Icons.more_vert), findsOneWidget);
     expect(find.byTooltip('Back'), findsNothing);
+  });
+
+  testWidgets('chat footer sends typed text and clears draft', (tester) async {
+    await pumpChatScreen(tester, buildGroupChat());
+
+    await tester.enterText(find.byType(TextField), 'hello footer');
+    await tester.pump();
+    await tester.tap(find.byTooltip('Send'));
+    await tester.pumpAndSettle();
+
+    expect(StubLibqaulWorker.sentTexts, ['hello footer']);
+    expect(tester.widget<TextField>(find.byType(TextField)).controller!.text, '');
+  });
+
+  testWidgets('chat footer prevents empty sends', (tester) async {
+    await pumpChatScreen(tester, buildGroupChat());
+
+    expect(find.byTooltip('Send'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+
+    expect(find.byTooltip('Send'), findsNothing);
+    expect(StubLibqaulWorker.sentTexts, isEmpty);
+  });
+
+  testWidgets('disabled room blocks chat footer sending', (tester) async {
+    await pumpChatScreen(
+      tester,
+      buildGroupChat(status: ChatRoomStatus.inviteAccepted),
+    );
+
+    expect(
+      find.text(
+        'Please wait for the admin to confirm your acceptance to send messages',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.byType(TextField), 'blocked');
+    await tester.pump();
+    await tester.tap(find.byTooltip('Send'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(StubLibqaulWorker.sentTexts, isEmpty);
   });
 
   testWidgets('group header menu opens group settings', (tester) async {

--- a/qaul_ui/test/chat_tab/chat_tab_test.dart
+++ b/qaul_ui/test/chat_tab/chat_tab_test.dart
@@ -79,7 +79,10 @@ void main() {
     expect(find.byType(ChatFooter), findsOneWidget);
     expect(find.text(otherUser.name), findsOneWidget);
     expect(find.text('Secure private message'), findsOneWidget);
-    expect(find.byTooltip('Record audio message'), findsOneWidget);
+    expect(
+      find.byTooltip('Record audio message'),
+      Platform.isLinux ? findsNothing : findsOneWidget,
+    );
     expect(find.byTooltip('Send File'), findsOneWidget);
     expect(find.byTooltip('Back'), findsNothing);
 

--- a/qaul_ui/test/chat_tab/chat_tab_test.dart
+++ b/qaul_ui/test/chat_tab/chat_tab_test.dart
@@ -83,8 +83,15 @@ void main() {
       find.byTooltip('Record audio message'),
       Platform.isLinux ? findsNothing : findsOneWidget,
     );
-    expect(find.byTooltip('Send File'), findsOneWidget);
+    expect(find.byTooltip('Send File'), findsWidgets);
     expect(find.byTooltip('Back'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('chat-footer-more')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('attachment')), findsOneWidget);
+    expect(find.byKey(const ValueKey('emoji')), findsNothing);
+    expect(find.byKey(const ValueKey('location')), findsNothing);
 
     final avatarTapTarget = find.descendant(
       of: find.byType(ChatHeader),

--- a/qaul_ui/test/chat_tab/fixtures.dart
+++ b/qaul_ui/test/chat_tab/fixtures.dart
@@ -10,22 +10,30 @@ final otherUser = User(
   id: Uint8List.fromList('otherUserId'.codeUnits),
 );
 
-ChatRoom buildGroupChat({List<Message>? messages}) => ChatRoom(
+ChatRoom buildGroupChat({
+  List<Message>? messages,
+  ChatRoomStatus status = ChatRoomStatus.active,
+}) => ChatRoom(
   name: 'Group Chat',
   messages: messages,
   conversationId: Uint8List.fromList('groupId'.codeUnits),
   isDirectChat: false,
+  status: status,
   members: [
     ChatRoomUser(defaultUser, joinedAt: DateTime(2000)),
     ChatRoomUser(otherUser, joinedAt: DateTime(2000)),
   ],
 );
 
-ChatRoom buildDirectChat({List<Message>? messages}) => ChatRoom(
+ChatRoom buildDirectChat({
+  List<Message>? messages,
+  ChatRoomStatus status = ChatRoomStatus.active,
+}) => ChatRoom(
   name: otherUser.name,
   messages: messages,
   conversationId: Uint8List.fromList('directId'.codeUnits),
   isDirectChat: true,
+  status: status,
   members: [
     ChatRoomUser(defaultUser, joinedAt: DateTime(2000)),
     ChatRoomUser(otherUser, joinedAt: DateTime(2000)),

--- a/qaul_ui/test/chat_tab/stubs.dart
+++ b/qaul_ui/test/chat_tab/stubs.dart
@@ -3,11 +3,14 @@ part of 'chat_tab_test.dart';
 class StubLibqaulWorker implements LibqaulWorker {
   StubLibqaulWorker(this.ref);
 
+  static final sentTexts = <String>[];
+
   final Ref ref;
   final _logger = Logger('StubLibqaulWorker');
 
   @override
   Future<void> sendMessage(Uint8List chatId, String content) async {
+    sentTexts.add(content);
     _logger.info('sending message "$content" to chat id: "$chatId"');
     final room = ref.read(currentOpenChatRoom);
 


### PR DESCRIPTION
## Description
Replaced the legacy custom chat text composer with the Widgetbook-backed `ChatFooter` component.

This wires text-message sending through the existing chat worker, preserves direct/group placeholders, disabled-room behavior, and keeps the existing camera/photo and audio recording flows available from the footer while hiding unsupported extra actions.

## Evidence

https://github.com/user-attachments/assets/92a2399a-0a7d-40d1-890f-22951d1d944a

## Observation

Audio recording follows the existing platform behavior from the legacy composer: the microphone action is not wired on Linux (`Platform.isLinux`). Because the new `ChatFooter` hides actions without callbacks, Linux test/CI environments should not expect the audio button to be rendered there.
