### PR TITLE
feat(dtn-v2): signed immutable route, recipient grants + PoW admission, signed responses

### DIFF
--- a/protobuf/generated/rust/qaul.net.messaging.rs
+++ b/protobuf/generated/rust/qaul.net.messaging.rs
@@ -30,7 +30,7 @@ pub struct Envelope {
 /// envelop payload
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnvelopPayload {
-    #[prost(oneof = "envelop_payload::Payload", tags = "1, 2, 3")]
+    #[prost(oneof = "envelop_payload::Payload", tags = "1, 2, 3, 4")]
     pub payload: ::core::option::Option<envelop_payload::Payload>,
 }
 /// Nested message and enum types in `EnvelopPayload`.
@@ -46,6 +46,10 @@ pub mod envelop_payload {
         /// directed custody routed DTN message (V2, signed immutable route)
         #[prost(message, tag = "3")]
         DtnV2(super::DtnV2Container),
+        /// a signed DTN v2 response carried as a custody payload, so a DELIVERY
+        /// ack can be routed back to an offline sender over the reverse route
+        #[prost(message, tag = "4")]
+        DtnResponseV2(super::DtnResponseV2),
     }
 }
 /// encrypted message data

--- a/protobuf/generated/rust/qaul.net.messaging.rs
+++ b/protobuf/generated/rust/qaul.net.messaging.rs
@@ -43,9 +43,9 @@ pub mod envelop_payload {
         /// DTN message
         #[prost(bytes, tag = "2")]
         Dtn(::prost::alloc::vec::Vec<u8>),
-        /// directed custody routed DTN message
+        /// directed custody routed DTN message (V2, signed immutable route)
         #[prost(message, tag = "3")]
-        DtnRoutedV2(super::DtnRoutedV2),
+        DtnV2(super::DtnV2Container),
     }
 }
 /// encrypted message data
@@ -82,7 +82,7 @@ pub struct Data {
 /// messaging unified message
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Messaging {
-    #[prost(oneof = "messaging::Message", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "messaging::Message", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub message: ::core::option::Option<messaging::Message>,
 }
 /// Nested message and enum types in `Messaging`.
@@ -107,6 +107,9 @@ pub mod messaging {
         /// common message
         #[prost(message, tag = "6")]
         CommonMessage(super::CommonMessage),
+        /// signed dtn response message (V2)
+        #[prost(message, tag = "7")]
+        DtnResponseV2(super::DtnResponseV2),
     }
 }
 /// message received confirmation
@@ -210,7 +213,7 @@ pub struct RtcMessage {
 /// DTN message
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Dtn {
-    #[prost(oneof = "dtn::Message", tags = "1, 2, 3")]
+    #[prost(oneof = "dtn::Message", tags = "1, 2, 3, 4")]
     pub message: ::core::option::Option<dtn::Message>,
 }
 /// Nested message and enum types in `Dtn`.
@@ -220,41 +223,281 @@ pub mod dtn {
         /// message container
         #[prost(bytes, tag = "1")]
         Container(::prost::alloc::vec::Vec<u8>),
-        /// message received response
+        /// message received response (V1, unauthenticated)
         #[prost(message, tag = "2")]
         Response(super::DtnResponse),
-        /// directed custody routed DTN message
+        /// directed custody routed DTN message (V2, signed immutable route)
         #[prost(message, tag = "3")]
-        RoutedV2(super::DtnRoutedV2),
+        ContainerV2(super::DtnV2Container),
+        /// signed DTN response (V2)
+        #[prost(message, tag = "4")]
+        ResponseV2(super::DtnResponseV2),
     }
 }
-/// DTN source routed message (V2)
-#[derive(serde::Serialize, serde::Deserialize)]
+/// DTN v2 custody container.
+///
+/// The route is authored and signed once by the sender and is immutable in
+/// transit: custodians verify `dtn_route_sig` over `dtn_route` against the
+/// sender's key and never rewrite it. Traversal is stateless (a custodian finds
+/// itself in the route), so there is no cursor or handoff counter on the wire.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct DtnRoutedV2 {
-    /// the original encrypted container bytes
+pub struct DtnV2Container {
+    /// encoded DtnRoute (the signed blob)
     #[prost(bytes = "vec", tag = "1")]
-    pub container: ::prost::alloc::vec::Vec<u8>,
-    /// ordered list of custody user IDs
-    #[prost(bytes = "vec", repeated, tag = "2")]
-    pub custody_route: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
-    /// index of the first custody entry that has not yet taken custody
-    #[prost(uint32, tag = "3")]
-    pub next_route_index: u32,
-    /// signature of the original message (used for dedup)
+    pub dtn_route: ::prost::alloc::vec::Vec<u8>,
+    /// sender's signature over `dtn_route` bytes
+    #[prost(bytes = "vec", tag = "2")]
+    pub dtn_route_sig: ::prost::alloc::vec::Vec<u8>,
+    /// the original message container bytes (signed inner message)
+    #[prost(bytes = "vec", tag = "3")]
+    pub envelope: ::prost::alloc::vec::Vec<u8>,
+    /// optional recipient-signed custody grant (primary admission gate)
+    #[prost(message, optional, tag = "4")]
+    pub custody_grant: ::core::option::Option<CustodyGrant>,
+    /// optional proof-of-work stamp (grant-less untrusted pool)
+    #[prost(message, optional, tag = "5")]
+    pub pow: ::core::option::Option<PowStamp>,
+}
+/// DTN routing information, signed by the sender.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DtnRoute {
+    /// signature of the original message (dedup / end-to-end key)
+    #[prost(bytes = "vec", tag = "1")]
+    pub original_signature: ::prost::alloc::vec::Vec<u8>,
+    /// custody route as hop entries, ordered by hop ascending.
+    /// Position gives the order; there is no explicit hop number. Several
+    /// interchangeable custodian ids may share one hop.
+    #[prost(message, repeated, tag = "2")]
+    pub route_hop: ::prost::alloc::vec::Vec<RouteHop>,
+    /// public key of the original sender (protobuf-encoded)
+    #[prost(bytes = "vec", tag = "3")]
+    pub sender_public_key: ::prost::alloc::vec::Vec<u8>,
+    /// optional expiry (ms since epoch). Retention is otherwise custodian-local.
+    #[prost(uint64, optional, tag = "4")]
+    pub expires_at: ::core::option::Option<u64>,
+}
+/// one custodian candidate within a hop
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RouteEntry {
+    /// custodian qaul id
+    ///
+    /// extension point for future relay / connectivity information
+    #[prost(bytes = "vec", tag = "1")]
+    pub id: ::prost::alloc::vec::Vec<u8>,
+}
+/// one hop: a set of interchangeable custodian candidates
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RouteHop {
+    #[prost(message, repeated, tag = "1")]
+    pub route_entry: ::prost::alloc::vec::Vec<RouteEntry>,
+}
+/// Recipient-signed custody grant (capability).
+///
+/// The recipient authorizes a specific sender to have messages held in custody
+/// on its behalf. A custodian accepts a grant-bearing message only if the grant
+/// is signed by the recipient named in the inner container, names this sender,
+/// and the deposit fits `quota_bytes`. Rotating `epoch` revokes older grants.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CustodyGrant {
+    /// sender authorized to deposit (qaul id)
+    #[prost(bytes = "vec", tag = "1")]
+    pub grantee: ::prost::alloc::vec::Vec<u8>,
+    /// recipient that issued and signed this grant (qaul id)
+    #[prost(bytes = "vec", tag = "2")]
+    pub recipient: ::prost::alloc::vec::Vec<u8>,
+    /// recipient's public key (protobuf-encoded), used to verify `signature`
+    #[prost(bytes = "vec", tag = "3")]
+    pub recipient_public_key: ::prost::alloc::vec::Vec<u8>,
+    /// per-sender custody budget this grant authorizes
+    #[prost(uint64, tag = "4")]
+    pub quota_bytes: u64,
+    /// grant epoch; a higher epoch from the same recipient supersedes lower ones
+    #[prost(uint32, tag = "5")]
+    pub epoch: u32,
+    /// optional expiry (ms since epoch), 0 = no expiry
+    #[prost(uint64, tag = "6")]
+    pub not_after: u64,
+    /// recipient's signature over the grant fields (signature field empty)
+    #[prost(bytes = "vec", tag = "7")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+}
+/// Proof-of-work stamp for the grant-less untrusted pool.
+///
+/// Verified bound to (original_signature, custodian_id, day) so a stamp cannot be
+/// reused across custodians or days. A one-machine Sybil flood pays
+/// difficulty x identities x custodians and does not scale.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PowStamp {
+    /// solution nonce
+    #[prost(uint64, tag = "1")]
+    pub nonce: u64,
+    /// required leading zero bits in the bound hash
+    #[prost(uint32, tag = "2")]
+    pub difficulty: u32,
+}
+/// Signed DTN response (V2).
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DtnResponseV2 {
+    #[prost(enumeration = "dtn_response_v2::Kind", tag = "1")]
+    pub kind: i32,
+    #[prost(enumeration = "dtn_response_v2::ResponseType", tag = "2")]
+    pub response_type: i32,
+    #[prost(enumeration = "dtn_response_v2::Reason", tag = "3")]
+    pub reason: i32,
+    /// the referenced message (original message signature)
     #[prost(bytes = "vec", tag = "4")]
     pub original_signature: ::prost::alloc::vec::Vec<u8>,
-    /// public key of the original sender (protobuf-encoded)
+    /// responder public key (protobuf-encoded); verifies `signature` and must
+    /// hash to the responder identity the verifier expects
     #[prost(bytes = "vec", tag = "5")]
-    pub sender_public_key: ::prost::alloc::vec::Vec<u8>,
-    /// expiry timestamp (milliseconds since epoch), 0 = no expiry
-    #[prost(uint64, tag = "6")]
-    pub expires_at: u64,
-    /// remaining allowed handoffs before message is dropped
-    #[prost(uint32, tag = "7")]
-    pub remaining_handoffs: u32,
+    pub responder_public_key: ::prost::alloc::vec::Vec<u8>,
+    /// responder's signature over the response fields (signature field empty)
+    #[prost(bytes = "vec", tag = "6")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }
-/// DTN response
+/// Nested message and enum types in `DtnResponseV2`.
+pub mod dtn_response_v2 {
+    /// what this response asserts
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Kind {
+        /// receiver -> sender: authoritative "delivered", stops retransmission
+        Delivery = 0,
+        /// receiver -> last custodian: custody release, free storage now
+        CustodyRelease = 1,
+        /// custodian -> previous holder: accepted into custody (receipt)
+        Receipt = 2,
+        /// custodian -> sender: dropped (denied / expired / full)
+        DropReport = 3,
+    }
+    impl Kind {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Delivery => "DELIVERY",
+                Self::CustodyRelease => "CUSTODY_RELEASE",
+                Self::Receipt => "RECEIPT",
+                Self::DropReport => "DROP_REPORT",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "DELIVERY" => Some(Self::Delivery),
+                "CUSTODY_RELEASE" => Some(Self::CustodyRelease),
+                "RECEIPT" => Some(Self::Receipt),
+                "DROP_REPORT" => Some(Self::DropReport),
+                _ => None,
+            }
+        }
+    }
+    /// accepted / rejected
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum ResponseType {
+        Accepted = 0,
+        Rejected = 1,
+    }
+    impl ResponseType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Accepted => "ACCEPTED",
+                Self::Rejected => "REJECTED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "ACCEPTED" => Some(Self::Accepted),
+                "REJECTED" => Some(Self::Rejected),
+                _ => None,
+            }
+        }
+    }
+    /// rejection / drop reason
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Reason {
+        None = 0,
+        UserNotAccepted = 1,
+        OverallQuota = 2,
+        UserQuota = 3,
+        /// no valid custody grant and no acceptable proof-of-work
+        NoGrant = 4,
+        /// grant-less deposit requires a proof-of-work stamp
+        PowRequired = 5,
+        /// sender is blocked by this custodian
+        Blocked = 6,
+    }
+    impl Reason {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::None => "NONE",
+                Self::UserNotAccepted => "USER_NOT_ACCEPTED",
+                Self::OverallQuota => "OVERALL_QUOTA",
+                Self::UserQuota => "USER_QUOTA",
+                Self::NoGrant => "NO_GRANT",
+                Self::PowRequired => "POW_REQUIRED",
+                Self::Blocked => "BLOCKED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "NONE" => Some(Self::None),
+                "USER_NOT_ACCEPTED" => Some(Self::UserNotAccepted),
+                "OVERALL_QUOTA" => Some(Self::OverallQuota),
+                "USER_QUOTA" => Some(Self::UserQuota),
+                "NO_GRANT" => Some(Self::NoGrant),
+                "POW_REQUIRED" => Some(Self::PowRequired),
+                "BLOCKED" => Some(Self::Blocked),
+                _ => None,
+            }
+        }
+    }
+}
+/// DTN response (V1, unauthenticated — retained for legacy V1 custody)
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DtnResponse {
     /// the type of the message

--- a/protobuf/generated/rust/qaul.rpc.dtn.rs
+++ b/protobuf/generated/rust/qaul.rpc.dtn.rs
@@ -5,7 +5,7 @@ pub struct Dtn {
     /// message type
     #[prost(
         oneof = "dtn::Message",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18"
     )]
     pub message: ::core::option::Option<dtn::Message>,
 }
@@ -56,6 +56,18 @@ pub mod dtn {
         /// dtn set custody enabled response
         #[prost(message, tag = "14")]
         DtnSetCustodyEnabledResponse(super::DtnSetCustodyEnabledResponse),
+        /// dtn issue custody grant request
+        #[prost(message, tag = "15")]
+        DtnIssueGrantRequest(super::DtnIssueGrantRequest),
+        /// dtn issue custody grant response
+        #[prost(message, tag = "16")]
+        DtnIssueGrantResponse(super::DtnIssueGrantResponse),
+        /// dtn import custody grant request
+        #[prost(message, tag = "17")]
+        DtnImportGrantRequest(super::DtnImportGrantRequest),
+        /// dtn import custody grant response
+        #[prost(message, tag = "18")]
+        DtnImportGrantResponse(super::DtnImportGrantResponse),
     }
 }
 /// Dtn State Request
@@ -184,6 +196,57 @@ pub struct DtnSetCustodyEnabledRequest {
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DtnSetCustodyEnabledResponse {
     /// whether the request was successful
+    #[prost(bool, tag = "1")]
+    pub status: bool,
+    /// error or status message
+    #[prost(string, tag = "2")]
+    pub message: ::prost::alloc::string::String,
+}
+/// Request to issue a recipient-signed custody grant to a sender.
+///
+/// The local user (recipient) authorizes `grantee` to have messages held in
+/// custody on its behalf, up to `quota_bytes`. The response returns the signed
+/// CustodyGrant bytes, which the grantee attaches to its DtnV2Container.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DtnIssueGrantRequest {
+    /// sender authorized to deposit (qaul id bytes)
+    #[prost(bytes = "vec", tag = "1")]
+    pub grantee: ::prost::alloc::vec::Vec<u8>,
+    /// per-sender custody budget this grant authorizes
+    #[prost(uint64, tag = "2")]
+    pub quota_bytes: u64,
+    /// grant epoch (higher supersedes lower from the same recipient)
+    #[prost(uint32, tag = "3")]
+    pub epoch: u32,
+    /// optional expiry (ms since epoch), 0 = no expiry
+    #[prost(uint64, tag = "4")]
+    pub not_after: u64,
+}
+/// Response carrying the signed custody grant.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DtnIssueGrantResponse {
+    /// whether the grant was issued
+    #[prost(bool, tag = "1")]
+    pub status: bool,
+    /// encoded CustodyGrant protobuf bytes
+    #[prost(bytes = "vec", tag = "2")]
+    pub grant: ::prost::alloc::vec::Vec<u8>,
+    /// error or status message
+    #[prost(string, tag = "3")]
+    pub message: ::prost::alloc::string::String,
+}
+/// Request to import a custody grant this node has been given by a recipient,
+/// so the originate path can attach it to outgoing custody messages.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DtnImportGrantRequest {
+    /// encoded CustodyGrant protobuf bytes
+    #[prost(bytes = "vec", tag = "1")]
+    pub grant: ::prost::alloc::vec::Vec<u8>,
+}
+/// Response to a grant import request.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DtnImportGrantResponse {
+    /// whether the grant was accepted and stored
     #[prost(bool, tag = "1")]
     pub status: bool,
     /// error or status message

--- a/protobuf/proto_definitions/services/dtn/dtn_rpc.proto
+++ b/protobuf/proto_definitions/services/dtn/dtn_rpc.proto
@@ -33,6 +33,14 @@ message DTN {
         DtnSetCustodyEnabledRequest dtn_set_custody_enabled_request = 13;
         // dtn set custody enabled response
         DtnSetCustodyEnabledResponse dtn_set_custody_enabled_response = 14;
+        // dtn issue custody grant request
+        DtnIssueGrantRequest dtn_issue_grant_request = 15;
+        // dtn issue custody grant response
+        DtnIssueGrantResponse dtn_issue_grant_response = 16;
+        // dtn import custody grant request
+        DtnImportGrantRequest dtn_import_grant_request = 17;
+        // dtn import custody grant response
+        DtnImportGrantResponse dtn_import_grant_response = 18;
     }
 }
 
@@ -137,6 +145,47 @@ message DtnSetCustodyEnabledRequest {
 // Response to custody enable/disable request
 message DtnSetCustodyEnabledResponse {
     // whether the request was successful
+    bool status = 1;
+    // error or status message
+    string message = 2;
+}
+
+// Request to issue a recipient-signed custody grant to a sender.
+//
+// The local user (recipient) authorizes `grantee` to have messages held in
+// custody on its behalf, up to `quota_bytes`. The response returns the signed
+// CustodyGrant bytes, which the grantee attaches to its DtnV2Container.
+message DtnIssueGrantRequest {
+    // sender authorized to deposit (qaul id bytes)
+    bytes grantee = 1;
+    // per-sender custody budget this grant authorizes
+    uint64 quota_bytes = 2;
+    // grant epoch (higher supersedes lower from the same recipient)
+    uint32 epoch = 3;
+    // optional expiry (ms since epoch), 0 = no expiry
+    uint64 not_after = 4;
+}
+
+// Response carrying the signed custody grant.
+message DtnIssueGrantResponse {
+    // whether the grant was issued
+    bool status = 1;
+    // encoded CustodyGrant protobuf bytes
+    bytes grant = 2;
+    // error or status message
+    string message = 3;
+}
+
+// Request to import a custody grant this node has been given by a recipient,
+// so the originate path can attach it to outgoing custody messages.
+message DtnImportGrantRequest {
+    // encoded CustodyGrant protobuf bytes
+    bytes grant = 1;
+}
+
+// Response to a grant import request.
+message DtnImportGrantResponse {
+    // whether the grant was accepted and stored
     bool status = 1;
     // error or status message
     string message = 2;

--- a/protobuf/proto_definitions/services/messaging/messaging.proto
+++ b/protobuf/proto_definitions/services/messaging/messaging.proto
@@ -29,8 +29,8 @@ message EnvelopPayload {
         Encrypted encrypted = 1;
         // DTN message
         bytes dtn = 2;
-        // directed custody routed DTN message
-        DtnRoutedV2 dtn_routed_v2 = 3;
+        // directed custody routed DTN message (V2, signed immutable route)
+        DtnV2Container dtn_v2 = 3;
     }
 }
 
@@ -83,6 +83,8 @@ message Messaging {
         GroupInviteMessage group_invite_message = 5;
         // common message
         CommonMessage common_message = 6;
+        // signed dtn response message (V2)
+        DtnResponseV2 dtn_response_v2 = 7;
     }
 }
 
@@ -167,32 +169,139 @@ message Dtn {
     oneof message {
         // message container
         bytes container = 1;
-        // message received response
+        // message received response (V1, unauthenticated)
         DtnResponse response = 2;
-        // directed custody routed DTN message
-        DtnRoutedV2 routed_v2 = 3;
+        // directed custody routed DTN message (V2, signed immutable route)
+        DtnV2Container container_v2 = 3;
+        // signed DTN response (V2)
+        DtnResponseV2 response_v2 = 4;
     }
 }
 
-// DTN source routed message (V2)
-message DtnRoutedV2 {
-    // the original encrypted container bytes
-    bytes container = 1;
-    // ordered list of custody user IDs
-    repeated bytes custody_route = 2;
-    // index of the first custody entry that has not yet taken custody
-    uint32 next_route_index = 3;
-    // signature of the original message (used for dedup)
-    bytes original_signature = 4;
-    // public key of the original sender (protobuf-encoded)
-    bytes sender_public_key = 5;
-    // expiry timestamp (milliseconds since epoch), 0 = no expiry
-    uint64 expires_at = 6;
-    // remaining allowed handoffs before message is dropped
-    uint32 remaining_handoffs = 7;
+// DTN v2 custody container.
+//
+// The route is authored and signed once by the sender and is immutable in
+// transit: custodians verify `dtn_route_sig` over `dtn_route` against the
+// sender's key and never rewrite it. Traversal is stateless (a custodian finds
+// itself in the route), so there is no cursor or handoff counter on the wire.
+message DtnV2Container {
+    // encoded DtnRoute (the signed blob)
+    bytes dtn_route = 1;
+    // sender's signature over `dtn_route` bytes
+    bytes dtn_route_sig = 2;
+    // the original message container bytes (signed inner message)
+    bytes envelope = 3;
+    // optional recipient-signed custody grant (primary admission gate)
+    CustodyGrant custody_grant = 4;
+    // optional proof-of-work stamp (grant-less untrusted pool)
+    PowStamp pow = 5;
 }
 
-// DTN response
+// DTN routing information, signed by the sender.
+message DtnRoute {
+    // signature of the original message (dedup / end-to-end key)
+    bytes original_signature = 1;
+    // custody route as hop entries, ordered by hop ascending.
+    // Position gives the order; there is no explicit hop number. Several
+    // interchangeable custodian ids may share one hop.
+    repeated RouteHop route_hop = 2;
+    // public key of the original sender (protobuf-encoded)
+    bytes sender_public_key = 3;
+    // optional expiry (ms since epoch). Retention is otherwise custodian-local.
+    optional uint64 expires_at = 4;
+}
+
+// one custodian candidate within a hop
+message RouteEntry {
+    // custodian qaul id
+    bytes id = 1;
+    // extension point for future relay / connectivity information
+}
+
+// one hop: a set of interchangeable custodian candidates
+message RouteHop {
+    repeated RouteEntry route_entry = 1;
+}
+
+// Recipient-signed custody grant (capability).
+//
+// The recipient authorizes a specific sender to have messages held in custody
+// on its behalf. A custodian accepts a grant-bearing message only if the grant
+// is signed by the recipient named in the inner container, names this sender,
+// and the deposit fits `quota_bytes`. Rotating `epoch` revokes older grants.
+message CustodyGrant {
+    // sender authorized to deposit (qaul id)
+    bytes grantee = 1;
+    // recipient that issued and signed this grant (qaul id)
+    bytes recipient = 2;
+    // recipient's public key (protobuf-encoded), used to verify `signature`
+    bytes recipient_public_key = 3;
+    // per-sender custody budget this grant authorizes
+    uint64 quota_bytes = 4;
+    // grant epoch; a higher epoch from the same recipient supersedes lower ones
+    uint32 epoch = 5;
+    // optional expiry (ms since epoch), 0 = no expiry
+    uint64 not_after = 6;
+    // recipient's signature over the grant fields (signature field empty)
+    bytes signature = 7;
+}
+
+// Proof-of-work stamp for the grant-less untrusted pool.
+//
+// Verified bound to (original_signature, custodian_id, day) so a stamp cannot be
+// reused across custodians or days. A one-machine Sybil flood pays
+// difficulty x identities x custodians and does not scale.
+message PowStamp {
+    // solution nonce
+    uint64 nonce = 1;
+    // required leading zero bits in the bound hash
+    uint32 difficulty = 2;
+}
+
+// Signed DTN response (V2).
+message DtnResponseV2 {
+    // what this response asserts
+    enum Kind {
+        // receiver -> sender: authoritative "delivered", stops retransmission
+        DELIVERY = 0;
+        // receiver -> last custodian: custody release, free storage now
+        CUSTODY_RELEASE = 1;
+        // custodian -> previous holder: accepted into custody (receipt)
+        RECEIPT = 2;
+        // custodian -> sender: dropped (denied / expired / full)
+        DROP_REPORT = 3;
+    }
+    // accepted / rejected
+    enum ResponseType {
+        ACCEPTED = 0;
+        REJECTED = 1;
+    }
+    // rejection / drop reason
+    enum Reason {
+        NONE = 0;
+        USER_NOT_ACCEPTED = 1;
+        OVERALL_QUOTA = 2;
+        USER_QUOTA = 3;
+        // no valid custody grant and no acceptable proof-of-work
+        NO_GRANT = 4;
+        // grant-less deposit requires a proof-of-work stamp
+        POW_REQUIRED = 5;
+        // sender is blocked by this custodian
+        BLOCKED = 6;
+    }
+    Kind kind = 1;
+    ResponseType response_type = 2;
+    Reason reason = 3;
+    // the referenced message (original message signature)
+    bytes original_signature = 4;
+    // responder public key (protobuf-encoded); verifies `signature` and must
+    // hash to the responder identity the verifier expects
+    bytes responder_public_key = 5;
+    // responder's signature over the response fields (signature field empty)
+    bytes signature = 6;
+}
+
+// DTN response (V1, unauthenticated — retained for legacy V1 custody)
 message DtnResponse {
     // the enum definition of the type
     enum ResponseType {

--- a/protobuf/proto_definitions/services/messaging/messaging.proto
+++ b/protobuf/proto_definitions/services/messaging/messaging.proto
@@ -31,6 +31,9 @@ message EnvelopPayload {
         bytes dtn = 2;
         // directed custody routed DTN message (V2, signed immutable route)
         DtnV2Container dtn_v2 = 3;
+        // a signed DTN v2 response carried as a custody payload, so a DELIVERY
+        // ack can be routed back to an offline sender over the reverse route
+        DtnResponseV2 dtn_response_v2 = 4;
     }
 }
 

--- a/rust/libqaul/src/services/dtn/mod.rs
+++ b/rust/libqaul/src/services/dtn/mod.rs
@@ -106,6 +106,11 @@ pub struct DtnStorageStateV2 {
 const TIER_UNTRUSTED: u8 = 0;
 const TIER_TRUSTED: u8 = 1;
 const TIER_GRANT: u8 = 2;
+/// A signed DTN response (e.g. a DELIVERY ack) being routed back to an offline
+/// sender over the reverse route. Control traffic: exempt from the grant/PoW
+/// admission gates (it is tied to an already-accepted custody flow and carries
+/// a verifiable signed response), and shed on the short untrusted retention.
+const TIER_CONTROL: u8 = 3;
 
 /// Per-sender ceiling for a grant-less stranger admitted via proof-of-work.
 const V2_UNTRUSTED_PER_SENDER_QUOTA: u64 = 5 * 1024 * 1024;
@@ -1071,6 +1076,129 @@ impl Dtn {
         }
     }
 
+    /// If an inner custody container carries a signed DTN response (an ack
+    /// being routed back to the sender), return it. Used to distinguish control
+    /// traffic from ordinary custody messages.
+    fn extract_ack(inner_container_bytes: &[u8]) -> Option<proto::DtnResponseV2> {
+        let container = proto::Container::decode(inner_container_bytes).ok()?;
+        let envelope = container.envelope?;
+        let payload = proto::EnvelopPayload::decode(&envelope.payload[..]).ok()?;
+        match payload.payload {
+            Some(proto::envelop_payload::Payload::DtnResponseV2(r)) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Route a signed DELIVERY ack back to the (possibly offline) original
+    /// sender over the reverse of the forward route.
+    ///
+    /// The ack is wrapped as its own custody message — a `DtnV2Container` whose
+    /// inner container carries the signed `DtnResponseV2` and whose route is the
+    /// forward route reversed. It is stored locally (TIER_CONTROL) so the
+    /// retransmit loop keeps retrying until a reverse path exists, and forwarded
+    /// immediately if a next hop is reachable. Custodians treat it as control
+    /// traffic (see the admission bypass in `net_routed_v2`), so it is not
+    /// subject to grant/PoW gates.
+    fn route_delivery_ack(
+        state: &crate::QaulState,
+        user_account: &UserAccount,
+        forward_route: &proto::DtnRoute,
+        original_signature: &[u8],
+    ) {
+        // The original sender is the author of the forward route.
+        let origin = match PublicKey::try_decode_protobuf(&forward_route.sender_public_key) {
+            Ok(k) => PeerId::from_public_key(&k),
+            Err(e) => {
+                log::error!("DtnV2: cannot derive sender for delivery ack: {}", e);
+                return;
+            }
+        };
+
+        let ack = match Self::build_signed_response(
+            user_account,
+            proto::dtn_response_v2::Kind::Delivery,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            original_signature.to_vec(),
+        ) {
+            Some(a) => a,
+            None => return,
+        };
+        // Dedup key for the ack's own custody entry.
+        let ack_dedup = ack.signature.clone();
+
+        // Inner container addressed to the original sender, carrying the ack.
+        let payload = proto::EnvelopPayload {
+            payload: Some(proto::envelop_payload::Payload::DtnResponseV2(ack)),
+        };
+        let inner_envelope = proto::Envelope {
+            sender_id: user_account.id.to_bytes(),
+            receiver_id: origin.to_bytes(),
+            payload: payload.encode_to_vec(),
+        };
+        let inner_sig = match user_account.keys.sign(&inner_envelope.encode_to_vec()) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("DtnV2: delivery ack inner signing failed: {}", e);
+                return;
+            }
+        };
+        let inner_container = proto::Container {
+            signature: inner_sig,
+            envelope: Some(inner_envelope),
+        };
+        let inner_bytes = inner_container.encode_to_vec();
+
+        // Reverse route: same hops, reversed order, authored by us (the acker).
+        let mut reversed_hops = forward_route.route_hop.clone();
+        reversed_hops.reverse();
+        let reverse_route = proto::DtnRoute {
+            original_signature: ack_dedup.clone(),
+            route_hop: reversed_hops,
+            sender_public_key: user_account.keys.public().encode_protobuf(),
+            expires_at: None,
+        };
+        let reverse_route_bytes = reverse_route.encode_to_vec();
+        let reverse_route_sig = match user_account.keys.sign(&reverse_route_bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("DtnV2: delivery ack route signing failed: {}", e);
+                return;
+            }
+        };
+        let ack_container = proto::DtnV2Container {
+            dtn_route: reverse_route_bytes,
+            dtn_route_sig: reverse_route_sig,
+            envelope: inner_bytes,
+            custody_grant: None,
+            pow: None,
+        };
+
+        // Store our own copy so the retransmit loop keeps retrying the reverse
+        // delivery until a path to the sender exists.
+        let entry_size = ack_container.envelope.len() as u32;
+        let entry = DtnRoutedV2Entry {
+            container_v2_bytes: ack_container.encode_to_vec(),
+            sender_public_key: reverse_route.sender_public_key.clone(),
+            size: entry_size,
+            accepted_at: Timestamp::get_timestamp(),
+            receiver_id: origin.to_bytes(),
+            tier: TIER_CONTROL,
+        };
+        if let Ok(bytes) = bincode::serialize(&entry) {
+            if let Ok(mut v2) = state.services.dtn.v2.write() {
+                if v2.db_ref_routed_v2.insert(ack_dedup, bytes).is_ok() {
+                    let _ = v2.db_ref_routed_v2.flush();
+                    v2.used_size += entry_size as u64;
+                    v2.message_count += 1;
+                }
+            }
+        }
+
+        // Forward now if a next hop (or the sender) is reachable.
+        Self::try_forward_v2(state, user_account, &ack_container, &reverse_route, &origin);
+    }
+
     /// Store a custody grant this node has been given, keyed by the issuing
     /// recipient id, so the originate path can attach it to outgoing messages.
     fn store_held_grant(state: &crate::QaulState, grant: &proto::CustodyGrant) -> bool {
@@ -1577,6 +1705,24 @@ impl Dtn {
                 return;
             }
             V2Precheck::Deliver => {
+                // A delivered container that carries a signed DTN response is a
+                // DELIVERY ack routed back to us (the original sender) — dispatch
+                // it to free our outgoing custody copy, do NOT re-ack it.
+                if let Some(ack) = Self::extract_ack(&container.envelope) {
+                    log::info!("DtnV2: received routed DELIVERY ack");
+                    Self::on_dtn_response_v2(state, &ack);
+                    Self::send_response_v2(
+                        state,
+                        &user_account,
+                        sender_id,
+                        proto::dtn_response_v2::Kind::CustodyRelease,
+                        proto::dtn_response_v2::ResponseType::Accepted,
+                        proto::dtn_response_v2::Reason::None,
+                        &original_signature,
+                    );
+                    return;
+                }
+
                 log::info!("DtnV2: I am the recipient, processing inner container");
                 if let Ok(inner) = proto::Container::decode(&container.envelope[..]) {
                     super::messaging::process::MessagingProcess::process_received_message(
@@ -1585,25 +1731,10 @@ impl Dtn {
                         inner,
                     );
                 }
-                // Authoritative signed DELIVERY ack back to the original sender.
-                // The sender may be offline; a full reverse-custody route is
-                // follow-up work — for now send it direct to the sender id.
-                // TODO(dtn-v2): route the DELIVERY ack back over the reverse of
-                // the forward route so it survives an offline sender.
-                if let Some(sender_pub) =
-                    PublicKey::try_decode_protobuf(&route.sender_public_key).ok()
-                {
-                    let origin = PeerId::from_public_key(&sender_pub);
-                    Self::send_response_v2(
-                        state,
-                        &user_account,
-                        &origin,
-                        proto::dtn_response_v2::Kind::Delivery,
-                        proto::dtn_response_v2::ResponseType::Accepted,
-                        proto::dtn_response_v2::Reason::None,
-                        &original_signature,
-                    );
-                }
+                // Authoritative signed DELIVERY ack, routed back to the (possibly
+                // offline) original sender over the reverse of the forward route
+                // so it survives the sender being offline at delivery time.
+                Self::route_delivery_ack(state, &user_account, &route, &original_signature);
                 // Custody release to the immediate previous holder so it can
                 // free its storage now.
                 Self::send_response_v2(
@@ -1665,6 +1796,52 @@ impl Dtn {
                 );
                 return;
             }
+        }
+
+        // 4b. Control traffic (a DELIVERY ack being routed back to the sender)
+        //     bypasses the grant/PoW admission gates: it is tied to an
+        //     already-accepted custody flow and carries a verifiable signed
+        //     response. The route signature (verified above) authenticates it.
+        //     We store it on the short control retention and forward it on.
+        if Self::extract_ack(&container.envelope).is_some() {
+            let entry_size = container.envelope.len() as u32;
+            let entry = DtnRoutedV2Entry {
+                container_v2_bytes: container.encode_to_vec(),
+                sender_public_key: route.sender_public_key.clone(),
+                size: entry_size,
+                accepted_at: now,
+                receiver_id: envelope_receiver
+                    .as_ref()
+                    .map(|r| r.to_bytes())
+                    .unwrap_or_default(),
+                tier: TIER_CONTROL,
+            };
+            if let Ok(bytes) = bincode::serialize(&entry) {
+                if let Ok(mut v2) = state.services.dtn.v2.write() {
+                    if v2
+                        .db_ref_routed_v2
+                        .insert(original_signature.clone(), bytes)
+                        .is_ok()
+                    {
+                        let _ = v2.db_ref_routed_v2.flush();
+                        v2.used_size += entry_size as u64;
+                        v2.message_count += 1;
+                    }
+                }
+            }
+            Self::send_response_v2(
+                state,
+                &user_account,
+                sender_id,
+                proto::dtn_response_v2::Kind::Receipt,
+                proto::dtn_response_v2::ResponseType::Accepted,
+                proto::dtn_response_v2::Reason::None,
+                &original_signature,
+            );
+            if let Some(recv) = envelope_receiver {
+                Self::try_forward_v2(state, &user_account, &container, &route, &recv);
+            }
+            return;
         }
 
         // 5. Inner-container sender signature verification. The signed route
@@ -2126,10 +2303,9 @@ impl Dtn {
                     .and_then(|c| proto::DtnRoute::decode(&c.dtn_route[..]).ok())
                     .and_then(|r| r.expires_at)
                     .filter(|e| *e > 0);
-                let retention_ms = if v2_entry.tier == TIER_UNTRUSTED {
-                    V2_MAX_RETENTION_MS
-                } else {
-                    V2_TRUSTED_RETENTION_MS
+                let retention_ms = match v2_entry.tier {
+                    TIER_UNTRUSTED | TIER_CONTROL => V2_MAX_RETENTION_MS,
+                    _ => V2_TRUSTED_RETENTION_MS,
                 };
                 let effective_expires_at =
                     route_expiry.unwrap_or_else(|| v2_entry.accepted_at.saturating_add(retention_ms));
@@ -2782,6 +2958,106 @@ mod tests {
             "forged response must leave custody untouched"
         );
         assert_eq!(v2.used_size, 100);
+    }
+
+    // ── Reverse-routed DELIVERY ack (survives an offline sender) ──
+
+    /// Build a control-ack DtnV2Container: an inner container carrying a signed
+    /// DtnResponseV2(DELIVERY) addressed to `origin`, over `custodians`.
+    fn build_ack_container(
+        acker: &Keypair,
+        origin: &PeerId,
+        custodians: Vec<Vec<u8>>,
+    ) -> proto::DtnV2Container {
+        let mut ack = proto::DtnResponseV2 {
+            kind: proto::dtn_response_v2::Kind::Delivery as i32,
+            response_type: proto::dtn_response_v2::ResponseType::Accepted as i32,
+            reason: proto::dtn_response_v2::Reason::None as i32,
+            original_signature: vec![0x99],
+            responder_public_key: acker.public().encode_protobuf(),
+            signature: Vec::new(),
+        };
+        ack.signature = acker.sign(&ack.encode_to_vec()).unwrap();
+        let payload = proto::EnvelopPayload {
+            payload: Some(proto::envelop_payload::Payload::DtnResponseV2(ack)),
+        };
+        let env = proto::Envelope {
+            sender_id: PeerId::from(acker.public()).to_bytes(),
+            receiver_id: origin.to_bytes(),
+            payload: payload.encode_to_vec(),
+        };
+        let inner = proto::Container {
+            signature: acker.sign(&env.encode_to_vec()).unwrap(),
+            envelope: Some(env),
+        };
+        let route = Dtn::build_route(
+            vec![0xAC],
+            &custodians,
+            acker.public().encode_protobuf(),
+            None,
+        );
+        let rb = route.encode_to_vec();
+        let rs = acker.sign(&rb).unwrap();
+        proto::DtnV2Container {
+            dtn_route: rb,
+            dtn_route_sig: rs,
+            envelope: inner.encode_to_vec(),
+            custody_grant: None,
+            pow: None,
+        }
+    }
+
+    // On delivery, the receiver must route a DELIVERY ack back toward the
+    // sender and keep a copy (TIER_CONTROL) so the retransmit loop retries it —
+    // this is what lets the ack survive an offline sender.
+    #[test]
+    fn delivery_routes_ack_back_to_sender() {
+        let (state, account) = make_custody_state();
+        // message addressed to the local account, so it is delivered here
+        let (sender_keys, container_bytes, sig) = signed_inner(&account.keys);
+        let sender_id = PeerId::from(sender_keys.public());
+        let container = build_container_v2(
+            &sender_keys,
+            container_bytes,
+            sig,
+            vec![random_peer().to_bytes()],
+            None,
+            None,
+            None,
+        );
+        Dtn::net_routed_v2(&state, &account.id, &sender_id, &[], container);
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        let has_control_ack = v2.db_ref_routed_v2.iter().filter_map(|kv| kv.ok()).any(|(_, b)| {
+            bincode::deserialize::<DtnRoutedV2Entry>(&b)
+                .map(|e| e.tier == TIER_CONTROL)
+                .unwrap_or(false)
+        });
+        assert!(has_control_ack, "delivery must store a reverse-routed ack copy");
+    }
+
+    // A custodian forwards a routed DELIVERY ack without a grant or PoW — a
+    // grant-less ordinary message would be rejected, but control traffic is
+    // exempt because it is tied to an already-accepted custody flow.
+    #[test]
+    fn custodian_accepts_control_ack_without_admission() {
+        let (state, account) = make_custody_state();
+        let acker = Keypair::generate_ed25519();
+        let origin = random_peer(); // ultimate sender, not this custodian
+        let container = build_ack_container(&acker, &origin, vec![random_peer().to_bytes()]);
+        Dtn::net_routed_v2(
+            &state,
+            &account.id,
+            &PeerId::from(acker.public()),
+            &[],
+            container,
+        );
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        let stored = v2.db_ref_routed_v2.get(&vec![0xAC]).unwrap();
+        assert!(stored.is_some(), "control ack must be admitted without grant/PoW");
+        let entry: DtnRoutedV2Entry = bincode::deserialize(&stored.unwrap()).unwrap();
+        assert_eq!(entry.tier, TIER_CONTROL);
     }
 
     // ── Retention ──

--- a/rust/libqaul/src/services/dtn/mod.rs
+++ b/rust/libqaul/src/services/dtn/mod.rs
@@ -10,6 +10,7 @@ use libp2p::identity::PublicKey;
 use libp2p::PeerId;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sled;
 use std::collections::HashMap;
 use std::{fmt, sync::RwLock};
@@ -53,19 +54,22 @@ pub struct DtnStorageState {
 }
 
 
-/// DTN V2 routed message entry stored in sled
+/// DTN V2 custody entry stored in sled
 #[derive(Serialize, Deserialize, Clone)]
 pub struct DtnRoutedV2Entry {
-    /// serialized DtnRoutedV2 protobuf message
-    pub routed_v2_bytes: Vec<u8>,
+    /// serialized DtnV2Container protobuf message
+    pub container_v2_bytes: Vec<u8>,
     /// public key of the original sender
     pub sender_public_key: Vec<u8>,
-    /// size of the entry in bytes
+    /// size of the entry in bytes (the stored envelope payload)
     pub size: u32,
-    /// timestamp when this entry was accepted
+    /// timestamp when this entry was accepted (custodian-local receive time)
     pub accepted_at: u64,
     /// the ultimate receiver's user ID
     pub receiver_id: Vec<u8>,
+    /// admission tier: see `tier` constants below. Governs retention and the
+    /// order in which entries are shed under storage pressure.
+    pub tier: u8,
 }
 
 /// Per-sender quota tracking for V2 DTN messages
@@ -80,26 +84,53 @@ pub struct SenderQuotaEntry {
 /// V2 DTN storage state
 #[derive(Clone)]
 pub struct DtnStorageStateV2 {
-    /// V2 routed messages: original_signature => DtnRoutedV2Entry
+    /// V2 custody messages: original_signature => DtnRoutedV2Entry
     pub db_ref_routed_v2: sled::Tree,
     /// Per-sender quota tracking: sender_public_key => SenderQuotaEntry
     pub db_ref_sender_quotas: sled::Tree,
+    /// Custody grants this node has been given by recipients, so the originate
+    /// path can attach them: recipient_id => encoded CustodyGrant bytes
+    pub db_ref_grants: sled::Tree,
     /// Total used size for V2 messages
     pub used_size: u64,
     /// Total V2 message count
     pub message_count: u32,
+    /// Bytes currently held for grant-less untrusted-tier senders. The
+    /// aggregate cap on this (V2_UNTRUSTED_POOL_QUOTA) is what actually bounds
+    /// a Sybil flood — per-sender quota alone can't, since identities are free.
+    pub untrusted_used: u64,
 }
 
-/// Maximum bytes a single sender can store on this node (10 MB)
-const V2_PER_SENDER_QUOTA: u64 = 10 * 1024 * 1024;
+/// Admission tier for a stored custody entry (`DtnRoutedV2Entry.tier`).
+/// Untrusted entries are the first to be shed and have the shortest retention.
+const TIER_UNTRUSTED: u8 = 0;
+const TIER_TRUSTED: u8 = 1;
+const TIER_GRANT: u8 = 2;
 
-/// Maximum time a V2 custody entry is retained when the sender specified
-/// no expiry (expires_at == 0), counted from local acceptance: 7 days in
-/// milliseconds. Without this cap such entries would be stored forever
+/// Per-sender ceiling for a grant-less stranger admitted via proof-of-work.
+const V2_UNTRUSTED_PER_SENDER_QUOTA: u64 = 5 * 1024 * 1024;
+/// Per-sender ceiling for a locally-trusted contact (verified).
+const V2_TRUSTED_PER_SENDER_QUOTA: u64 = 20 * 1024 * 1024;
+/// Aggregate ceiling for the whole grant-less untrusted pool. Bounds a Sybil
+/// flood even when each fake sender stays under its own per-sender quota.
+const V2_UNTRUSTED_POOL_QUOTA: u64 = 50 * 1024 * 1024;
+
+/// Maximum time an untrusted custody entry is retained, counted from local
+/// acceptance: 7 days. Without this cap such entries would be stored forever
 /// if the recipient never becomes reachable.
 const V2_MAX_RETENTION_MS: u64 = 7 * 24 * 60 * 60 * 1000;
+/// Retention for trusted / grant-backed entries: 180 days.
+const V2_TRUSTED_RETENTION_MS: u64 = 180 * 24 * 60 * 60 * 1000;
 
-/// Outcome of the stateless checks run on every incoming DtnRoutedV2
+/// Minimum acceptable proof-of-work difficulty (leading zero bits) for a
+/// grant-less deposit. ~2^20 hashes to solve (sub-second) but trivial to
+/// verify; a one-machine Sybil flood pays this per (identity, custodian, day).
+const V2_MIN_POW_DIFFICULTY: u32 = 20;
+
+/// Milliseconds in a day, used to bind a PoW stamp to the current day.
+const MS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
+
+/// Outcome of the stateless checks run on every incoming DtnV2Container
 /// before the custody acceptance pipeline.
 #[derive(Debug, PartialEq, Eq)]
 enum V2Precheck {
@@ -107,8 +138,6 @@ enum V2Precheck {
     Expired,
     /// the local user is the final recipient — deliver
     Deliver,
-    /// no handoffs left and we are not the recipient — reject
-    Exhausted,
     /// continue with the custody acceptance pipeline
     Continue,
 }
@@ -132,6 +161,7 @@ impl DtnModuleState {
         let dtn_ids = db.open_tree("dtn-messages-ids").unwrap();
         let dtn_routed_v2 = db.open_tree("dtn-routed-v2").unwrap();
         let dtn_sender_quotas = db.open_tree("dtn-sender-quotas").unwrap();
+        let dtn_grants = db.open_tree("dtn-grants").unwrap();
         Self {
             inner: RwLock::new(DtnStorageState {
                 message_counts: 0,
@@ -142,8 +172,10 @@ impl DtnModuleState {
             v2: RwLock::new(DtnStorageStateV2 {
                 message_count: 0,
                 used_size: 0,
+                untrusted_used: 0,
                 db_ref_routed_v2: dtn_routed_v2,
                 db_ref_sender_quotas: dtn_sender_quotas,
+                db_ref_grants: dtn_grants,
             }),
             _db: RwLock::new(db),
         }
@@ -196,13 +228,24 @@ impl DtnModuleState {
                 return;
             }
         };
+        let db_ref_grants = match db.open_tree("dtn-grants") {
+            Ok(tree) => tree,
+            Err(e) => {
+                log::error!("Failed to open dtn-grants tree: {}", e);
+                return;
+            }
+        };
 
         let mut v2_used_size: u64 = 0;
+        let mut v2_untrusted_used: u64 = 0;
         let mut sender_quotas: HashMap<Vec<u8>, SenderQuotaEntry> = HashMap::new();
         for entry in db_ref_routed_v2.iter() {
             if let Ok((_, entry_bytes)) = entry {
                 if let Ok(v2_entry) = bincode::deserialize::<DtnRoutedV2Entry>(&entry_bytes) {
                     v2_used_size += v2_entry.size as u64;
+                    if v2_entry.tier == TIER_UNTRUSTED {
+                        v2_untrusted_used += v2_entry.size as u64;
+                    }
                     let quota = sender_quotas
                         .entry(v2_entry.sender_public_key.clone())
                         .or_default();
@@ -248,8 +291,10 @@ impl DtnModuleState {
             let mut v2_state = self.v2.write().unwrap();
             v2_state.message_count = db_ref_routed_v2.len() as u32;
             v2_state.used_size = v2_used_size;
+            v2_state.untrusted_used = v2_untrusted_used;
             v2_state.db_ref_routed_v2 = db_ref_routed_v2;
             v2_state.db_ref_sender_quotas = db_ref_sender_quotas;
+            v2_state.db_ref_grants = db_ref_grants;
         }
         {
             let mut db_lock = self._db.write().unwrap();
@@ -824,6 +869,12 @@ impl Dtn {
                 Some(proto_rpc::dtn::Message::DtnSetCustodyEnabledRequest(req)) => {
                     Self::rpc_set_custody_enabled(state, my_user_id, req, request_id);
                 }
+                Some(proto_rpc::dtn::Message::DtnIssueGrantRequest(req)) => {
+                    Self::rpc_issue_grant(state, my_user_id, req, request_id);
+                }
+                Some(proto_rpc::dtn::Message::DtnImportGrantRequest(req)) => {
+                    Self::rpc_import_grant(state, req, request_id);
+                }
                 _ => {
                     log::error!("Unhandled Protobuf DTN RPC message");
                 }
@@ -831,6 +882,223 @@ impl Dtn {
             Err(error) => {
                 log::error!("{:?}", error);
             }
+        }
+    }
+
+    // ===================================================================
+    // DTN v2 redesign: crypto, proof-of-work, grant & route helpers
+    // ===================================================================
+
+    /// Derive the wire id (PeerId bytes) for a protobuf-encoded public key.
+    fn peer_id_bytes_from_pubkey(pubkey_bytes: &[u8]) -> Option<Vec<u8>> {
+        PublicKey::try_decode_protobuf(pubkey_bytes)
+            .ok()
+            .map(|pk| PeerId::from_public_key(&pk).to_bytes())
+    }
+
+    /// Build an (unsigned) DtnRoute from a flat custody-user list: one RouteHop
+    /// per custodian (single interchangeable entry), ordered by hop ascending.
+    fn build_route(
+        original_signature: Vec<u8>,
+        custody_route: &[Vec<u8>],
+        sender_public_key: Vec<u8>,
+        expires_at: Option<u64>,
+    ) -> proto::DtnRoute {
+        let route_hop = custody_route
+            .iter()
+            .map(|id| proto::RouteHop {
+                route_entry: vec![proto::RouteEntry { id: id.clone() }],
+            })
+            .collect();
+        proto::DtnRoute {
+            original_signature,
+            route_hop,
+            sender_public_key,
+            expires_at,
+        }
+    }
+
+    /// Verify the sender's signature over the encoded route bytes.
+    fn verify_route_sig(route: &proto::DtnRoute, dtn_route_bytes: &[u8], sig: &[u8]) -> bool {
+        match PublicKey::try_decode_protobuf(&route.sender_public_key) {
+            Ok(key) => key.verify(dtn_route_bytes, sig),
+            Err(_) => false,
+        }
+    }
+
+    /// Sign a custody grant with the local user's key (canonical: sig empty).
+    fn sign_grant(
+        user_account: &UserAccount,
+        mut grant: proto::CustodyGrant,
+    ) -> Option<proto::CustodyGrant> {
+        grant.signature = Vec::new();
+        match user_account.keys.sign(&grant.encode_to_vec()) {
+            Ok(sig) => {
+                grant.signature = sig;
+                Some(grant)
+            }
+            Err(e) => {
+                log::error!("DTN v2: grant signing failed: {}", e);
+                None
+            }
+        }
+    }
+
+    /// Verify a recipient-signed custody grant in isolation: the embedded
+    /// public key must be the named recipient, the grant must be unexpired, and
+    /// the signature must verify. The caller additionally checks that the grant
+    /// names *this* sender and receiver and that the deposit fits `quota_bytes`.
+    fn verify_grant(grant: &proto::CustodyGrant, now_ms: u64) -> bool {
+        match Self::peer_id_bytes_from_pubkey(&grant.recipient_public_key) {
+            Some(id) if id == grant.recipient => {}
+            _ => return false,
+        }
+        if grant.not_after != 0 && now_ms > grant.not_after {
+            return false;
+        }
+        let key = match PublicKey::try_decode_protobuf(&grant.recipient_public_key) {
+            Ok(k) => k,
+            Err(_) => return false,
+        };
+        let mut unsigned = grant.clone();
+        unsigned.signature = Vec::new();
+        key.verify(&unsigned.encode_to_vec(), &grant.signature)
+    }
+
+    /// Proof-of-work bind hash over (original_signature, custodian_id, day, nonce).
+    fn pow_hash(original_signature: &[u8], custodian_id: &[u8], day: u64, nonce: u64) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(original_signature);
+        hasher.update(custodian_id);
+        hasher.update(day.to_le_bytes());
+        hasher.update(nonce.to_le_bytes());
+        hasher.finalize().into()
+    }
+
+    /// Count leading zero bits across a 32-byte digest.
+    fn leading_zero_bits(hash: &[u8; 32]) -> u32 {
+        let mut bits = 0u32;
+        for byte in hash {
+            if *byte == 0 {
+                bits += 8;
+            } else {
+                bits += byte.leading_zeros();
+                break;
+            }
+        }
+        bits
+    }
+
+    /// Verify a PoW stamp, bound to this custodian and the current or previous
+    /// day (tolerating a clock at the day boundary). A stamp solved for one
+    /// custodian/day cannot be replayed against another.
+    fn verify_pow(
+        stamp: &proto::PowStamp,
+        original_signature: &[u8],
+        custodian_id: &[u8],
+        now_ms: u64,
+    ) -> bool {
+        if stamp.difficulty < V2_MIN_POW_DIFFICULTY {
+            return false;
+        }
+        let today = now_ms / MS_PER_DAY;
+        for day in [today, today.saturating_sub(1)] {
+            let hash = Self::pow_hash(original_signature, custodian_id, day, stamp.nonce);
+            if Self::leading_zero_bits(&hash) >= stamp.difficulty {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Solve a PoW stamp (originate side / tests).
+    fn solve_pow(
+        original_signature: &[u8],
+        custodian_id: &[u8],
+        day: u64,
+        difficulty: u32,
+    ) -> proto::PowStamp {
+        let mut nonce = 0u64;
+        loop {
+            let hash = Self::pow_hash(original_signature, custodian_id, day, nonce);
+            if Self::leading_zero_bits(&hash) >= difficulty {
+                return proto::PowStamp { nonce, difficulty };
+            }
+            nonce = nonce.wrapping_add(1);
+        }
+    }
+
+    /// Build and sign a DtnResponseV2 (canonical: signature field empty while
+    /// signing, then filled).
+    fn build_signed_response(
+        user_account: &UserAccount,
+        kind: proto::dtn_response_v2::Kind,
+        response_type: proto::dtn_response_v2::ResponseType,
+        reason: proto::dtn_response_v2::Reason,
+        original_signature: Vec<u8>,
+    ) -> Option<proto::DtnResponseV2> {
+        let mut resp = proto::DtnResponseV2 {
+            kind: kind as i32,
+            response_type: response_type as i32,
+            reason: reason as i32,
+            original_signature,
+            responder_public_key: user_account.keys.public().encode_protobuf(),
+            signature: Vec::new(),
+        };
+        match user_account.keys.sign(&resp.encode_to_vec()) {
+            Ok(sig) => {
+                resp.signature = sig;
+                Some(resp)
+            }
+            Err(e) => {
+                log::error!("DTN v2: response signing failed: {}", e);
+                None
+            }
+        }
+    }
+
+    /// Verify a DtnResponseV2 signature against its embedded responder key.
+    /// Returns the responder's PeerId bytes on success — this is the check that
+    /// makes only a genuinely-signed response able to mutate custody state.
+    fn verify_response_v2(resp: &proto::DtnResponseV2) -> Option<Vec<u8>> {
+        let key = PublicKey::try_decode_protobuf(&resp.responder_public_key).ok()?;
+        let mut unsigned = resp.clone();
+        unsigned.signature = Vec::new();
+        if key.verify(&unsigned.encode_to_vec(), &resp.signature) {
+            Some(PeerId::from_public_key(&key).to_bytes())
+        } else {
+            None
+        }
+    }
+
+    /// Store a custody grant this node has been given, keyed by the issuing
+    /// recipient id, so the originate path can attach it to outgoing messages.
+    fn store_held_grant(state: &crate::QaulState, grant: &proto::CustodyGrant) -> bool {
+        match state.services.dtn.v2.write() {
+            Ok(v2) => {
+                if let Err(e) = v2
+                    .db_ref_grants
+                    .insert(grant.recipient.clone(), grant.encode_to_vec())
+                {
+                    log::error!("DTN v2: failed to store held grant: {}", e);
+                    return false;
+                }
+                let _ = v2.db_ref_grants.flush();
+                true
+            }
+            Err(e) => {
+                log::error!("DTN v2: failed to acquire write lock for grant store: {}", e);
+                false
+            }
+        }
+    }
+
+    /// Look up a held grant issued by `recipient_id`, if any.
+    fn held_grant_for(state: &crate::QaulState, recipient_id: &[u8]) -> Option<proto::CustodyGrant> {
+        let v2 = state.services.dtn.v2.read().ok()?;
+        match v2.db_ref_grants.get(recipient_id) {
+            Ok(Some(bytes)) => proto::CustodyGrant::decode(&bytes[..]).ok(),
+            _ => None,
         }
     }
 
@@ -895,22 +1163,11 @@ impl Dtn {
             }
         };
 
-        // Use the flat custody route directly
-        let custody_route = req.custody_route.clone();
-
-        // Calculate expiry
+        // Optional expiry (retention is otherwise custodian-local)
         let expires_at = if req.expiry_seconds > 0 {
-            Timestamp::get_timestamp() + (req.expiry_seconds * 1000)
+            Some(Timestamp::get_timestamp() + (req.expiry_seconds * 1000))
         } else {
-            0
-        };
-
-        // Calculate remaining handoffs
-        let total_custodians: u32 = custody_route.len() as u32;
-        let remaining_handoffs = if req.max_handoffs > 0 {
-            req.max_handoffs
-        } else {
-            total_custodians * 2
+            None
         };
 
         // Extract original_signature from the inner Container
@@ -928,19 +1185,25 @@ impl Dtn {
             }
         };
 
-        // Build the DtnRoutedV2 message
-        let routed_v2 = proto::DtnRoutedV2 {
-            container: req.data.clone(),
-            custody_route,
-            next_route_index: 0,
-            original_signature,
-            sender_public_key: user_account.keys.public().encode_protobuf(),
+        // Build and sign the immutable route
+        let route = Self::build_route(
+            original_signature.clone(),
+            &req.custody_route,
+            user_account.keys.public().encode_protobuf(),
             expires_at,
-            remaining_handoffs,
+        );
+        let dtn_route_bytes = route.encode_to_vec();
+        let dtn_route_sig = match user_account.keys.sign(&dtn_route_bytes) {
+            Ok(sig) => sig,
+            Err(e) => {
+                send_response(false, format!("route signing failed: {}", e));
+                return;
+            }
         };
 
-        // Find initial target
-        let target = match Self::select_custody_target(state, &routed_v2, &receiver_id) {
+        // Find the first hop / recipient (my_user_id is the sender, not in the
+        // route, so traversal treats it as being before the first hop).
+        let target = match Self::select_custody_target(state, &route, &my_user_id, &receiver_id) {
             Some(t) => t,
             None => {
                 send_response(false, "no reachable custodian found".to_string());
@@ -948,30 +1211,60 @@ impl Dtn {
             }
         };
 
+        // Admission credential: attach a recipient-issued grant if we hold one,
+        // otherwise a proof-of-work stamp bound to the first custodian so a
+        // grant-less deposit can still be admitted into the untrusted pool.
+        let custody_grant = Self::held_grant_for(state, &receiver_id.to_bytes());
+        let pow = if custody_grant.is_none() {
+            let day = Timestamp::get_timestamp() / MS_PER_DAY;
+            Some(Self::solve_pow(
+                &original_signature,
+                &target.to_bytes(),
+                day,
+                V2_MIN_POW_DIFFICULTY,
+            ))
+        } else {
+            None
+        };
+        let tier = if custody_grant.is_some() {
+            TIER_GRANT
+        } else {
+            TIER_TRUSTED
+        };
+
+        let container_v2 = proto::DtnV2Container {
+            dtn_route: dtn_route_bytes,
+            dtn_route_sig,
+            envelope: req.data.clone(),
+            custody_grant,
+            pow,
+        };
+
         // Send via envelope
-        match super::messaging::Messaging::send_dtn_routed_v2_message(
+        match super::messaging::Messaging::send_dtn_v2_message(
             state,
             &user_account,
             &target,
-            routed_v2.clone(),
+            container_v2.clone(),
         ) {
             Ok(_sig) => {
-                // Store in V2 state so on_dtn_response_v2 can clean up
-                // when the first custodian responds
-                let entry_size = routed_v2.container.len() as u32;
+                // Store our own copy so the retransmit loop can re-forward and
+                // on_dtn_response_v2 can clean up once the receiver confirms
+                // delivery. Size accounts the stored payload (envelope).
+                let entry_size = container_v2.envelope.len() as u32;
                 let v2_entry = DtnRoutedV2Entry {
-                    routed_v2_bytes: routed_v2.encode_to_vec(),
-                    sender_public_key: routed_v2.sender_public_key.clone(),
+                    container_v2_bytes: container_v2.encode_to_vec(),
+                    sender_public_key: route.sender_public_key.clone(),
                     size: entry_size,
                     accepted_at: Timestamp::get_timestamp(),
                     receiver_id: receiver_id.to_bytes(),
+                    tier,
                 };
                 if let Ok(entry_bytes) = bincode::serialize(&v2_entry) {
                     if let Ok(mut v2) = state.services.dtn.v2.write() {
-                        let _ = v2.db_ref_routed_v2.insert(
-                            routed_v2.original_signature.clone(),
-                            entry_bytes,
-                        );
+                        let _ = v2
+                            .db_ref_routed_v2
+                            .insert(original_signature.clone(), entry_bytes);
                         let _ = v2.db_ref_routed_v2.flush();
                         v2.used_size += entry_size as u64;
                         v2.message_count += 1;
@@ -985,10 +1278,6 @@ impl Dtn {
         }
     }
 
-    /// Determine where to forward a V2 DTN message.
-    ///
-    /// Returns the recipient if online, otherwise scans the custody route
-    /// forward from `next_route_index`, returning the first reachable user.
     /// Handle DtnSetCustodyEnabledRequest RPC
     fn rpc_set_custody_enabled(
         state: &crate::QaulState,
@@ -1029,506 +1318,704 @@ impl Dtn {
         }
     }
 
+    /// Handle DtnIssueGrantRequest RPC: the local user (recipient) issues a
+    /// signed custody grant authorizing `grantee` to have messages held for it.
+    fn rpc_issue_grant(
+        state: &crate::QaulState,
+        my_user_id: PeerId,
+        req: proto_rpc::DtnIssueGrantRequest,
+        request_id: String,
+    ) {
+        let respond = |status: bool, grant: Vec<u8>, message: String| {
+            let proto_message = proto_rpc::Dtn {
+                message: Some(proto_rpc::dtn::Message::DtnIssueGrantResponse(
+                    proto_rpc::DtnIssueGrantResponse {
+                        status,
+                        grant,
+                        message,
+                    },
+                )),
+            };
+            Rpc::send_message(
+                state,
+                proto_message.encode_to_vec(),
+                crate::rpc::proto::Modules::Dtn as i32,
+                request_id.clone(),
+                Vec::new(),
+            );
+        };
+
+        if PeerId::from_bytes(&req.grantee).is_err() {
+            respond(false, Vec::new(), "invalid grantee id".to_string());
+            return;
+        }
+        let user_account = match UserAccounts::get_by_id(state, my_user_id) {
+            Some(ua) => ua,
+            None => {
+                respond(false, Vec::new(), "user account not found".to_string());
+                return;
+            }
+        };
+        let quota_bytes = if req.quota_bytes > 0 {
+            req.quota_bytes
+        } else {
+            V2_TRUSTED_PER_SENDER_QUOTA
+        };
+        let grant = proto::CustodyGrant {
+            grantee: req.grantee,
+            recipient: my_user_id.to_bytes(),
+            recipient_public_key: user_account.keys.public().encode_protobuf(),
+            quota_bytes,
+            epoch: req.epoch,
+            not_after: req.not_after,
+            signature: Vec::new(),
+        };
+        match Self::sign_grant(&user_account, grant) {
+            Some(signed) => respond(true, signed.encode_to_vec(), "".to_string()),
+            None => respond(false, Vec::new(), "grant signing failed".to_string()),
+        }
+    }
+
+    /// Handle DtnImportGrantRequest RPC: store a grant this node has been given
+    /// so the originate path can attach it to outgoing custody messages.
+    fn rpc_import_grant(
+        state: &crate::QaulState,
+        req: proto_rpc::DtnImportGrantRequest,
+        request_id: String,
+    ) {
+        let respond = |status: bool, message: String| {
+            let proto_message = proto_rpc::Dtn {
+                message: Some(proto_rpc::dtn::Message::DtnImportGrantResponse(
+                    proto_rpc::DtnImportGrantResponse { status, message },
+                )),
+            };
+            Rpc::send_message(
+                state,
+                proto_message.encode_to_vec(),
+                crate::rpc::proto::Modules::Dtn as i32,
+                request_id.clone(),
+                Vec::new(),
+            );
+        };
+
+        let grant = match proto::CustodyGrant::decode(&req.grant[..]) {
+            Ok(g) => g,
+            Err(e) => {
+                respond(false, format!("invalid grant: {}", e));
+                return;
+            }
+        };
+        if !Self::verify_grant(&grant, Timestamp::get_timestamp()) {
+            respond(false, "grant signature verification failed".to_string());
+            return;
+        }
+        if Self::store_held_grant(state, &grant) {
+            respond(true, "".to_string());
+        } else {
+            respond(false, "failed to store grant".to_string());
+        }
+    }
+
+    /// Determine the next target for a V2 custody message via stateless
+    /// traversal of the immutable signed route.
+    ///
+    /// Deliver directly to the receiver if reachable; otherwise locate our own
+    /// id in the route and forward to the *furthest* reachable hop strictly
+    /// after it (skipping dead intermediate hops). If our id is not in the
+    /// route (we were reached opportunistically) treat our position as being
+    /// before the first hop. The route carries no cursor — position is derived
+    /// each time, so the message is never rewritten in transit.
     pub fn select_custody_target(
         state: &crate::QaulState,
-        routed_v2: &proto::DtnRoutedV2,
+        route: &proto::DtnRoute,
+        my_id: &PeerId,
         receiver_id: &PeerId,
     ) -> Option<PeerId> {
         let rs = state.get_router();
-        // Check if recipient is directly reachable
+        // Deliver straight to the recipient when reachable.
         if rs.routing_table.get_route_to_user(*receiver_id).is_some() {
             return Some(*receiver_id);
         }
 
-        // Strict forward scan from next_route_index
-        let start = routed_v2.next_route_index as usize;
-        let len = routed_v2.custody_route.len();
-        if start >= len {
-            return None;
-        }
-        for i in start..len {
-            if let Ok(custodian_id) = PeerId::from_bytes(&routed_v2.custody_route[i]) {
-                if rs.routing_table.get_route_to_user(custodian_id).is_some() {
-                    return Some(custodian_id);
+        let my_bytes = my_id.to_bytes();
+        // Our hop index = first hop that lists our id.
+        let self_hop = route
+            .route_hop
+            .iter()
+            .position(|hop| hop.route_entry.iter().any(|e| e.id == my_bytes));
+        let start_after = match self_hop {
+            Some(i) => i + 1,
+            None => 0,
+        };
+        // Hops strictly after ours, furthest first — first reachable wins.
+        for hop in route.route_hop[start_after..].iter().rev() {
+            for entry in &hop.route_entry {
+                if let Ok(custodian_id) = PeerId::from_bytes(&entry.id) {
+                    if rs.routing_table.get_route_to_user(custodian_id).is_some() {
+                        return Some(custodian_id);
+                    }
                 }
             }
         }
-
         None
     }
 
-    /// Process a received DtnRoutedV2 message from the network
+    /// Free the accounting for a custody entry being removed (does NOT remove
+    /// the tree key — the caller does that). Decrements node totals, the
+    /// untrusted-pool counter, and the per-sender quota.
+    fn free_entry(v2: &mut DtnStorageStateV2, entry: &DtnRoutedV2Entry) {
+        v2.used_size = v2.used_size.saturating_sub(entry.size as u64);
+        v2.message_count = v2.message_count.saturating_sub(1);
+        if entry.tier == TIER_UNTRUSTED {
+            v2.untrusted_used = v2.untrusted_used.saturating_sub(entry.size as u64);
+        }
+        if let Ok(Some(quota_bytes)) = v2.db_ref_sender_quotas.get(&entry.sender_public_key) {
+            if let Ok(mut quota) = bincode::deserialize::<SenderQuotaEntry>(&quota_bytes) {
+                quota.used_bytes = quota.used_bytes.saturating_sub(entry.size as u64);
+                quota.message_count = quota.message_count.saturating_sub(1);
+                if let Ok(bytes) = bincode::serialize(&quota) {
+                    let _ = v2
+                        .db_ref_sender_quotas
+                        .insert(entry.sender_public_key.clone(), bytes);
+                }
+            }
+        }
+    }
+
+    /// Build and send a signed DtnResponseV2 to `target_id`.
+    fn send_response_v2(
+        state: &crate::QaulState,
+        user_account: &UserAccount,
+        target_id: &PeerId,
+        kind: proto::dtn_response_v2::Kind,
+        response_type: proto::dtn_response_v2::ResponseType,
+        reason: proto::dtn_response_v2::Reason,
+        original_signature: &[u8],
+    ) {
+        let resp = match Self::build_signed_response(
+            user_account,
+            kind,
+            response_type,
+            reason,
+            original_signature.to_vec(),
+        ) {
+            Some(r) => r,
+            None => return,
+        };
+        let send_message = proto::Messaging {
+            message: Some(proto::messaging::Message::DtnResponseV2(resp)),
+        };
+        if let Err(e) = super::messaging::Messaging::pack_and_send_message(
+            state,
+            user_account,
+            target_id,
+            send_message.encode_to_vec(),
+            MessagingServiceType::DtnStored,
+            &Vec::new(),
+            false,
+        ) {
+            log::error!("DtnV2: send response error: {}", e);
+        }
+    }
+
+    /// Process a received DtnV2Container from the network.
+    ///
+    /// The route is verified as a signed, immutable blob and the admission
+    /// decision is capability-first: a recipient-signed grant, else a trusted
+    /// local contact, else a valid proof-of-work stamp for the grant-less pool.
     pub fn net_routed_v2(
         state: &crate::QaulState,
         user_id: &PeerId,
         sender_id: &PeerId,
         _signature: &[u8],
-        routed_v2: proto::DtnRoutedV2,
+        container: proto::DtnV2Container,
     ) {
-        log::info!("Received DtnRoutedV2 message from {}", sender_id.to_base58());
+        log::info!("Received DtnV2Container from {}", sender_id.to_base58());
+        let now = Timestamp::get_timestamp();
 
         let user_account = match UserAccounts::get_by_id(state, *user_id) {
             Some(ua) => ua,
             None => {
-                log::error!("DtnRoutedV2: user account not found for {}", user_id.to_base58());
-                if let Some(default_user) = UserAccounts::get_default_user(state) {
-                    Self::send_v2_response(
-                        state,
-                        &default_user,
-                        sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::UserNotAccepted,
-                    );
-                }
+                log::error!(
+                    "DtnV2: user account not found for {}",
+                    user_id.to_base58()
+                );
                 return;
             }
         };
 
-        // 1. Stateless prechecks: expiry, final delivery, handoff budget
-        let envelope_receiver = Self::get_receiver_from_container(&routed_v2.container);
-        match Self::precheck_routed_v2(
-            &routed_v2,
-            envelope_receiver.as_ref(),
-            user_id,
-            Timestamp::get_timestamp(),
-        ) {
+        // 1. Decode and verify the signed immutable route. A route that does
+        //    not verify is unauthenticated garbage — drop it silently, do not
+        //    even acknowledge (an attacker must not learn anything).
+        let route = match proto::DtnRoute::decode(&container.dtn_route[..]) {
+            Ok(r) => r,
+            Err(e) => {
+                log::error!("DtnV2: failed to decode route: {}", e);
+                return;
+            }
+        };
+        if !Self::verify_route_sig(&route, &container.dtn_route, &container.dtn_route_sig) {
+            log::error!("DtnV2: route signature verification failed, dropping");
+            return;
+        }
+        let original_signature = route.original_signature.clone();
+
+        // 2. Stateless prechecks: expiry, or am-I-the-final-recipient.
+        let envelope_receiver = Self::get_receiver_from_container(&container.envelope);
+        match Self::precheck_routed_v2(&route, envelope_receiver.as_ref(), user_id, now) {
             V2Precheck::Expired => {
-                log::warn!("DtnRoutedV2 message expired, dropping");
-                Self::send_v2_response(
+                log::warn!("DtnV2 message expired, dropping");
+                Self::send_response_v2(
                     state,
                     &user_account,
                     sender_id,
-                    &routed_v2.original_signature,
-                    proto::dtn_response::ResponseType::Rejected,
-                    proto::dtn_response::Reason::None,
+                    proto::dtn_response_v2::Kind::DropReport,
+                    proto::dtn_response_v2::ResponseType::Rejected,
+                    proto::dtn_response_v2::Reason::None,
+                    &original_signature,
                 );
                 return;
             }
             V2Precheck::Deliver => {
-                log::info!("DtnRoutedV2: I am the recipient, processing inner container");
-                if let Ok(container) = proto::Container::decode(&routed_v2.container[..]) {
+                log::info!("DtnV2: I am the recipient, processing inner container");
+                if let Ok(inner) = proto::Container::decode(&container.envelope[..]) {
                     super::messaging::process::MessagingProcess::process_received_message(
                         state,
                         user_account.clone(),
-                        container,
+                        inner,
                     );
                 }
-                Self::send_v2_response(
+                // Authoritative signed DELIVERY ack back to the original sender.
+                // The sender may be offline; a full reverse-custody route is
+                // follow-up work — for now send it direct to the sender id.
+                // TODO(dtn-v2): route the DELIVERY ack back over the reverse of
+                // the forward route so it survives an offline sender.
+                if let Some(sender_pub) =
+                    PublicKey::try_decode_protobuf(&route.sender_public_key).ok()
+                {
+                    let origin = PeerId::from_public_key(&sender_pub);
+                    Self::send_response_v2(
+                        state,
+                        &user_account,
+                        &origin,
+                        proto::dtn_response_v2::Kind::Delivery,
+                        proto::dtn_response_v2::ResponseType::Accepted,
+                        proto::dtn_response_v2::Reason::None,
+                        &original_signature,
+                    );
+                }
+                // Custody release to the immediate previous holder so it can
+                // free its storage now.
+                Self::send_response_v2(
                     state,
                     &user_account,
                     sender_id,
-                    &routed_v2.original_signature,
-                    proto::dtn_response::ResponseType::Accepted,
-                    proto::dtn_response::Reason::None,
-                );
-                return;
-            }
-            V2Precheck::Exhausted => {
-                log::warn!("DtnRoutedV2 message has no remaining handoffs, dropping");
-                Self::send_v2_response(
-                    state,
-                    &user_account,
-                    sender_id,
-                    &routed_v2.original_signature,
-                    proto::dtn_response::ResponseType::Rejected,
-                    proto::dtn_response::Reason::None,
+                    proto::dtn_response_v2::Kind::CustodyRelease,
+                    proto::dtn_response_v2::ResponseType::Accepted,
+                    proto::dtn_response_v2::Reason::None,
+                    &original_signature,
                 );
                 return;
             }
             V2Precheck::Continue => {}
         }
 
-        // 2. Duplicate check
+        // 3. Duplicate check — already in custody. Send a receipt and stop.
         {
             let v2 = match state.services.dtn.v2.read() {
                 Ok(s) => s,
                 Err(e) => {
-                    log::error!("DtnRoutedV2: failed to acquire read lock: {}", e);
+                    log::error!("DtnV2: read lock failed: {}", e);
                     return;
                 }
             };
             if v2
                 .db_ref_routed_v2
-                .contains_key(&routed_v2.original_signature)
+                .contains_key(&original_signature)
                 .unwrap_or(false)
             {
-                log::info!("DtnRoutedV2 duplicate detected, accepting silently");
                 drop(v2);
-                Self::send_v2_response(
+                log::info!("DtnV2 duplicate, accepting silently");
+                Self::send_response_v2(
                     state,
                     &user_account,
                     sender_id,
-                    &routed_v2.original_signature,
-                    proto::dtn_response::ResponseType::Accepted,
-                    proto::dtn_response::Reason::None,
+                    proto::dtn_response_v2::Kind::Receipt,
+                    proto::dtn_response_v2::ResponseType::Accepted,
+                    proto::dtn_response_v2::Reason::None,
+                    &original_signature,
                 );
                 return;
             }
         }
 
-        // 3. Custody opt-in check
+        // 4. Custody opt-in.
         match Configuration::get_user(state, user_account.id.to_string()) {
-            Some(user_profile) => {
-                if !user_profile.storage.dtn_v2_custody_enabled {
-                    log::warn!("DtnRoutedV2: custody not enabled for this node");
-                    Self::send_v2_response(
+            Some(profile) if profile.storage.dtn_v2_custody_enabled => {}
+            _ => {
+                log::warn!("DtnV2: custody not enabled on this node");
+                Self::send_response_v2(
+                    state,
+                    &user_account,
+                    sender_id,
+                    proto::dtn_response_v2::Kind::DropReport,
+                    proto::dtn_response_v2::ResponseType::Rejected,
+                    proto::dtn_response_v2::Reason::UserNotAccepted,
+                    &original_signature,
+                );
+                return;
+            }
+        }
+
+        // 5. Inner-container sender signature verification. The signed route
+        //    vouches for `sender_public_key`; the inner message must be signed
+        //    by that same key.
+        let inner = match proto::Container::decode(&container.envelope[..]) {
+            Ok(c) => c,
+            Err(e) => {
+                log::error!("DtnV2: failed to decode inner container: {}", e);
+                Self::send_response_v2(
+                    state,
+                    &user_account,
+                    sender_id,
+                    proto::dtn_response_v2::Kind::DropReport,
+                    proto::dtn_response_v2::ResponseType::Rejected,
+                    proto::dtn_response_v2::Reason::None,
+                    &original_signature,
+                );
+                return;
+            }
+        };
+        let sender_pub_key = match PublicKey::try_decode_protobuf(&route.sender_public_key) {
+            Ok(k) => k,
+            Err(e) => {
+                log::error!("DtnV2: invalid sender public key: {}", e);
+                return;
+            }
+        };
+        match inner.envelope.as_ref() {
+            Some(envelope) => {
+                let mut buf = Vec::with_capacity(envelope.encoded_len());
+                envelope
+                    .encode(&mut buf)
+                    .expect("Vec<u8> provides capacity as needed");
+                if !sender_pub_key.verify(&buf, &inner.signature) {
+                    log::error!("DtnV2: inner container signature verification failed");
+                    Self::send_response_v2(
                         state,
                         &user_account,
                         sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::UserNotAccepted,
+                        proto::dtn_response_v2::Kind::DropReport,
+                        proto::dtn_response_v2::ResponseType::Rejected,
+                        proto::dtn_response_v2::Reason::UserNotAccepted,
+                        &original_signature,
                     );
                     return;
                 }
             }
             None => {
-                log::error!("DtnRoutedV2: user profile not found for custody check");
-                Self::send_v2_response(
-                    state,
-                    &user_account,
-                    sender_id,
-                    &routed_v2.original_signature,
-                    proto::dtn_response::ResponseType::Rejected,
-                    proto::dtn_response::Reason::UserNotAccepted,
-                );
+                log::error!("DtnV2: inner container has no envelope");
                 return;
             }
         }
+        let inner_sender = PeerId::from_public_key(&sender_pub_key);
+        let inner_sender_bytes = inner_sender.to_bytes();
 
-        // 4. Sender signature verification
-        let sender_pub_key = {
-            let inner_container = match proto::Container::decode(&routed_v2.container[..]) {
-                Ok(c) => c,
-                Err(e) => {
-                    log::error!("DtnRoutedV2: failed to decode inner container: {}", e);
-                    Self::send_v2_response(
-                        state,
-                        &user_account,
-                        sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::None,
-                    );
-                    return;
-                }
-            };
-            let sender_key = match PublicKey::try_decode_protobuf(&routed_v2.sender_public_key) {
-                Ok(k) => k,
-                Err(e) => {
-                    log::error!("DtnRoutedV2: invalid sender public key: {}", e);
-                    Self::send_v2_response(
-                        state,
-                        &user_account,
-                        sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::None,
-                    );
-                    return;
-                }
-            };
-            if let Some(envelope) = inner_container.envelope.as_ref() {
-                let mut envelope_buf = Vec::with_capacity(envelope.encoded_len());
-                envelope
-                    .encode(&mut envelope_buf)
-                    .expect("Vec<u8> provides capacity as needed");
-                if !sender_key.verify(&envelope_buf, &inner_container.signature) {
-                    log::error!("DtnRoutedV2: inner container signature verification failed");
-                    Self::send_v2_response(
-                        state,
-                        &user_account,
-                        sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::UserNotAccepted,
-                    );
-                    return;
-                }
-            } else {
-                log::error!("DtnRoutedV2: inner container has no envelope");
-                Self::send_v2_response(
-                    state,
-                    &user_account,
-                    sender_id,
-                    &routed_v2.original_signature,
-                    proto::dtn_response::ResponseType::Rejected,
-                    proto::dtn_response::Reason::None,
-                );
-                return;
-            }
-            sender_key
-        };
-
-        // 5. Blocked-sender check: a sender this node's user has blocked
-        // must not consume custody storage
+        // 6. Blocked-sender check.
         {
-            let sender_peer = PeerId::from_public_key(&sender_pub_key);
             let rs = state.get_router();
-            if let Some(user) = Users::get_user_snapshot(&rs, &QaulId::to_q8id(sender_peer)) {
+            if let Some(user) = Users::get_user_snapshot(&rs, &QaulId::to_q8id(inner_sender)) {
                 if user.blocked {
                     log::warn!(
-                        "DtnRoutedV2: rejecting message from blocked sender {}",
-                        sender_peer.to_base58()
+                        "DtnV2: rejecting message from blocked sender {}",
+                        inner_sender.to_base58()
                     );
-                    Self::send_v2_response(
+                    Self::send_response_v2(
                         state,
                         &user_account,
                         sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::UserNotAccepted,
+                        proto::dtn_response_v2::Kind::DropReport,
+                        proto::dtn_response_v2::ResponseType::Rejected,
+                        proto::dtn_response_v2::Reason::Blocked,
+                        &original_signature,
                     );
                     return;
                 }
             }
         }
 
-        // 6. Per-sender quota check
-        {
-            let v2 = match state.services.dtn.v2.read() {
-                Ok(s) => s,
-                Err(e) => {
-                    log::error!("DtnRoutedV2: failed to acquire read lock for quota check: {}", e);
-                    return;
-                }
-            };
-            if let Ok(Some(quota_bytes)) = v2
-                .db_ref_sender_quotas
-                .get(&routed_v2.sender_public_key)
-            {
-                if let Ok(quota) = bincode::deserialize::<SenderQuotaEntry>(&quota_bytes) {
-                    if quota.used_bytes + (routed_v2.container.len() as u64) > V2_PER_SENDER_QUOTA {
-                        log::warn!("DtnRoutedV2: per-sender quota exceeded");
-                        drop(v2);
-                        Self::send_v2_response(
-                            state,
-                            &user_account,
-                            sender_id,
-                            &routed_v2.original_signature,
-                            proto::dtn_response::ResponseType::Rejected,
-                            proto::dtn_response::Reason::UserQuota,
-                        );
-                        return;
-                    }
-                }
-            }
-        }
+        let payload_size = container.envelope.len() as u64;
+        let receiver_bytes = envelope_receiver
+            .as_ref()
+            .map(|r| r.to_bytes())
+            .unwrap_or_default();
 
-        // 7. Overall quota check
-        {
-            let v2 = match state.services.dtn.v2.read() {
-                Ok(s) => s,
-                Err(e) => {
-                    log::error!("DtnRoutedV2: failed to acquire read lock for overall quota: {}", e);
-                    return;
-                }
-            };
-            let v1_state = match state.services.dtn.inner.read() {
-                Ok(s) => s,
-                Err(e) => {
-                    log::error!("DtnRoutedV2: failed to acquire V1 read lock: {}", e);
-                    return;
-                }
-            };
-            match Configuration::get_user(state, user_account.id.to_string()) {
-                Some(user_profile) => {
-                    let total_limit = (user_profile.storage.size_total as u64) * 1024 * 1024;
-                    let total_used =
-                        v1_state.used_size + v2.used_size + (routed_v2.container.len() as u64);
-                    if total_used > total_limit {
-                        log::warn!("DtnRoutedV2: overall quota exceeded");
-                        drop(v1_state);
-                        drop(v2);
-                        Self::send_v2_response(
+        // 7. Admission tier: grant → trusted contact → proof-of-work pool.
+        let is_trusted = {
+            let rs = state.get_router();
+            Users::get_user_snapshot(&rs, &QaulId::to_q8id(inner_sender))
+                .map(|u| u.verified)
+                .unwrap_or(false)
+        };
+        let grant_ok = match container.custody_grant.as_ref() {
+            Some(grant) => {
+                Self::verify_grant(grant, now)
+                    && grant.grantee == inner_sender_bytes
+                    && grant.recipient == receiver_bytes
+                    && payload_size <= grant.quota_bytes
+            }
+            None => false,
+        };
+
+        let (tier, per_sender_ceiling) = if grant_ok {
+            let ceiling = container
+                .custody_grant
+                .as_ref()
+                .map(|g| g.quota_bytes)
+                .unwrap_or(V2_TRUSTED_PER_SENDER_QUOTA);
+            (TIER_GRANT, ceiling)
+        } else if is_trusted {
+            (TIER_TRUSTED, V2_TRUSTED_PER_SENDER_QUOTA)
+        } else {
+            // Grant-less stranger: a proof-of-work stamp bound to THIS custodian
+            // is required. This gates the grant-less untrusted pool; without it
+            // a Sybil flood is free.
+            match container.pow.as_ref() {
+                Some(pow) if Self::verify_pow(pow, &original_signature, &user_id.to_bytes(), now) => {
+                    // Aggregate untrusted-pool cap — the real anti-flood bound.
+                    let pool_used = state
+                        .services
+                        .dtn
+                        .v2
+                        .read()
+                        .map(|v2| v2.untrusted_used)
+                        .unwrap_or(u64::MAX);
+                    if pool_used + payload_size > V2_UNTRUSTED_POOL_QUOTA {
+                        log::warn!("DtnV2: untrusted pool full, rejecting");
+                        Self::send_response_v2(
                             state,
                             &user_account,
                             sender_id,
-                            &routed_v2.original_signature,
-                            proto::dtn_response::ResponseType::Rejected,
-                            proto::dtn_response::Reason::OverallQuota,
+                            proto::dtn_response_v2::Kind::DropReport,
+                            proto::dtn_response_v2::ResponseType::Rejected,
+                            proto::dtn_response_v2::Reason::OverallQuota,
+                            &original_signature,
                         );
                         return;
                     }
+                    (TIER_UNTRUSTED, V2_UNTRUSTED_PER_SENDER_QUOTA)
+                }
+                Some(_) => {
+                    log::warn!("DtnV2: invalid proof-of-work, rejecting");
+                    Self::send_response_v2(
+                        state,
+                        &user_account,
+                        sender_id,
+                        proto::dtn_response_v2::Kind::DropReport,
+                        proto::dtn_response_v2::ResponseType::Rejected,
+                        proto::dtn_response_v2::Reason::NoGrant,
+                        &original_signature,
+                    );
+                    return;
                 }
                 None => {
-                    log::error!("DtnRoutedV2: user profile not found");
-                    drop(v1_state);
-                    drop(v2);
-                    Self::send_v2_response(
+                    log::warn!("DtnV2: grant-less deposit without proof-of-work, rejecting");
+                    Self::send_response_v2(
                         state,
                         &user_account,
                         sender_id,
-                        &routed_v2.original_signature,
-                        proto::dtn_response::ResponseType::Rejected,
-                        proto::dtn_response::Reason::UserNotAccepted,
+                        proto::dtn_response_v2::Kind::DropReport,
+                        proto::dtn_response_v2::ResponseType::Rejected,
+                        proto::dtn_response_v2::Reason::PowRequired,
+                        &original_signature,
+                    );
+                    return;
+                }
+            }
+        };
+
+        // 8. Per-sender quota against the tier ceiling.
+        {
+            let v2 = match state.services.dtn.v2.read() {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("DtnV2: read lock failed for quota: {}", e);
+                    return;
+                }
+            };
+            if let Ok(Some(quota_bytes)) = v2.db_ref_sender_quotas.get(&route.sender_public_key) {
+                if let Ok(quota) = bincode::deserialize::<SenderQuotaEntry>(&quota_bytes) {
+                    if quota.used_bytes + payload_size > per_sender_ceiling {
+                        drop(v2);
+                        log::warn!("DtnV2: per-sender quota exceeded");
+                        Self::send_response_v2(
+                            state,
+                            &user_account,
+                            sender_id,
+                            proto::dtn_response_v2::Kind::DropReport,
+                            proto::dtn_response_v2::ResponseType::Rejected,
+                            proto::dtn_response_v2::Reason::UserQuota,
+                            &original_signature,
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+
+        // 9. Overall node quota (V1 + V2).
+        {
+            let v2 = match state.services.dtn.v2.read() {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("DtnV2: read lock failed for overall quota: {}", e);
+                    return;
+                }
+            };
+            let v1 = match state.services.dtn.inner.read() {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("DtnV2: V1 read lock failed: {}", e);
+                    return;
+                }
+            };
+            if let Some(profile) = Configuration::get_user(state, user_account.id.to_string()) {
+                let total_limit = (profile.storage.size_total as u64) * 1024 * 1024;
+                if v1.used_size + v2.used_size + payload_size > total_limit {
+                    drop(v1);
+                    drop(v2);
+                    log::warn!("DtnV2: overall quota exceeded");
+                    Self::send_response_v2(
+                        state,
+                        &user_account,
+                        sender_id,
+                        proto::dtn_response_v2::Kind::DropReport,
+                        proto::dtn_response_v2::ResponseType::Rejected,
+                        proto::dtn_response_v2::Reason::OverallQuota,
+                        &original_signature,
                     );
                     return;
                 }
             }
         }
 
-        // 8. Accept custody: store in DB
-        let entry_size = routed_v2.container.len() as u32;
+        // 10. Accept custody: store the entry and update accounting.
+        let entry_size = payload_size as u32;
         let v2_entry = DtnRoutedV2Entry {
-            routed_v2_bytes: routed_v2.encode_to_vec(),
-            sender_public_key: routed_v2.sender_public_key.clone(),
+            container_v2_bytes: container.encode_to_vec(),
+            sender_public_key: route.sender_public_key.clone(),
             size: entry_size,
-            accepted_at: Timestamp::get_timestamp(),
-            receiver_id: envelope_receiver.map(|r| r.to_bytes()).unwrap_or_default(),
+            accepted_at: now,
+            receiver_id: receiver_bytes,
+            tier,
         };
         let entry_bytes = match bincode::serialize(&v2_entry) {
-            Ok(bytes) => bytes,
+            Ok(b) => b,
             Err(e) => {
-                log::error!("DtnRoutedV2: failed to serialize entry: {}", e);
+                log::error!("DtnV2: failed to serialize entry: {}", e);
                 return;
             }
         };
-
         {
             let mut v2 = match state.services.dtn.v2.write() {
                 Ok(s) => s,
                 Err(e) => {
-                    log::error!("DtnRoutedV2: failed to acquire write lock: {}", e);
+                    log::error!("DtnV2: write lock failed: {}", e);
                     return;
                 }
             };
             if let Err(e) = v2
                 .db_ref_routed_v2
-                .insert(routed_v2.original_signature.clone(), entry_bytes)
+                .insert(original_signature.clone(), entry_bytes)
             {
-                log::error!("DtnRoutedV2: storage insert error: {}", e);
+                log::error!("DtnV2: storage insert error: {}", e);
+                return;
             }
             let _ = v2.db_ref_routed_v2.flush();
-
-            v2.used_size += entry_size as u64;
+            v2.used_size += payload_size;
             v2.message_count += 1;
-
-            // Update sender quota
-            let mut quota = if let Ok(Some(quota_bytes)) = v2
-                .db_ref_sender_quotas
-                .get(&routed_v2.sender_public_key)
+            if tier == TIER_UNTRUSTED {
+                v2.untrusted_used += payload_size;
+            }
+            let mut quota = if let Ok(Some(quota_bytes)) =
+                v2.db_ref_sender_quotas.get(&route.sender_public_key)
             {
                 bincode::deserialize::<SenderQuotaEntry>(&quota_bytes).unwrap_or_default()
             } else {
                 SenderQuotaEntry::default()
             };
-            quota.used_bytes += entry_size as u64;
+            quota.used_bytes += payload_size;
             quota.message_count += 1;
-            if let Ok(quota_bytes) = bincode::serialize(&quota) {
+            if let Ok(bytes) = bincode::serialize(&quota) {
                 let _ = v2
                     .db_ref_sender_quotas
-                    .insert(routed_v2.sender_public_key.clone(), quota_bytes);
-            } else {
-                log::error!("DtnRoutedV2: failed to serialize sender quota");
+                    .insert(route.sender_public_key.clone(), bytes);
             }
             let _ = v2.db_ref_sender_quotas.flush();
         }
 
-        // Send acceptance response
-        Self::send_v2_response(
+        // 11. Signed receipt to the previous holder, then immediate forward.
+        Self::send_response_v2(
             state,
             &user_account,
             sender_id,
-            &routed_v2.original_signature,
-            proto::dtn_response::ResponseType::Accepted,
-            proto::dtn_response::Reason::None,
+            proto::dtn_response_v2::Kind::Receipt,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            &original_signature,
         );
-
-        // 9. Attempt immediate forward
-        if let Some(recv_id) = envelope_receiver {
-            Self::try_forward_v2(state, &user_account, &routed_v2, &recv_id);
+        if let Some(recv) = envelope_receiver {
+            Self::try_forward_v2(state, &user_account, &container, &route, &recv);
         }
     }
 
-    /// Try to forward a V2 message to the next custodian or recipient
+    /// Try to forward a stored V2 message to the next reachable hop or the
+    /// recipient. The route is immutable, so forwarding re-sends the same
+    /// container unchanged.
     fn try_forward_v2(
         state: &crate::QaulState,
         user_account: &UserAccount,
-        routed_v2: &proto::DtnRoutedV2,
+        container: &proto::DtnV2Container,
+        route: &proto::DtnRoute,
         receiver_id: &PeerId,
     ) {
-        if let Some(target) = Self::select_custody_target(state, routed_v2, receiver_id) {
-            let mut forwarded = routed_v2.clone();
-            forwarded.remaining_handoffs = forwarded.remaining_handoffs.saturating_sub(1);
-
-            // Advance next_route_index past the target
-            for (i, user_bytes) in forwarded.custody_route.iter().enumerate() {
-                if let Ok(uid) = PeerId::from_bytes(user_bytes) {
-                    if uid == target && i as u32 >= forwarded.next_route_index {
-                        forwarded.next_route_index = (i as u32) + 1;
-                        break;
-                    }
-                }
-            }
-
-            if let Err(e) = super::messaging::Messaging::send_dtn_routed_v2_message(
+        if let Some(target) =
+            Self::select_custody_target(state, route, &user_account.id, receiver_id)
+        {
+            if let Err(e) = super::messaging::Messaging::send_dtn_v2_message(
                 state,
                 user_account,
                 &target,
-                forwarded,
+                container.clone(),
             ) {
-                log::error!("DtnRoutedV2: forward error: {}", e);
+                log::error!("DtnV2: forward error: {}", e);
             }
         }
     }
 
-    /// Send a DTN response message for V2 handling
-    fn send_v2_response(
-        state: &crate::QaulState,
-        user_account: &UserAccount,
-        sender_id: &PeerId,
-        signature: &[u8],
-        response_type: proto::dtn_response::ResponseType,
-        reason: proto::dtn_response::Reason,
-    ) {
-        let dtn_response = proto::DtnResponse {
-            response_type: response_type as i32,
-            reason: reason as i32,
-            signature: signature.to_vec(),
-        };
-        let send_message = proto::Messaging {
-            message: Some(proto::messaging::Message::DtnResponse(dtn_response)),
-        };
-        if let Err(e) = super::messaging::Messaging::pack_and_send_message(
-            state,
-            user_account,
-            sender_id,
-            send_message.encode_to_vec(),
-            MessagingServiceType::DtnStored,
-            &Vec::new(),
-            false,
-        ) {
-            log::error!("DtnRoutedV2: send response error: {}", e);
-        }
-    }
-
-    /// Stateless checks for an incoming DtnRoutedV2 message.
+    /// Stateless checks for an incoming DtnV2Container.
     ///
-    /// Order matters: the recipient check runs before the handoff check —
-    /// a message that has used up all its custody handoffs must still be
-    /// delivered when it arrives at its final recipient, because delivery
-    /// is not a handoff.
+    /// The recipient check runs before anything else that could drop the
+    /// message: a message that reaches its final recipient must be delivered
+    /// even if it would otherwise be past policy.
     fn precheck_routed_v2(
-        routed_v2: &proto::DtnRoutedV2,
+        route: &proto::DtnRoute,
         envelope_receiver: Option<&PeerId>,
         my_id: &PeerId,
         now: u64,
     ) -> V2Precheck {
-        if routed_v2.expires_at > 0 && now > routed_v2.expires_at {
-            return V2Precheck::Expired;
-        }
         if envelope_receiver == Some(my_id) {
             return V2Precheck::Deliver;
         }
-        if routed_v2.remaining_handoffs == 0 {
-            return V2Precheck::Exhausted;
+        if let Some(expires_at) = route.expires_at {
+            if expires_at > 0 && now > expires_at {
+                return V2Precheck::Expired;
+            }
         }
         V2Precheck::Continue
     }
 
-    /// Extract the receiver PeerId from a serialized Container
+    /// Extract the receiver PeerId from a serialized inner Container.
     fn get_receiver_from_container(container_bytes: &[u8]) -> Option<PeerId> {
         if let Ok(container) = proto::Container::decode(container_bytes) {
             if let Some(envelope) = container.envelope {
@@ -1538,130 +2025,134 @@ impl Dtn {
         None
     }
 
-    /// Handle DTN response for V2 messages
-    pub fn on_dtn_response_v2(state: &crate::QaulState, dtn_response: &proto::DtnResponse) {
-        let mut v2 = match state.services.dtn.v2.write() {
-            Ok(s) => s,
-            Err(e) => {
-                log::error!("DtnRoutedV2: failed to acquire write lock for response: {}", e);
+    /// Handle a signed DtnResponseV2.
+    ///
+    /// The signature is verified against the responder's embedded key BEFORE
+    /// any state change — this is the fix for the old unauthenticated ACK,
+    /// where any peer could forge a response and free (or falsely confirm)
+    /// custody storage. Only a validly-signed response mutates the store.
+    pub fn on_dtn_response_v2(state: &crate::QaulState, resp: &proto::DtnResponseV2) {
+        let responder_id = match Self::verify_response_v2(resp) {
+            Some(id) => id,
+            None => {
+                log::warn!("DtnV2: dropping response with invalid signature");
                 return;
             }
         };
-        if let Ok(Some(entry_bytes)) = v2
-            .db_ref_routed_v2
-            .get(&dtn_response.signature)
-        {
-            if let Ok(entry) = bincode::deserialize::<DtnRoutedV2Entry>(&entry_bytes) {
-                // Only remove on acceptance
-                if dtn_response.response_type
-                    == proto::dtn_response::ResponseType::Accepted as i32
+
+        let kind = proto::dtn_response_v2::Kind::try_from(resp.kind)
+            .unwrap_or(proto::dtn_response_v2::Kind::Receipt);
+        let accepted =
+            resp.response_type == proto::dtn_response_v2::ResponseType::Accepted as i32;
+
+        match kind {
+            proto::dtn_response_v2::Kind::Delivery
+            | proto::dtn_response_v2::Kind::CustodyRelease
+                if accepted =>
+            {
+                let mut v2 = match state.services.dtn.v2.write() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::error!("DtnV2: write lock failed for response: {}", e);
+                        return;
+                    }
+                };
+                let entry_bytes = match v2.db_ref_routed_v2.get(&resp.original_signature) {
+                    Ok(Some(b)) => b,
+                    _ => return,
+                };
+                let entry = match bincode::deserialize::<DtnRoutedV2Entry>(&entry_bytes) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        log::error!("DtnV2: response entry deserialize: {}", e);
+                        return;
+                    }
+                };
+                // A DELIVERY ack is authoritative only from the real receiver.
+                if kind == proto::dtn_response_v2::Kind::Delivery
+                    && !entry.receiver_id.is_empty()
+                    && responder_id != entry.receiver_id
                 {
-                    // Remove from V2 storage
-                    let _ = v2.db_ref_routed_v2.remove(&dtn_response.signature);
-                    let _ = v2.db_ref_routed_v2.flush();
-
-                    // Update counts
-                    v2.used_size = v2.used_size.saturating_sub(entry.size as u64);
-                    if v2.message_count > 0 {
-                        v2.message_count -= 1;
-                    }
-
-                    // Update sender quota
-                    if let Ok(Some(quota_bytes)) =
-                        v2.db_ref_sender_quotas.get(&entry.sender_public_key)
-                    {
-                        if let Ok(mut quota) =
-                            bincode::deserialize::<SenderQuotaEntry>(&quota_bytes)
-                        {
-                            quota.used_bytes = quota.used_bytes.saturating_sub(entry.size as u64);
-                            quota.message_count = quota.message_count.saturating_sub(1);
-                            if let Ok(quota_bytes) = bincode::serialize(&quota) {
-                                let _ = v2
-                                    .db_ref_sender_quotas
-                                    .insert(entry.sender_public_key.clone(), quota_bytes);
-                                let _ = v2.db_ref_sender_quotas.flush();
-                            }
-                        }
-                    }
+                    log::warn!("DtnV2: DELIVERY ack responder is not the receiver, ignoring");
+                    return;
                 }
+                Self::free_entry(&mut v2, &entry);
+                let _ = v2.db_ref_routed_v2.remove(&resp.original_signature);
+                let _ = v2.db_ref_routed_v2.flush();
+                let _ = v2.db_ref_sender_quotas.flush();
+            }
+            proto::dtn_response_v2::Kind::DropReport => {
+                // A downstream custodian dropped the message. This is the
+                // origin sender's cue to re-route; we do not delete our own
+                // custody copy on someone else's drop.
+                log::info!("DtnV2: received DROP_REPORT (reason {})", resp.reason);
+            }
+            _ => {
+                // RECEIPT (or a non-accepted DELIVERY/RELEASE): custody stays
+                // held until an authoritative delivery/release arrives.
+                log::debug!("DtnV2: response kind {} noted", resp.kind);
             }
         }
     }
 
-    /// Process V2 routed messages in the retransmit loop.
-    /// Called periodically to check if stored V2 messages can be forwarded.
+    /// Periodic retention sweep + re-forward for stored V2 custody messages.
     pub fn process_retransmit_v2(state: &crate::QaulState) {
-        let v2 = match state.services.dtn.v2.read() {
-            Ok(s) => s,
-            Err(e) => {
-                log::error!("DtnRoutedV2: failed to acquire read lock for retransmit: {}", e);
-                return;
-            }
-        };
         let now = Timestamp::get_timestamp();
-
         let mut to_remove: Vec<Vec<u8>> = Vec::new();
-        let mut to_forward: Vec<(Vec<u8>, DtnRoutedV2Entry)> = Vec::new();
+        let mut to_forward: Vec<DtnRoutedV2Entry> = Vec::new();
 
-        for entry in v2.db_ref_routed_v2.iter() {
-            if let Ok((sig, entry_bytes)) = entry {
-                if let Ok(v2_entry) = bincode::deserialize::<DtnRoutedV2Entry>(&entry_bytes) {
-                    if let Ok(routed_v2) =
-                        proto::DtnRoutedV2::decode(&v2_entry.routed_v2_bytes[..])
-                    {
-                        // Check expiry. Entries whose sender specified no
-                        // expiry (expires_at == 0) are still bounded by the
-                        // local maximum retention, counted from acceptance.
-                        let effective_expires_at = if routed_v2.expires_at > 0 {
-                            routed_v2.expires_at
-                        } else {
-                            v2_entry.accepted_at.saturating_add(V2_MAX_RETENTION_MS)
-                        };
-                        if now > effective_expires_at {
-                            to_remove.push(sig.to_vec());
-                            continue;
-                        }
-
-                        to_forward.push((sig.to_vec(), v2_entry));
-                    }
+        {
+            let v2 = match state.services.dtn.v2.read() {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("DtnV2: read lock failed for retransmit: {}", e);
+                    return;
                 }
+            };
+            for item in v2.db_ref_routed_v2.iter() {
+                let (sig, entry_bytes) = match item {
+                    Ok(kv) => kv,
+                    Err(_) => continue,
+                };
+                let v2_entry = match bincode::deserialize::<DtnRoutedV2Entry>(&entry_bytes) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                // Retention: an explicit sender expiry wins; otherwise a
+                // tier-dependent local cap counted from acceptance (untrusted
+                // entries are shed first / soonest).
+                let route_expiry = proto::DtnV2Container::decode(&v2_entry.container_v2_bytes[..])
+                    .ok()
+                    .and_then(|c| proto::DtnRoute::decode(&c.dtn_route[..]).ok())
+                    .and_then(|r| r.expires_at)
+                    .filter(|e| *e > 0);
+                let retention_ms = if v2_entry.tier == TIER_UNTRUSTED {
+                    V2_MAX_RETENTION_MS
+                } else {
+                    V2_TRUSTED_RETENTION_MS
+                };
+                let effective_expires_at =
+                    route_expiry.unwrap_or_else(|| v2_entry.accepted_at.saturating_add(retention_ms));
+                if now > effective_expires_at {
+                    to_remove.push(sig.to_vec());
+                    continue;
+                }
+                to_forward.push(v2_entry);
             }
         }
-        drop(v2);
 
-        // Remove expired entries
         if !to_remove.is_empty() {
             let mut v2 = match state.services.dtn.v2.write() {
                 Ok(s) => s,
                 Err(e) => {
-                    log::error!("DtnRoutedV2: failed to acquire write lock for cleanup: {}", e);
+                    log::error!("DtnV2: write lock failed for cleanup: {}", e);
                     return;
                 }
             };
             for sig in &to_remove {
                 if let Ok(Some(entry_bytes)) = v2.db_ref_routed_v2.get(sig) {
                     if let Ok(entry) = bincode::deserialize::<DtnRoutedV2Entry>(&entry_bytes) {
-                        v2.used_size = v2.used_size.saturating_sub(entry.size as u64);
-                        if v2.message_count > 0 {
-                            v2.message_count -= 1;
-                        }
-                        // Update sender quota
-                        if let Ok(Some(quota_bytes)) =
-                            v2.db_ref_sender_quotas.get(&entry.sender_public_key)
-                        {
-                            if let Ok(mut quota) =
-                                bincode::deserialize::<SenderQuotaEntry>(&quota_bytes)
-                            {
-                                quota.used_bytes =
-                                    quota.used_bytes.saturating_sub(entry.size as u64);
-                                quota.message_count = quota.message_count.saturating_sub(1);
-                                if let Ok(quota_bytes) = bincode::serialize(&quota) {
-                                    let _ = v2
-                                        .db_ref_sender_quotas
-                                        .insert(entry.sender_public_key.clone(), quota_bytes);
-                                }
-                            }
-                        }
+                        Self::free_entry(&mut v2, &entry);
                     }
                 }
                 let _ = v2.db_ref_routed_v2.remove(sig);
@@ -1670,14 +2161,18 @@ impl Dtn {
             let _ = v2.db_ref_sender_quotas.flush();
         }
 
-        // Try to forward stored messages
-        for (_sig, v2_entry) in &to_forward {
-            if let Ok(routed_v2) = proto::DtnRoutedV2::decode(&v2_entry.routed_v2_bytes[..]) {
-                if let Ok(recv_id) = PeerId::from_bytes(&v2_entry.receiver_id) {
-                    // We need a user account to send from. Use the first local account.
-                    if let Some(user_account) = UserAccounts::get_default_user(state) {
-                        Self::try_forward_v2(state, &user_account, &routed_v2, &recv_id);
-                    }
+        for v2_entry in &to_forward {
+            let container = match proto::DtnV2Container::decode(&v2_entry.container_v2_bytes[..]) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let route = match proto::DtnRoute::decode(&container.dtn_route[..]) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            if let Ok(recv_id) = PeerId::from_bytes(&v2_entry.receiver_id) {
+                if let Some(user_account) = UserAccounts::get_default_user(state) {
+                    Self::try_forward_v2(state, &user_account, &container, &route, &recv_id);
                 }
             }
         }
@@ -1694,10 +2189,10 @@ mod tests {
     use prost::Message;
     use std::collections::HashMap;
 
-    // A delivered DTN message must FREE the storage it occupied (the
-    // accounting previously *added* the size, so used_size grew without
-    // bound until the custodian rejected everything as over-quota), and
-    // both index trees must be cleared together (atomic removal).
+    // ── V1 response accounting (unchanged behaviour, must keep passing) ──
+
+    // A delivered DTN message must FREE the storage it occupied and clear both
+    // index trees together (atomic removal).
     #[test]
     fn dtn_response_frees_storage_and_clears_both_trees() {
         let dtn = DtnModuleState::new();
@@ -1707,8 +2202,6 @@ mod tests {
             org_sig: org_sig.clone(),
             size: 500,
         };
-
-        // simulate one stored message occupying 500 bytes
         {
             let st = dtn.inner.write().unwrap();
             st.db_ref
@@ -1723,8 +2216,6 @@ mod tests {
             st.used_size = 500;
             st.message_counts = 1;
         }
-
-        // delivery confirmation for that message
         let resp = proto::DtnResponse {
             signature: sig.clone(),
             ..Default::default()
@@ -1734,18 +2225,10 @@ mod tests {
         let st = dtn.inner.read().unwrap();
         assert_eq!(st.used_size, 0, "delivered message must free its storage");
         assert_eq!(st.message_counts, 0);
-        assert!(
-            !st.db_ref.contains_key(sig.as_slice()).unwrap(),
-            "entry removed from db_ref"
-        );
-        assert!(
-            !st.db_ref_id.contains_key(org_sig.as_slice()).unwrap(),
-            "entry removed from db_ref_id (atomic with db_ref)"
-        );
+        assert!(!st.db_ref.contains_key(sig.as_slice()).unwrap());
+        assert!(!st.db_ref_id.contains_key(org_sig.as_slice()).unwrap());
     }
 
-    // An unknown / already-delivered signature is a harmless no-op
-    // (never a panic), even on a corrupted row.
     #[test]
     fn dtn_response_unknown_signature_is_noop() {
         let dtn = DtnModuleState::new();
@@ -1757,10 +2240,21 @@ mod tests {
         assert_eq!(dtn.inner.read().unwrap().used_size, 0);
     }
 
-    /// Create a random PeerId from a fresh Ed25519 keypair.
+    // ── Helpers ──
+
     fn random_peer() -> PeerId {
-        let keys = Keypair::generate_ed25519();
-        PeerId::from(keys.public())
+        PeerId::from(Keypair::generate_ed25519().public())
+    }
+
+    fn account_from(keys: Keypair) -> UserAccount {
+        let id = PeerId::from(keys.public());
+        UserAccount {
+            id,
+            keys,
+            name: "u".to_string(),
+            password_hash: None,
+            password_salt: None,
+        }
     }
 
     /// Make a user appear "online" by inserting a routing entry.
@@ -1787,627 +2281,75 @@ mod tests {
         );
     }
 
-    /// Build a DtnRoutedV2 with the given custody route and next_route_index.
-    fn build_routed_v2(custody_route: Vec<Vec<u8>>, next_route_index: u32) -> proto::DtnRoutedV2 {
-        proto::DtnRoutedV2 {
-            container: vec![1, 2, 3],
-            custody_route,
-            next_route_index,
-            original_signature: vec![0xAA],
-            sender_public_key: vec![0xBB],
-            expires_at: 0,
-            remaining_handoffs: 10,
-        }
-    }
-
-    // ── Serialization tests ──
-
-    #[test]
-    fn dtn_routed_v2_round_trip() {
-        let original = proto::DtnRoutedV2 {
-            container: vec![10, 20, 30, 40],
-            custody_route: vec![vec![1, 2, 3], vec![4, 5, 6]],
-            next_route_index: 0,
-            original_signature: vec![0xAA, 0xBB],
-            sender_public_key: vec![0xCC, 0xDD],
-            expires_at: 1234567890,
-            remaining_handoffs: 5,
-        };
-
-        let encoded = original.encode_to_vec();
-        assert!(!encoded.is_empty());
-
-        let decoded = proto::DtnRoutedV2::decode(&encoded[..]).unwrap();
-        assert_eq!(decoded.container, original.container);
-        assert_eq!(decoded.custody_route.len(), 2);
-        assert_eq!(decoded.custody_route[0], vec![1, 2, 3]);
-        assert_eq!(decoded.custody_route[1], vec![4, 5, 6]);
-        assert_eq!(decoded.next_route_index, 0);
-        assert_eq!(decoded.original_signature, original.original_signature);
-        assert_eq!(decoded.sender_public_key, original.sender_public_key);
-        assert_eq!(decoded.expires_at, original.expires_at);
-        assert_eq!(decoded.remaining_handoffs, original.remaining_handoffs);
-    }
-
-    #[test]
-    fn dtn_routed_v2_serde_round_trip() {
-        let original = proto::DtnRoutedV2 {
-            container: vec![10, 20],
-            custody_route: vec![vec![1, 2, 3]],
-            next_route_index: 1,
-            original_signature: vec![0xAA],
-            sender_public_key: vec![0xCC],
-            expires_at: 0,
-            remaining_handoffs: 3,
-        };
-
-        let serialized = bincode::serialize(&original).unwrap();
-        let deserialized: proto::DtnRoutedV2 = bincode::deserialize(&serialized).unwrap();
-        assert_eq!(deserialized.container, original.container);
-        assert_eq!(deserialized.remaining_handoffs, 3);
-    }
-
-    #[test]
-    fn dtn_routed_v2_entry_serde_round_trip() {
-        let entry = DtnRoutedV2Entry {
-            routed_v2_bytes: vec![1, 2, 3, 4],
-            sender_public_key: vec![5, 6],
-            size: 100,
-            accepted_at: 999,
-            receiver_id: vec![7, 8, 9],
-        };
-
-        let serialized = bincode::serialize(&entry).unwrap();
-        let deserialized: DtnRoutedV2Entry = bincode::deserialize(&serialized).unwrap();
-        assert_eq!(deserialized.routed_v2_bytes, entry.routed_v2_bytes);
-        assert_eq!(deserialized.size, 100);
-        assert_eq!(deserialized.accepted_at, 999);
-    }
-
-    #[test]
-    fn sender_quota_entry_serde_round_trip() {
-        let entry = SenderQuotaEntry {
-            used_bytes: 5000,
-            message_count: 3,
-        };
-
-        let serialized = bincode::serialize(&entry).unwrap();
-        let deserialized: SenderQuotaEntry = bincode::deserialize(&serialized).unwrap();
-        assert_eq!(deserialized.used_bytes, 5000);
-        assert_eq!(deserialized.message_count, 3);
-    }
-
-    #[test]
-    fn envelop_payload_dtn_routed_v2_variant() {
-        let routed_v2 = proto::DtnRoutedV2 {
-            container: vec![1, 2, 3],
-            custody_route: vec![],
-            next_route_index: 0,
-            original_signature: vec![],
-            sender_public_key: vec![],
-            expires_at: 0,
-            remaining_handoffs: 1,
-        };
-
-        let payload = proto::EnvelopPayload {
-            payload: Some(proto::envelop_payload::Payload::DtnRoutedV2(routed_v2)),
-        };
-
-        let encoded = payload.encode_to_vec();
-        let decoded = proto::EnvelopPayload::decode(&encoded[..]).unwrap();
-
-        match decoded.payload {
-            Some(proto::envelop_payload::Payload::DtnRoutedV2(v2)) => {
-                assert_eq!(v2.container, vec![1, 2, 3]);
-                assert_eq!(v2.remaining_handoffs, 1);
-            }
-            _ => panic!("Expected DtnRoutedV2 payload variant"),
-        }
-    }
-
-    // ── select_custody_target tests ──
-    //
-    // Each test gets its own isolated `QaulState` (via `new_for_simulation()`),
-    // so there is no shared global routing table to serialize against.
-
-    #[test]
-    fn select_target_returns_recipient_when_online() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-        let recipient = random_peer();
-        let custodian = random_peer();
-
-        let mut table = HashMap::new();
-        make_online(&mut table, recipient);
-        // custodian is NOT online
-        qaul_state
-            .get_router()
-            .routing_table
-            .set(crate::router::table::RoutingTable { table });
-
-        let v2 = build_routed_v2(vec![custodian.to_bytes()], 0);
-
-        let target = Dtn::select_custody_target(&qaul_state, &v2, &recipient);
-        assert_eq!(target, Some(recipient));
-    }
-
-    #[test]
-    fn select_target_returns_first_reachable_custodian() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-        let recipient = random_peer();
-        let c1 = random_peer();
-        let c2 = random_peer();
-
-        let mut table = HashMap::new();
-        // recipient offline, c1 offline, c2 online
-        make_online(&mut table, c2);
-        qaul_state
-            .get_router()
-            .routing_table
-            .set(crate::router::table::RoutingTable { table });
-
-        let v2 = build_routed_v2(vec![c1.to_bytes(), c2.to_bytes()], 0);
-
-        let target = Dtn::select_custody_target(&qaul_state, &v2, &recipient);
-        assert_eq!(target, Some(c2));
-    }
-
-    #[test]
-    fn select_target_returns_none_when_nobody_online() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-        let recipient = random_peer();
-        let c1 = random_peer();
-        let c2 = random_peer();
-
-        // Empty routing table — nobody online
-        qaul_state
-            .get_router()
-            .routing_table
-            .set(crate::router::table::RoutingTable {
-                table: HashMap::new(),
-            });
-
-        let v2 = build_routed_v2(vec![c1.to_bytes(), c2.to_bytes()], 0);
-
-        let target = Dtn::select_custody_target(&qaul_state, &v2, &recipient);
-        assert_eq!(target, None);
-    }
-
-    #[test]
-    fn select_target_respects_next_route_index() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-        let recipient = random_peer();
-        let c1 = random_peer();
-        let c2 = random_peer();
-
-        let mut table = HashMap::new();
-        // Both custodians online
-        make_online(&mut table, c1);
-        make_online(&mut table, c2);
-        qaul_state
-            .get_router()
-            .routing_table
-            .set(crate::router::table::RoutingTable { table });
-
-        // next_route_index = 1 means c1 (index 0) is already done, only c2 eligible
-        let v2 = build_routed_v2(vec![c1.to_bytes(), c2.to_bytes()], 1);
-
-        let target = Dtn::select_custody_target(&qaul_state, &v2, &recipient);
-        assert_eq!(target, Some(c2));
-    }
-
-    #[test]
-    fn select_target_skips_exhausted_route() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-        let recipient = random_peer();
-        let c1 = random_peer();
-
-        let mut table = HashMap::new();
-        make_online(&mut table, c1);
-        qaul_state
-            .get_router()
-            .routing_table
-            .set(crate::router::table::RoutingTable { table });
-
-        // next_route_index == len means the route is exhausted
-        let v2 = build_routed_v2(vec![c1.to_bytes()], 1);
-
-        let target = Dtn::select_custody_target(&qaul_state, &v2, &recipient);
-        assert_eq!(target, None);
-    }
-
-    #[test]
-    fn select_target_picks_first_reachable_in_forward_order() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-        let recipient = random_peer();
-        let c1 = random_peer(); // first in route
-        let c2 = random_peer(); // second in route
-
-        let mut table = HashMap::new();
-        // Both online
-        make_online(&mut table, c1);
-        make_online(&mut table, c2);
-        qaul_state
-            .get_router()
-            .routing_table
-            .set(crate::router::table::RoutingTable { table });
-
-        let v2 = build_routed_v2(vec![c1.to_bytes(), c2.to_bytes()], 0);
-
-        // Forward scan should pick c1 (index 0) as the first reachable
-        let target = Dtn::select_custody_target(&qaul_state, &v2, &recipient);
-        assert_eq!(target, Some(c1));
-    }
-
-    // ── Route advancement tests ──
-
-    #[test]
-    fn route_next_route_index_advances_on_forward() {
-        let c1 = random_peer();
-        let c2 = random_peer();
-        let target = c2;
-
-        let mut routed = proto::DtnRoutedV2 {
-            container: vec![],
-            custody_route: vec![c1.to_bytes(), c2.to_bytes()],
-            next_route_index: 0,
-            original_signature: vec![],
-            sender_public_key: vec![],
-            expires_at: 0,
-            remaining_handoffs: 5,
-        };
-
-        // Simulate what try_forward_v2 does to the route state
-        routed.remaining_handoffs = routed.remaining_handoffs.saturating_sub(1);
-        for (i, user_bytes) in routed.custody_route.iter().enumerate() {
-            if let Ok(uid) = PeerId::from_bytes(user_bytes) {
-                if uid == target && i as u32 >= routed.next_route_index {
-                    routed.next_route_index = (i as u32) + 1;
-                    break;
-                }
-            }
-        }
-
-        assert_eq!(routed.remaining_handoffs, 4);
-        assert_eq!(routed.next_route_index, 2); // c2 is at index 1, so next = 2
-    }
-
-    #[test]
-    fn route_next_route_index_advances_for_middle_custodian() {
-        let c1 = random_peer();
-        let c2 = random_peer();
-        let c3 = random_peer();
-        let target = c2;
-
-        let mut routed = proto::DtnRoutedV2 {
-            container: vec![],
-            custody_route: vec![c1.to_bytes(), c2.to_bytes(), c3.to_bytes()],
-            next_route_index: 0,
-            original_signature: vec![],
-            sender_public_key: vec![],
-            expires_at: 0,
-            remaining_handoffs: 5,
-        };
-
-        routed.remaining_handoffs = routed.remaining_handoffs.saturating_sub(1);
-        for (i, user_bytes) in routed.custody_route.iter().enumerate() {
-            if let Ok(uid) = PeerId::from_bytes(user_bytes) {
-                if uid == target && i as u32 >= routed.next_route_index {
-                    routed.next_route_index = (i as u32) + 1;
-                    break;
-                }
-            }
-        }
-
-        // c2 at index 1, next_route_index should advance to 2, leaving c3 still eligible
-        assert_eq!(routed.next_route_index, 2);
-    }
-
-    // ── V2 storage tests ──
-
-    #[test]
-    fn v2_storage_insert_and_retrieve() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-
-        let sig = vec![0x01, 0x02, 0x03];
-        let entry = DtnRoutedV2Entry {
-            routed_v2_bytes: vec![10, 20, 30],
-            sender_public_key: vec![0xAA],
-            size: 3,
-            accepted_at: 12345,
-            receiver_id: vec![0xBB],
-        };
-        let entry_bytes = bincode::serialize(&entry).unwrap();
-
-        {
-            let mut state = qaul_state.services.dtn.v2.write().unwrap();
-            state
-                .db_ref_routed_v2
-                .insert(sig.clone(), entry_bytes)
-                .unwrap();
-            state.db_ref_routed_v2.flush().unwrap();
-            state.used_size += entry.size as u64;
-            state.message_count += 1;
-        }
-
-        // Retrieve
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            assert!(state.db_ref_routed_v2.contains_key(&sig).unwrap());
-            let stored = state.db_ref_routed_v2.get(&sig).unwrap().unwrap();
-            let decoded: DtnRoutedV2Entry = bincode::deserialize(&stored).unwrap();
-            assert_eq!(decoded.routed_v2_bytes, vec![10, 20, 30]);
-            assert_eq!(decoded.size, 3);
-        }
-    }
-
-    #[test]
-    fn v2_storage_duplicate_detection() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-
-        let sig = vec![0xDE, 0xAD];
-        let entry = DtnRoutedV2Entry {
-            routed_v2_bytes: vec![1],
-            sender_public_key: vec![2],
-            size: 1,
-            accepted_at: 0,
-            receiver_id: vec![3],
-        };
-        let entry_bytes = bincode::serialize(&entry).unwrap();
-
-        {
-            let state = qaul_state.services.dtn.v2.write().unwrap();
-            state
-                .db_ref_routed_v2
-                .insert(sig.clone(), entry_bytes)
-                .unwrap();
-        }
-
-        // Should detect duplicate
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            assert!(state.db_ref_routed_v2.contains_key(&sig).unwrap());
-        }
-    }
-
-    #[test]
-    fn v2_sender_quota_tracking() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-
-        let sender_key = vec![0xCC, 0xDD];
-        let quota = SenderQuotaEntry {
-            used_bytes: 500,
-            message_count: 2,
-        };
-        let quota_bytes = bincode::serialize(&quota).unwrap();
-
-        {
-            let state = qaul_state.services.dtn.v2.write().unwrap();
-            state
-                .db_ref_sender_quotas
-                .insert(sender_key.clone(), quota_bytes)
-                .unwrap();
-        }
-
-        // Retrieve and check
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            let stored = state
-                .db_ref_sender_quotas
-                .get(&sender_key)
-                .unwrap()
-                .unwrap();
-            let decoded: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-            assert_eq!(decoded.used_bytes, 500);
-            assert_eq!(decoded.message_count, 2);
-        }
-
-        // Simulate removing a message — quota should decrease
-        {
-            let state = qaul_state.services.dtn.v2.write().unwrap();
-            let stored = state
-                .db_ref_sender_quotas
-                .get(&sender_key)
-                .unwrap()
-                .unwrap();
-            let mut decoded: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-            decoded.used_bytes = decoded.used_bytes.saturating_sub(200);
-            decoded.message_count = decoded.message_count.saturating_sub(1);
-            let updated = bincode::serialize(&decoded).unwrap();
-            state
-                .db_ref_sender_quotas
-                .insert(sender_key.clone(), updated)
-                .unwrap();
-        }
-
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            let stored = state
-                .db_ref_sender_quotas
-                .get(&sender_key)
-                .unwrap()
-                .unwrap();
-            let decoded: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-            assert_eq!(decoded.used_bytes, 300);
-            assert_eq!(decoded.message_count, 1);
-        }
-    }
-
-    #[test]
-    fn v2_per_sender_quota_limit_enforced() {
-        let qaul_state = crate::QaulState::new_for_simulation();
-
-        let sender_key = vec![0xEE, 0xFF];
-        // Set quota near the limit
-        let quota = SenderQuotaEntry {
-            used_bytes: V2_PER_SENDER_QUOTA - 10,
-            message_count: 100,
-        };
-        let quota_bytes = bincode::serialize(&quota).unwrap();
-
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            state
-                .db_ref_sender_quotas
-                .insert(sender_key.clone(), quota_bytes)
-                .unwrap();
-        }
-
-        // A message of size 11 should exceed the quota
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            let stored = state
-                .db_ref_sender_quotas
-                .get(&sender_key)
-                .unwrap()
-                .unwrap();
-            let decoded: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-            let new_msg_size: u64 = 11;
-            assert!(decoded.used_bytes + new_msg_size > V2_PER_SENDER_QUOTA);
-        }
-
-        // A message of size 5 should be under the quota
-        {
-            let state = qaul_state.services.dtn.v2.read().unwrap();
-            let stored = state
-                .db_ref_sender_quotas
-                .get(&sender_key)
-                .unwrap()
-                .unwrap();
-            let decoded: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-            let new_msg_size: u64 = 5;
-            assert!(decoded.used_bytes + new_msg_size <= V2_PER_SENDER_QUOTA);
-        }
-    }
-
-    // ── Signature verification tests ──
-
-    /// Helper: create a properly signed inner Container with a real keypair.
-    /// Returns (keypair, container_bytes, container_signature).
-    fn build_signed_container(receiver: &PeerId) -> (Keypair, Vec<u8>, Vec<u8>) {
-        let keys = Keypair::generate_ed25519();
-        let sender = PeerId::from(keys.public());
-
+    /// Sign an inner Container for `receiver_keys`. Returns
+    /// (sender_keys, container_bytes, original_signature).
+    fn signed_inner(receiver_keys: &Keypair) -> (Keypair, Vec<u8>, Vec<u8>) {
+        let sender_keys = Keypair::generate_ed25519();
+        let sender = PeerId::from(sender_keys.public());
+        let receiver = PeerId::from(receiver_keys.public());
         let envelope = proto::Envelope {
             sender_id: sender.to_bytes(),
             receiver_id: receiver.to_bytes(),
-            payload: vec![0xDE, 0xAD],
+            payload: vec![1, 2, 3],
         };
-
-        let mut envelope_buf = Vec::with_capacity(envelope.encoded_len());
-        envelope.encode(&mut envelope_buf).unwrap();
-
-        let signature = keys.sign(&envelope_buf).unwrap();
-
+        let mut buf = Vec::with_capacity(envelope.encoded_len());
+        envelope.encode(&mut buf).unwrap();
+        let signature = sender_keys.sign(&buf).unwrap();
         let container = proto::Container {
             signature: signature.clone(),
             envelope: Some(envelope),
         };
-
-        (keys, container.encode_to_vec(), signature)
+        (sender_keys, container.encode_to_vec(), signature)
     }
 
-    #[test]
-    fn signature_verification_accepts_valid_signature() {
-        let receiver = random_peer();
-        let (keys, container_bytes, _sig) = build_signed_container(&receiver);
-
-        // Decode the inner container
-        let inner = proto::Container::decode(&container_bytes[..]).unwrap();
-        let sender_key = keys.public();
-
-        // Re-encode envelope and verify
-        let envelope = inner.envelope.as_ref().unwrap();
-        let mut envelope_buf = Vec::with_capacity(envelope.encoded_len());
-        envelope.encode(&mut envelope_buf).unwrap();
-
-        assert!(sender_key.verify(&envelope_buf, &inner.signature));
-    }
-
-    #[test]
-    fn signature_verification_rejects_wrong_key() {
-        let receiver = random_peer();
-        let (_keys, container_bytes, _sig) = build_signed_container(&receiver);
-
-        // Use a different key to verify
-        let wrong_keys = Keypair::generate_ed25519();
-        let wrong_key = wrong_keys.public();
-
-        let inner = proto::Container::decode(&container_bytes[..]).unwrap();
-        let envelope = inner.envelope.as_ref().unwrap();
-        let mut envelope_buf = Vec::with_capacity(envelope.encoded_len());
-        envelope.encode(&mut envelope_buf).unwrap();
-
-        assert!(!wrong_key.verify(&envelope_buf, &inner.signature));
-    }
-
-    #[test]
-    fn signature_verification_rejects_tampered_envelope() {
-        let receiver = random_peer();
-        let (keys, container_bytes, _sig) = build_signed_container(&receiver);
-
-        let mut inner = proto::Container::decode(&container_bytes[..]).unwrap();
-        // Tamper with the envelope
-        inner.envelope.as_mut().unwrap().payload = vec![0xFF, 0xFF];
-
-        let sender_key = keys.public();
-        let envelope = inner.envelope.as_ref().unwrap();
-        let mut envelope_buf = Vec::with_capacity(envelope.encoded_len());
-        envelope.encode(&mut envelope_buf).unwrap();
-
-        // Original signature should not verify against tampered envelope
-        assert!(!sender_key.verify(&envelope_buf, &inner.signature));
-    }
-
-    #[test]
-    fn original_signature_extracted_from_inner_container() {
-        let receiver = random_peer();
-        let (_keys, container_bytes, expected_sig) = build_signed_container(&receiver);
-
-        // Simulate what rpc_send_routed does: decode Container to get signature
-        let inner = proto::Container::decode(&container_bytes[..]).unwrap();
-        assert_eq!(inner.signature, expected_sig);
-        assert!(!inner.signature.is_empty());
-    }
-
-    #[test]
-    fn public_key_protobuf_round_trip() {
-        let keys = Keypair::generate_ed25519();
-        let pub_key = keys.public();
-
-        // Encode to protobuf bytes (as stored in sender_public_key)
-        let encoded = pub_key.encode_protobuf();
-        assert!(!encoded.is_empty());
-
-        // Decode back
-        let decoded = libp2p::identity::PublicKey::try_decode_protobuf(&encoded).unwrap();
-        assert_eq!(decoded, pub_key);
-    }
-
-    // ── Release hardening: retention, quota rebuild, blocked senders ──
-
-    /// Unwrap a `Result` in a test with a panic message that names the step.
-    fn ok<T, E: std::fmt::Debug>(res: Result<T, E>, ctx: &str) -> T {
-        match res {
-            Ok(v) => v,
-            Err(e) => panic!("{}: {:?}", ctx, e),
+    /// Build a signed DtnV2Container around a signed inner container.
+    fn build_container_v2(
+        sender_keys: &Keypair,
+        container_bytes: Vec<u8>,
+        original_signature: Vec<u8>,
+        custodians: Vec<Vec<u8>>,
+        grant: Option<proto::CustodyGrant>,
+        pow: Option<proto::PowStamp>,
+        expires_at: Option<u64>,
+    ) -> proto::DtnV2Container {
+        let route = Dtn::build_route(
+            original_signature,
+            &custodians,
+            sender_keys.public().encode_protobuf(),
+            expires_at,
+        );
+        let route_bytes = route.encode_to_vec();
+        let sig = sender_keys.sign(&route_bytes).unwrap();
+        proto::DtnV2Container {
+            dtn_route: route_bytes,
+            dtn_route_sig: sig,
+            envelope: container_bytes,
+            custody_grant: grant,
+            pow,
         }
     }
 
-    /// Build a simulation state with one local account whose profile has
-    /// DTN V2 custody enabled. Bypasses `UserAccounts::create` because that
-    /// calls `Configuration::save`, which would write a config.yaml into
-    /// the test runner's working directory.
+    /// A recipient-signed custody grant for `grantee`.
+    fn make_grant(receiver_keys: &Keypair, grantee: Vec<u8>, quota: u64, not_after: u64) -> proto::CustodyGrant {
+        let recipient = PeerId::from(receiver_keys.public());
+        let mut grant = proto::CustodyGrant {
+            grantee,
+            recipient: recipient.to_bytes(),
+            recipient_public_key: receiver_keys.public().encode_protobuf(),
+            quota_bytes: quota,
+            epoch: 1,
+            not_after,
+            signature: Vec::new(),
+        };
+        grant.signature = receiver_keys.sign(&grant.encode_to_vec()).unwrap();
+        grant
+    }
+
+    /// Simulation state with one local account whose profile has V2 custody
+    /// enabled. Returns (state, custodian_account).
     fn make_custody_state() -> (crate::QaulState, UserAccount) {
         let state = crate::QaulState::new_for_simulation();
-        let keys = Keypair::generate_ed25519();
-        let id = PeerId::from(keys.public());
-        let account = UserAccount {
-            id,
-            keys,
-            name: "custodian".to_string(),
-            password_hash: None,
-            password_salt: None,
-        };
+        let account = account_from(Keypair::generate_ed25519());
         match state.user_accounts.inner.write() {
             Ok(mut users) => users.users.push(account.clone()),
             Err(e) => panic!("user accounts lock poisoned: {}", e),
@@ -2416,7 +2358,7 @@ mod tests {
             Ok(mut cfg) => {
                 cfg.user_accounts
                     .push(crate::storage::configuration::UserAccount {
-                        id: id.to_string(),
+                        id: account.id.to_string(),
                         storage: crate::storage::configuration::StorageOptions {
                             dtn_v2_custody_enabled: true,
                             ..Default::default()
@@ -2429,332 +2371,535 @@ mod tests {
         (state, account)
     }
 
-    /// Build a fully valid DtnRoutedV2 around a signed container.
-    fn build_valid_routed_v2(
-        keys: &Keypair,
-        container_bytes: Vec<u8>,
-        signature: Vec<u8>,
-        expires_at: u64,
-    ) -> proto::DtnRoutedV2 {
-        proto::DtnRoutedV2 {
-            container: container_bytes,
-            custody_route: vec![random_peer().to_bytes()],
-            next_route_index: 0,
-            original_signature: signature,
-            sender_public_key: keys.public().encode_protobuf(),
-            expires_at,
-            remaining_handoffs: 5,
-        }
-    }
+    // ── Signed immutable route ──
 
-    /// Insert a V2 entry with its quota record, as acceptance does.
-    fn store_v2_entry(
-        state: &crate::QaulState,
-        sig: &[u8],
-        entry: &DtnRoutedV2Entry,
-    ) {
-        let mut v2 = ok(state.services.dtn.v2.write(), "v2 write lock");
-        let entry_bytes = ok(bincode::serialize(entry), "serialize entry");
-        ok(
-            v2.db_ref_routed_v2.insert(sig.to_vec(), entry_bytes),
-            "insert entry",
-        );
-        v2.used_size += entry.size as u64;
-        v2.message_count += 1;
-        let quota = SenderQuotaEntry {
-            used_bytes: entry.size as u64,
-            message_count: 1,
-        };
-        let quota_bytes = ok(bincode::serialize(&quota), "serialize quota");
-        ok(
-            v2.db_ref_sender_quotas
-                .insert(entry.sender_public_key.clone(), quota_bytes),
-            "insert quota",
-        );
-    }
-
-    /// Entries whose sender specified no expiry (expires_at == 0) must
-    /// still be swept once they exceed the local maximum retention.
-    /// Without the retention cap, a custodian that never reaches the
-    /// recipient stores such messages forever.
+    // The route is the integrity anchor: a valid sender signature must verify,
+    // and any tampering with the route bytes or a wrong key must be rejected —
+    // otherwise a custodian could rewrite the route undetected.
     #[test]
-    fn retransmit_sweeps_no_expiry_entries_after_max_retention() {
-        let (state, _account) = make_custody_state();
-        let now = Timestamp::get_timestamp();
-
-        // Stale entry: no expiry, accepted longer than max retention ago
-        let receiver = random_peer();
-        let (stale_keys, stale_container, stale_sig) = build_signed_container(&receiver);
-        let stale_v2 = build_valid_routed_v2(&stale_keys, stale_container, stale_sig.clone(), 0);
-        let stale_entry = DtnRoutedV2Entry {
-            routed_v2_bytes: stale_v2.encode_to_vec(),
-            sender_public_key: stale_v2.sender_public_key.clone(),
-            size: 100,
-            accepted_at: now.saturating_sub(V2_MAX_RETENTION_MS + 1_000),
-            receiver_id: receiver.to_bytes(),
-        };
-        store_v2_entry(&state, &stale_sig, &stale_entry);
-
-        // Fresh entry: no expiry, accepted just now — must survive
-        let (fresh_keys, fresh_container, fresh_sig) = build_signed_container(&receiver);
-        let fresh_v2 = build_valid_routed_v2(&fresh_keys, fresh_container, fresh_sig.clone(), 0);
-        let fresh_entry = DtnRoutedV2Entry {
-            routed_v2_bytes: fresh_v2.encode_to_vec(),
-            sender_public_key: fresh_v2.sender_public_key.clone(),
-            size: 40,
-            accepted_at: now,
-            receiver_id: receiver.to_bytes(),
-        };
-        store_v2_entry(&state, &fresh_sig, &fresh_entry);
-
-        Dtn::process_retransmit_v2(&state);
-
-        let v2 = ok(state.services.dtn.v2.read(), "v2 read lock");
-        assert!(
-            !ok(
-                v2.db_ref_routed_v2.contains_key(&stale_sig),
-                "contains stale"
-            ),
-            "no-expiry entry past max retention must be swept"
+    fn route_signature_verifies_and_rejects_tampering() {
+        let keys = Keypair::generate_ed25519();
+        let route = Dtn::build_route(
+            vec![0xAA],
+            &[random_peer().to_bytes()],
+            keys.public().encode_protobuf(),
+            None,
         );
-        assert!(
-            ok(
-                v2.db_ref_routed_v2.contains_key(&fresh_sig),
-                "contains fresh"
-            ),
-            "fresh no-expiry entry must survive the sweep"
-        );
-        assert_eq!(v2.message_count, 1);
-        assert_eq!(v2.used_size, 40);
+        let bytes = route.encode_to_vec();
+        let sig = keys.sign(&bytes).unwrap();
+        assert!(Dtn::verify_route_sig(&route, &bytes, &sig));
 
-        // The swept entry's sender quota must be released
-        let quota_bytes = ok(
-            v2.db_ref_sender_quotas.get(&stale_entry.sender_public_key),
-            "get stale quota",
-        );
-        if let Some(bytes) = quota_bytes {
-            let quota: SenderQuotaEntry =
-                ok(bincode::deserialize(&bytes), "decode stale quota");
-            assert_eq!(quota.used_bytes, 0);
-            assert_eq!(quota.message_count, 0);
-        }
+        // tampered bytes
+        let mut tampered = bytes.clone();
+        tampered[0] ^= 0xFF;
+        assert!(!Dtn::verify_route_sig(&route, &tampered, &sig));
+
+        // wrong signing key
+        let other = Keypair::generate_ed25519();
+        let wrong_sig = other.sign(&bytes).unwrap();
+        assert!(!Dtn::verify_route_sig(&route, &bytes, &wrong_sig));
     }
 
-    /// A crash between the entry insert and the quota update leaves
-    /// dtn-sender-quotas out of sync with dtn-routed-v2. Init must
-    /// rebuild the quotas from the entries so drift heals on restart.
+    // ── Custody grants ──
+
     #[test]
-    fn init_production_rebuilds_sender_quotas_from_entries() {
-        let db = ok(
-            sled::Config::new().temporary(true).open(),
-            "open temp sled db",
-        );
-        let entries_tree = ok(db.open_tree("dtn-routed-v2"), "open entries tree");
-        let quotas_tree = ok(db.open_tree("dtn-sender-quotas"), "open quotas tree");
-
-        let sender_a = vec![0xAA];
-        let sender_b = vec![0xBB];
-        let sender_c = vec![0xCC];
-
-        for (sig, sender, size) in [
-            (vec![0x01], &sender_a, 100u32),
-            (vec![0x02], &sender_a, 50),
-            (vec![0x03], &sender_b, 70),
-        ] {
-            let entry = DtnRoutedV2Entry {
-                routed_v2_bytes: vec![0; size as usize],
-                sender_public_key: sender.clone(),
-                size,
-                accepted_at: 1_000,
-                receiver_id: vec![],
-            };
-            let bytes = ok(bincode::serialize(&entry), "serialize entry");
-            ok(entries_tree.insert(sig, bytes), "insert entry");
-        }
-
-        // Drifted quota records: A wildly wrong, B missing, C stale
-        let wrong_a = SenderQuotaEntry {
-            used_bytes: 999_999,
-            message_count: 42,
-        };
-        ok(
-            quotas_tree.insert(
-                sender_a.clone(),
-                ok(bincode::serialize(&wrong_a), "serialize wrong quota"),
-            ),
-            "insert wrong quota",
-        );
-        let stale_c = SenderQuotaEntry {
-            used_bytes: 10,
-            message_count: 1,
-        };
-        ok(
-            quotas_tree.insert(
-                sender_c.clone(),
-                ok(bincode::serialize(&stale_c), "serialize stale quota"),
-            ),
-            "insert stale quota",
-        );
-
-        let module_state = DtnModuleState::new();
-        module_state.init_production(db);
-
-        let v2 = ok(module_state.v2.read(), "v2 read lock");
-        assert_eq!(v2.used_size, 220);
-        assert_eq!(v2.message_count, 3);
-
-        let quota_a: SenderQuotaEntry = match ok(
-            v2.db_ref_sender_quotas.get(&sender_a),
-            "get quota A",
-        ) {
-            Some(bytes) => ok(bincode::deserialize(&bytes), "decode quota A"),
-            None => panic!("quota for sender A missing after rebuild"),
-        };
-        assert_eq!(quota_a.used_bytes, 150);
-        assert_eq!(quota_a.message_count, 2);
-
-        let quota_b: SenderQuotaEntry = match ok(
-            v2.db_ref_sender_quotas.get(&sender_b),
-            "get quota B",
-        ) {
-            Some(bytes) => ok(bincode::deserialize(&bytes), "decode quota B"),
-            None => panic!("quota for sender B missing after rebuild"),
-        };
-        assert_eq!(quota_b.used_bytes, 70);
-        assert_eq!(quota_b.message_count, 1);
-
-        assert!(
-            ok(v2.db_ref_sender_quotas.get(&sender_c), "get quota C").is_none(),
-            "stale quota record for sender with no entries must be dropped"
-        );
+    fn grant_valid_verifies() {
+        let receiver_keys = Keypair::generate_ed25519();
+        let grantee = random_peer().to_bytes();
+        let grant = make_grant(&receiver_keys, grantee, 1024, 0);
+        assert!(Dtn::verify_grant(&grant, 1000));
     }
 
-    /// Register a remote user in the router users table.
-    fn register_user(state: &crate::QaulState, keys: &Keypair, blocked: bool) {
-        let rs = state.get_router();
-        crate::router::users::Users::add(
-            state,
-            &rs,
-            crate::router::users::User {
-                id: PeerId::from(keys.public()),
-                key: keys.public(),
-                name: "remote".to_string(),
-                verified: false,
-                blocked,
-                capabilities: 0,
-                bio: String::new(),
-                avatar: vec![],
-                version: 0,
-                updated_at: 0,
-                signed_profile_bytes: vec![],
-                signed_profile_signature: vec![],
-                preferred_custody_route: vec![],
-            },
-        );
-    }
-
-    /// A message that has consumed all custody handoffs must still be
-    /// delivered when it reaches its final recipient — delivery is not a
-    /// handoff. (Regression: the handoff check used to run before the
-    /// recipient check and rejected such messages even at the recipient.)
+    // A grant whose embedded key is not the named recipient is a forgery.
     #[test]
-    fn precheck_delivers_to_recipient_with_zero_handoffs() {
+    fn grant_rejects_mismatched_recipient_key() {
+        let receiver_keys = Keypair::generate_ed25519();
+        let mut grant = make_grant(&receiver_keys, random_peer().to_bytes(), 1024, 0);
+        // Replace the recipient id with someone else while keeping the key.
+        grant.recipient = random_peer().to_bytes();
+        assert!(!Dtn::verify_grant(&grant, 1000));
+    }
+
+    #[test]
+    fn grant_rejects_expired() {
+        let receiver_keys = Keypair::generate_ed25519();
+        let grant = make_grant(&receiver_keys, random_peer().to_bytes(), 1024, 500);
+        assert!(!Dtn::verify_grant(&grant, 1000), "grant past not_after must fail");
+        assert!(Dtn::verify_grant(&grant, 400), "grant before not_after must pass");
+    }
+
+    #[test]
+    fn grant_rejects_tampered_signature() {
+        let receiver_keys = Keypair::generate_ed25519();
+        let mut grant = make_grant(&receiver_keys, random_peer().to_bytes(), 1024, 0);
+        grant.quota_bytes = 999_999; // change a signed field after signing
+        assert!(!Dtn::verify_grant(&grant, 1000));
+    }
+
+    // ── Proof of work ──
+
+    #[test]
+    fn pow_solve_then_verify() {
+        let sig = vec![7u8; 32];
+        let custodian = random_peer().to_bytes();
+        let day = 20_000u64;
+        let stamp = Dtn::solve_pow(&sig, &custodian, day, V2_MIN_POW_DIFFICULTY);
+        let now = day * MS_PER_DAY + 5;
+        assert!(Dtn::verify_pow(&stamp, &sig, &custodian, now));
+    }
+
+    // A stamp below the minimum difficulty is rejected regardless of its hash.
+    #[test]
+    fn pow_rejects_below_min_difficulty() {
+        let sig = vec![7u8; 32];
+        let custodian = random_peer().to_bytes();
+        let day = 20_000u64;
+        let mut stamp = Dtn::solve_pow(&sig, &custodian, day, V2_MIN_POW_DIFFICULTY);
+        stamp.difficulty = V2_MIN_POW_DIFFICULTY - 1;
+        assert!(!Dtn::verify_pow(&stamp, &sig, &custodian, day * MS_PER_DAY));
+    }
+
+    // A stamp solved for one custodian cannot be replayed against another —
+    // this is what stops a single solved stamp fanning out across the mesh.
+    #[test]
+    fn pow_bound_to_custodian_and_day() {
+        let sig = vec![7u8; 32];
+        let custodian = random_peer().to_bytes();
+        let day = 20_000u64;
+        let stamp = Dtn::solve_pow(&sig, &custodian, day, V2_MIN_POW_DIFFICULTY);
+
+        let other_custodian = random_peer().to_bytes();
+        assert!(!Dtn::verify_pow(&stamp, &sig, &other_custodian, day * MS_PER_DAY));
+
+        // Two days later (outside the today/yesterday window) it is stale.
+        let much_later = (day + 2) * MS_PER_DAY;
+        assert!(!Dtn::verify_pow(&stamp, &sig, &custodian, much_later));
+    }
+
+    #[test]
+    fn leading_zero_bits_counts_msb_first() {
+        let mut h = [0u8; 32];
+        assert_eq!(Dtn::leading_zero_bits(&h), 256);
+        h[0] = 0b0001_0000;
+        assert_eq!(Dtn::leading_zero_bits(&h), 3);
+    }
+
+    // ── Signed responses ──
+
+    #[test]
+    fn signed_response_verifies_and_returns_responder() {
+        let account = account_from(Keypair::generate_ed25519());
+        let resp = Dtn::build_signed_response(
+            &account,
+            proto::dtn_response_v2::Kind::Delivery,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            vec![0xAB],
+        )
+        .expect("sign");
+        assert_eq!(Dtn::verify_response_v2(&resp), Some(account.id.to_bytes()));
+    }
+
+    // A forged response signature must not verify — the guard that stops a
+    // malicious custodian from forging "delivered" and silencing the sender.
+    #[test]
+    fn forged_response_signature_is_rejected() {
+        let account = account_from(Keypair::generate_ed25519());
+        let mut resp = Dtn::build_signed_response(
+            &account,
+            proto::dtn_response_v2::Kind::Delivery,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            vec![0xAB],
+        )
+        .expect("sign");
+        resp.signature[0] ^= 0xFF;
+        assert_eq!(Dtn::verify_response_v2(&resp), None);
+    }
+
+    // ── Prechecks ──
+
+    #[test]
+    fn precheck_delivers_to_recipient() {
         let me = random_peer();
-        let mut v2 = build_routed_v2(vec![random_peer().to_bytes()], 0);
-        v2.remaining_handoffs = 0;
+        let route = Dtn::build_route(vec![], &[], vec![], None);
         assert_eq!(
-            Dtn::precheck_routed_v2(&v2, Some(&me), &me, 1_000),
+            Dtn::precheck_routed_v2(&route, Some(&me), &me, 1000),
             V2Precheck::Deliver
         );
     }
 
-    /// At a custodian (not the recipient), an exhausted handoff budget
-    /// still rejects the message.
     #[test]
-    fn precheck_rejects_exhausted_handoffs_at_custodian() {
+    fn precheck_expired_when_past_expiry() {
         let me = random_peer();
-        let receiver = random_peer();
-        let mut v2 = build_routed_v2(vec![random_peer().to_bytes()], 0);
-        v2.remaining_handoffs = 0;
+        let other = random_peer();
+        let route = Dtn::build_route(vec![], &[], vec![], Some(500));
         assert_eq!(
-            Dtn::precheck_routed_v2(&v2, Some(&receiver), &me, 1_000),
-            V2Precheck::Exhausted
-        );
-    }
-
-    /// An expired message is rejected even at its final recipient.
-    #[test]
-    fn precheck_expiry_wins_over_delivery() {
-        let me = random_peer();
-        let mut v2 = build_routed_v2(vec![random_peer().to_bytes()], 0);
-        v2.expires_at = 500;
-        assert_eq!(
-            Dtn::precheck_routed_v2(&v2, Some(&me), &me, 1_000),
+            Dtn::precheck_routed_v2(&route, Some(&other), &me, 1000),
             V2Precheck::Expired
         );
     }
 
-    /// A custodian with handoff budget continues into the acceptance
-    /// pipeline.
     #[test]
-    fn precheck_continues_for_custodian_with_budget() {
+    fn precheck_continues_for_custodian() {
         let me = random_peer();
-        let receiver = random_peer();
-        let v2 = build_routed_v2(vec![random_peer().to_bytes()], 0);
+        let other = random_peer();
+        let route = Dtn::build_route(vec![], &[], vec![], None);
         assert_eq!(
-            Dtn::precheck_routed_v2(&v2, Some(&receiver), &me, 1_000),
+            Dtn::precheck_routed_v2(&route, Some(&other), &me, 1000),
             V2Precheck::Continue
         );
     }
 
-    /// A blocked sender must not be able to consume custody storage.
+    // ── Stateless traversal ──
+
     #[test]
-    fn net_routed_v2_rejects_blocked_sender() {
-        let (state, account) = make_custody_state();
-
-        let receiver = random_peer();
-        let (keys, container_bytes, signature) = build_signed_container(&receiver);
-        register_user(&state, &keys, true);
-
-        let routed_v2 = build_valid_routed_v2(&keys, container_bytes, signature.clone(), 0);
-        let sender_peer = PeerId::from(keys.public());
-        Dtn::net_routed_v2(&state, &account.id, &sender_peer, &[], routed_v2);
-
-        let v2 = ok(state.services.dtn.v2.read(), "v2 read lock");
-        assert!(
-            !ok(
-                v2.db_ref_routed_v2.contains_key(&signature),
-                "contains key"
-            ),
-            "blocked sender's message must not be stored"
+    fn select_target_returns_recipient_when_online() {
+        let state = crate::QaulState::new_for_simulation();
+        let recipient = random_peer();
+        let sender = random_peer();
+        let mut table = HashMap::new();
+        make_online(&mut table, recipient);
+        state
+            .get_router()
+            .routing_table
+            .set(crate::router::table::RoutingTable { table });
+        let route = Dtn::build_route(vec![0xAA], &[random_peer().to_bytes()], vec![], None);
+        assert_eq!(
+            Dtn::select_custody_target(&state, &route, &sender, &recipient),
+            Some(recipient)
         );
-        assert_eq!(v2.message_count, 0);
+    }
+
+    // Forward to the FURTHEST reachable hop, skipping a dead intermediate hop.
+    #[test]
+    fn select_target_picks_furthest_reachable_hop() {
+        let state = crate::QaulState::new_for_simulation();
+        let recipient = random_peer();
+        let sender = random_peer();
+        let c1 = random_peer();
+        let c2 = random_peer();
+        let c3 = random_peer();
+        let mut table = HashMap::new();
+        make_online(&mut table, c1);
+        make_online(&mut table, c3); // c2 is offline
+        state
+            .get_router()
+            .routing_table
+            .set(crate::router::table::RoutingTable { table });
+        let route = Dtn::build_route(
+            vec![0xAA],
+            &[c1.to_bytes(), c2.to_bytes(), c3.to_bytes()],
+            vec![],
+            None,
+        );
+        assert_eq!(
+            Dtn::select_custody_target(&state, &route, &sender, &recipient),
+            Some(c3)
+        );
+    }
+
+    #[test]
+    fn select_target_none_when_nobody_online() {
+        let state = crate::QaulState::new_for_simulation();
+        state
+            .get_router()
+            .routing_table
+            .set(crate::router::table::RoutingTable {
+                table: HashMap::new(),
+            });
+        let route = Dtn::build_route(vec![0xAA], &[random_peer().to_bytes()], vec![], None);
+        assert_eq!(
+            Dtn::select_custody_target(&state, &route, &random_peer(), &random_peer()),
+            None
+        );
+    }
+
+    // ── Admission pipeline (end to end) ──
+
+    #[test]
+    fn admission_accepts_grant_backed_message() {
+        let (state, account) = make_custody_state();
+        let receiver_keys = Keypair::generate_ed25519();
+        let (sender_keys, container_bytes, sig) = signed_inner(&receiver_keys);
+        let sender_id = PeerId::from(sender_keys.public());
+        let grant = make_grant(
+            &receiver_keys,
+            sender_id.to_bytes(),
+            10 * 1024 * 1024,
+            0,
+        );
+        let container = build_container_v2(
+            &sender_keys,
+            container_bytes,
+            sig.clone(),
+            vec![random_peer().to_bytes()],
+            Some(grant),
+            None,
+            None,
+        );
+        Dtn::net_routed_v2(&state, &account.id, &sender_id, &[], container);
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        let stored = v2.db_ref_routed_v2.get(&sig).unwrap();
+        assert!(stored.is_some(), "grant-backed message must be admitted");
+        let entry: DtnRoutedV2Entry = bincode::deserialize(&stored.unwrap()).unwrap();
+        assert_eq!(entry.tier, TIER_GRANT);
+    }
+
+    #[test]
+    fn admission_accepts_pow_stranger_into_untrusted_pool() {
+        let (state, account) = make_custody_state();
+        let receiver_keys = Keypair::generate_ed25519();
+        let (sender_keys, container_bytes, sig) = signed_inner(&receiver_keys);
+        let sender_id = PeerId::from(sender_keys.public());
+        let day = Timestamp::get_timestamp() / MS_PER_DAY;
+        let pow = Dtn::solve_pow(&sig, &account.id.to_bytes(), day, V2_MIN_POW_DIFFICULTY);
+        let container = build_container_v2(
+            &sender_keys,
+            container_bytes,
+            sig.clone(),
+            vec![random_peer().to_bytes()],
+            None,
+            Some(pow),
+            None,
+        );
+        Dtn::net_routed_v2(&state, &account.id, &sender_id, &[], container);
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        let stored = v2.db_ref_routed_v2.get(&sig).unwrap();
+        assert!(stored.is_some(), "valid PoW stranger must be admitted");
+        let entry: DtnRoutedV2Entry = bincode::deserialize(&stored.unwrap()).unwrap();
+        assert_eq!(entry.tier, TIER_UNTRUSTED);
+        assert!(v2.untrusted_used > 0, "untrusted pool accounting must update");
+    }
+
+    // A grant-less stranger with no proof of work is the Sybil-flood vector —
+    // it must be rejected at admission, before consuming any storage.
+    #[test]
+    fn admission_rejects_grantless_stranger_without_pow() {
+        let (state, account) = make_custody_state();
+        let receiver_keys = Keypair::generate_ed25519();
+        let (sender_keys, container_bytes, sig) = signed_inner(&receiver_keys);
+        let sender_id = PeerId::from(sender_keys.public());
+        let container = build_container_v2(
+            &sender_keys,
+            container_bytes,
+            sig.clone(),
+            vec![random_peer().to_bytes()],
+            None,
+            None,
+            None,
+        );
+        Dtn::net_routed_v2(&state, &account.id, &sender_id, &[], container);
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        assert!(
+            v2.db_ref_routed_v2.get(&sig).unwrap().is_none(),
+            "grant-less no-PoW stranger must not consume storage"
+        );
+    }
+
+    // ── Signed response handling (security) ──
+
+    #[test]
+    fn valid_delivery_ack_frees_custody() {
+        let (state, _account) = make_custody_state();
+        let receiver_keys = Keypair::generate_ed25519();
+        let receiver_account = account_from(receiver_keys);
+        let sig = vec![0x42; 16];
+        // seed a stored entry addressed to receiver
+        {
+            let mut v2 = state.services.dtn.v2.write().unwrap();
+            let entry = DtnRoutedV2Entry {
+                container_v2_bytes: vec![],
+                sender_public_key: vec![0x01],
+                size: 100,
+                accepted_at: 0,
+                receiver_id: receiver_account.id.to_bytes(),
+                tier: TIER_GRANT,
+            };
+            v2.db_ref_routed_v2
+                .insert(sig.clone(), bincode::serialize(&entry).unwrap())
+                .unwrap();
+            v2.used_size += 100;
+            v2.message_count += 1;
+        }
+        let resp = Dtn::build_signed_response(
+            &receiver_account,
+            proto::dtn_response_v2::Kind::Delivery,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            sig.clone(),
+        )
+        .expect("sign");
+        Dtn::on_dtn_response_v2(&state, &resp);
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        assert!(v2.db_ref_routed_v2.get(&sig).unwrap().is_none());
         assert_eq!(v2.used_size, 0);
     }
 
-    /// Control for the blocked test: the identical message from a
-    /// non-blocked sender is accepted — proving the rejection above is
-    /// caused by the blocked flag, not by some other pipeline step.
+    // A forged (badly-signed) response must NOT mutate custody storage. This is
+    // the core fix over the old unauthenticated ACK, where any peer could free
+    // or falsely confirm a stored message.
     #[test]
-    fn net_routed_v2_accepts_unblocked_sender() {
-        let (state, account) = make_custody_state();
+    fn forged_response_does_not_touch_custody() {
+        let (state, _account) = make_custody_state();
+        let receiver_account = account_from(Keypair::generate_ed25519());
+        let sig = vec![0x42; 16];
+        {
+            let mut v2 = state.services.dtn.v2.write().unwrap();
+            let entry = DtnRoutedV2Entry {
+                container_v2_bytes: vec![],
+                sender_public_key: vec![0x01],
+                size: 100,
+                accepted_at: 0,
+                receiver_id: receiver_account.id.to_bytes(),
+                tier: TIER_GRANT,
+            };
+            v2.db_ref_routed_v2
+                .insert(sig.clone(), bincode::serialize(&entry).unwrap())
+                .unwrap();
+            v2.used_size += 100;
+            v2.message_count += 1;
+        }
+        let mut resp = Dtn::build_signed_response(
+            &receiver_account,
+            proto::dtn_response_v2::Kind::Delivery,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            sig.clone(),
+        )
+        .expect("sign");
+        resp.signature[0] ^= 0xFF; // forge
 
-        let receiver = random_peer();
-        let (keys, container_bytes, signature) = build_signed_container(&receiver);
-        register_user(&state, &keys, false);
+        Dtn::on_dtn_response_v2(&state, &resp);
 
-        let routed_v2 = build_valid_routed_v2(&keys, container_bytes, signature.clone(), 0);
-        let sender_peer = PeerId::from(keys.public());
-        Dtn::net_routed_v2(&state, &account.id, &sender_peer, &[], routed_v2);
-
-        let v2 = ok(state.services.dtn.v2.read(), "v2 read lock");
+        let v2 = state.services.dtn.v2.read().unwrap();
         assert!(
-            ok(
-                v2.db_ref_routed_v2.contains_key(&signature),
-                "contains key"
-            ),
-            "non-blocked sender's message must be stored"
+            v2.db_ref_routed_v2.get(&sig).unwrap().is_some(),
+            "forged response must leave custody untouched"
         );
-        assert_eq!(v2.message_count, 1);
+        assert_eq!(v2.used_size, 100);
+    }
+
+    // ── Retention ──
+
+    // An untrusted entry with no explicit expiry must be swept once it exceeds
+    // the untrusted retention window, so a never-reachable recipient can't pin
+    // grant-less storage forever.
+    #[test]
+    fn retransmit_sweeps_untrusted_after_max_retention() {
+        let (state, _account) = make_custody_state();
+        let now = Timestamp::get_timestamp();
+        let sig = vec![0x55; 16];
+        {
+            let mut v2 = state.services.dtn.v2.write().unwrap();
+            let entry = DtnRoutedV2Entry {
+                container_v2_bytes: proto::DtnV2Container {
+                    dtn_route: Dtn::build_route(sig.clone(), &[], vec![], None).encode_to_vec(),
+                    dtn_route_sig: vec![],
+                    envelope: vec![],
+                    custody_grant: None,
+                    pow: None,
+                }
+                .encode_to_vec(),
+                sender_public_key: vec![0x01],
+                size: 10,
+                accepted_at: now.saturating_sub(V2_MAX_RETENTION_MS + 1),
+                receiver_id: random_peer().to_bytes(),
+                tier: TIER_UNTRUSTED,
+            };
+            v2.db_ref_routed_v2
+                .insert(sig.clone(), bincode::serialize(&entry).unwrap())
+                .unwrap();
+            v2.used_size += 10;
+            v2.untrusted_used += 10;
+            v2.message_count += 1;
+        }
+        Dtn::process_retransmit_v2(&state);
+
+        let v2 = state.services.dtn.v2.read().unwrap();
+        assert!(v2.db_ref_routed_v2.get(&sig).unwrap().is_none(), "stale untrusted entry swept");
+        assert_eq!(v2.used_size, 0);
+        assert_eq!(v2.untrusted_used, 0);
+    }
+
+    // ── Wire round-trips ──
+
+    #[test]
+    fn dtn_v2_container_survives_envelope_chain() {
+        let receiver_keys = Keypair::generate_ed25519();
+        let (sender_keys, container_bytes, sig) = signed_inner(&receiver_keys);
+        let custodian = random_peer();
+        let container =
+            build_container_v2(&sender_keys, container_bytes, sig, vec![custodian.to_bytes()], None, None, None);
+        let payload = proto::EnvelopPayload {
+            payload: Some(proto::envelop_payload::Payload::DtnV2(container)),
+        };
+        let decoded = proto::EnvelopPayload::decode(&payload.encode_to_vec()[..]).unwrap();
+        match decoded.payload {
+            Some(proto::envelop_payload::Payload::DtnV2(c)) => {
+                let route = proto::DtnRoute::decode(&c.dtn_route[..]).unwrap();
+                assert_eq!(route.route_hop.len(), 1);
+                assert_eq!(route.route_hop[0].route_entry[0].id, custodian.to_bytes());
+            }
+            _ => panic!("expected DtnV2 payload"),
+        }
+    }
+
+    #[test]
+    fn dtn_response_v2_in_dtn_oneof() {
+        let account = account_from(Keypair::generate_ed25519());
+        let resp = Dtn::build_signed_response(
+            &account,
+            proto::dtn_response_v2::Kind::Receipt,
+            proto::dtn_response_v2::ResponseType::Accepted,
+            proto::dtn_response_v2::Reason::None,
+            vec![0x01],
+        )
+        .expect("sign");
+        let dtn = proto::Dtn {
+            message: Some(proto::dtn::Message::ResponseV2(resp)),
+        };
+        let decoded = proto::Dtn::decode(&dtn.encode_to_vec()[..]).unwrap();
+        match decoded.message {
+            Some(proto::dtn::Message::ResponseV2(r)) => {
+                assert_eq!(Dtn::verify_response_v2(&r), Some(account.id.to_bytes()));
+            }
+            _ => panic!("expected ResponseV2 variant"),
+        }
+    }
+
+    // ── Storage entry serde ──
+
+    #[test]
+    fn dtn_routed_v2_entry_serde_round_trip() {
+        let entry = DtnRoutedV2Entry {
+            container_v2_bytes: vec![1, 2, 3, 4],
+            sender_public_key: vec![5, 6],
+            size: 100,
+            accepted_at: 999,
+            receiver_id: vec![7, 8, 9],
+            tier: TIER_TRUSTED,
+        };
+        let bytes = bincode::serialize(&entry).unwrap();
+        let back: DtnRoutedV2Entry = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(back.container_v2_bytes, entry.container_v2_bytes);
+        assert_eq!(back.size, 100);
+        assert_eq!(back.tier, TIER_TRUSTED);
+    }
+
+    #[test]
+    fn sender_quota_entry_serde_round_trip() {
+        let entry = SenderQuotaEntry {
+            used_bytes: 5000,
+            message_count: 3,
+        };
+        let back: SenderQuotaEntry =
+            bincode::deserialize(&bincode::serialize(&entry).unwrap()).unwrap();
+        assert_eq!(back.used_bytes, 5000);
+        assert_eq!(back.message_count, 3);
     }
 }

--- a/rust/libqaul/src/services/messaging/mod.rs
+++ b/rust/libqaul/src/services/messaging/mod.rs
@@ -799,16 +799,16 @@ impl Messaging {
         }
     }
 
-    /// Pack, sign and schedule a DtnRoutedV2 message for sending
-    pub fn send_dtn_routed_v2_message(
+    /// Pack, sign and schedule a DtnV2Container custody message for sending
+    pub fn send_dtn_v2_message(
         state: &crate::QaulState,
         user_account: &UserAccount,
         target_id: &PeerId,
-        routed_v2: proto::DtnRoutedV2,
+        container_v2: proto::DtnV2Container,
     ) -> Result<Vec<u8>, String> {
-        // Create envelope payload with DtnRoutedV2
+        // Create envelope payload with the V2 custody container
         let dtn_payload = proto::EnvelopPayload {
-            payload: Some(proto::envelop_payload::Payload::DtnRoutedV2(routed_v2)),
+            payload: Some(proto::envelop_payload::Payload::DtnV2(container_v2)),
         };
         let envelope = proto::Envelope {
             sender_id: user_account.id.to_bytes(),

--- a/rust/libqaul/src/services/messaging/process.rs
+++ b/rust/libqaul/src/services/messaging/process.rs
@@ -80,11 +80,14 @@ impl MessagingProcess {
                     log::error!("send confirmation failed {}", e);
                 }
             }
+            Some(super::proto::messaging::Message::DtnResponseV2(dtn_response_v2)) => {
+                // Signed V2 custody response: the handler verifies the
+                // signature before mutating any custody state.
+                dtn::Dtn::on_dtn_response_v2(state, &dtn_response_v2);
+            }
             Some(super::proto::messaging::Message::DtnResponse(dtn_response)) => {
                 // update DTN V1 state
                 state.services.dtn.on_dtn_response(&dtn_response);
-                // update DTN V2 state
-                dtn::Dtn::on_dtn_response_v2(state, &dtn_response);
 
                 // Fan the response out to any active event subscribers
                 // before it gets folded into the unconfirmed-table update,
@@ -347,8 +350,8 @@ impl MessagingProcess {
                     Some(super::proto::envelop_payload::Payload::Dtn(dtn)) => {
                         dtn::Dtn::net(state, &receiver_id, &sender_id, &container.signature, &dtn);
                     }
-                    Some(super::proto::envelop_payload::Payload::DtnRoutedV2(routed_v2)) => {
-                        dtn::Dtn::net_routed_v2(state, &receiver_id, &sender_id, &container.signature, routed_v2);
+                    Some(super::proto::envelop_payload::Payload::DtnV2(container_v2)) => {
+                        dtn::Dtn::net_routed_v2(state, &receiver_id, &sender_id, &container.signature, container_v2);
                     }
                     _ => {
                         log::error!("unknown envelop payload");

--- a/rust/libqaul/tests/dtn_routed_v2.rs
+++ b/rust/libqaul/tests/dtn_routed_v2.rs
@@ -1,17 +1,21 @@
 // Copyright (c) 2023 Open Community Project Association https://ocpa.ch
 // This software is published under the AGPLv3 license.
 
-//! # DTN Routed V2 Integration Tests
+//! # DTN v2 Custody Integration Tests
 //!
-//! Tests the directed custody routing message types end-to-end:
-//! - Protobuf encode/decode through the full envelope chain
-//! - V2 storage entry serialization via bincode (as used in sled)
-//! - Expiry and handoff validation logic
-//! - Single flat route message construction and round-trip
-//! - Duplicate detection via sled (temporary DB)
-//! - Quota tracking via sled (temporary DB)
+//! Exercises the redesigned custody wire format end-to-end at the boundaries
+//! an external crate can reach:
+//! - the signed, immutable `DtnV2Container` / `DtnRoute` through the full
+//!   envelope chain and the `Dtn` oneof,
+//! - the signed `DtnResponseV2`,
+//! - sled storage of the custody entry (with its admission `tier`),
+//! - duplicate detection and per-sender quota bookkeeping.
+//!
+//! The crypto/admission logic itself (grant + proof-of-work verification,
+//! stateless traversal, signed-response handling) lives in the unit tests
+//! inside `services/dtn/mod.rs`, which can reach the private helpers.
 
-use libp2p::identity::Keypair;
+use libp2p::identity::{Keypair, PublicKey};
 use libp2p::PeerId;
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -19,146 +23,200 @@ use serde::{Deserialize, Serialize};
 /// Protobuf types from qaul-proto (public crate)
 use qaul_proto::qaul_net_messaging as proto;
 
-/// Mirror of DtnRoutedV2Entry from libqaul (not publicly exported).
-/// We redefine it here to test the sled storage layer independently.
+/// Mirror of `DtnRoutedV2Entry` from libqaul (not publicly exported), so we can
+/// exercise the sled storage layer independently.
 #[derive(Serialize, Deserialize, Clone)]
 struct DtnRoutedV2Entry {
-    routed_v2_bytes: Vec<u8>,
+    container_v2_bytes: Vec<u8>,
     sender_public_key: Vec<u8>,
     size: u32,
     accepted_at: u64,
     receiver_id: Vec<u8>,
+    tier: u8,
 }
 
-/// Mirror of SenderQuotaEntry.
+/// Mirror of `SenderQuotaEntry`.
 #[derive(Default, Serialize, Deserialize, Clone)]
 struct SenderQuotaEntry {
     used_bytes: u64,
     message_count: u32,
 }
 
-/// Per-sender quota limit (same as in libqaul).
-const V2_PER_SENDER_QUOTA: u64 = 10 * 1024 * 1024;
+const TIER_GRANT: u8 = 2;
 
 fn random_peer() -> PeerId {
-    let keys = Keypair::generate_ed25519();
-    PeerId::from(keys.public())
+    PeerId::from(Keypair::generate_ed25519().public())
 }
 
-/// Build a DtnRoutedV2 with a properly signed inner Container.
-fn build_test_v2(
-    receiver: &PeerId,
-    custodians: Vec<PeerId>,
-    expires_at: u64,
-    remaining_handoffs: u32,
-) -> proto::DtnRoutedV2 {
+/// Build a signed inner Container for `receiver`.
+/// Returns (sender_keys, container_bytes, original_signature).
+fn signed_inner(receiver: &PeerId) -> (Keypair, Vec<u8>, Vec<u8>) {
     let keys = Keypair::generate_ed25519();
     let sender = PeerId::from(keys.public());
     let envelope = proto::Envelope {
         sender_id: sender.to_bytes(),
         receiver_id: receiver.to_bytes(),
-        payload: vec![],
+        payload: vec![1, 2, 3],
     };
-
-    // Sign the envelope properly
-    let mut envelope_buf = Vec::with_capacity(envelope.encoded_len());
-    envelope.encode(&mut envelope_buf).unwrap();
-    let signature = keys.sign(&envelope_buf).unwrap();
-
+    let mut buf = Vec::with_capacity(envelope.encoded_len());
+    envelope.encode(&mut buf).unwrap();
+    let signature = keys.sign(&buf).unwrap();
     let container = proto::Container {
         signature: signature.clone(),
         envelope: Some(envelope),
     };
-
-    let custody_route: Vec<Vec<u8>> = custodians.iter().map(|c| c.to_bytes()).collect();
-
-    proto::DtnRoutedV2 {
-        container: container.encode_to_vec(),
-        custody_route,
-        next_route_index: 0,
-        original_signature: signature,
-        sender_public_key: keys.public().encode_protobuf(),
-        expires_at,
-        remaining_handoffs,
-    }
+    (keys, container.encode_to_vec(), signature)
 }
 
-// ── Full envelope chain tests ──
+/// Build a signed `DtnV2Container` (one RouteHop per custodian).
+fn build_container_v2(
+    receiver: &PeerId,
+    custodians: Vec<PeerId>,
+    expires_at: Option<u64>,
+) -> (proto::DtnV2Container, Keypair) {
+    let (keys, container_bytes, signature) = signed_inner(receiver);
+    let route_hop = custodians
+        .iter()
+        .map(|c| proto::RouteHop {
+            route_entry: vec![proto::RouteEntry { id: c.to_bytes() }],
+        })
+        .collect();
+    let route = proto::DtnRoute {
+        original_signature: signature,
+        route_hop,
+        sender_public_key: keys.public().encode_protobuf(),
+        expires_at,
+    };
+    let dtn_route = route.encode_to_vec();
+    let dtn_route_sig = keys.sign(&dtn_route).unwrap();
+    (
+        proto::DtnV2Container {
+            dtn_route,
+            dtn_route_sig,
+            envelope: container_bytes,
+            custody_grant: None,
+            pow: None,
+        },
+        keys,
+    )
+}
+
+// ── Wire round-trips ──
 
 #[test]
-fn v2_message_survives_full_envelope_chain() {
+fn v2_container_survives_full_envelope_chain() {
     let receiver = random_peer();
     let sender = random_peer();
     let custodian = random_peer();
+    let (container_v2, _keys) = build_container_v2(&receiver, vec![custodian], None);
 
-    let v2 = build_test_v2(&receiver, vec![custodian], 0, 5);
-
-    // Wrap in EnvelopPayload
     let payload = proto::EnvelopPayload {
-        payload: Some(proto::envelop_payload::Payload::DtnRoutedV2(v2.clone())),
+        payload: Some(proto::envelop_payload::Payload::DtnV2(container_v2)),
     };
-    let payload_bytes = payload.encode_to_vec();
-
-    // Wrap in Envelope
     let envelope = proto::Envelope {
         sender_id: sender.to_bytes(),
         receiver_id: receiver.to_bytes(),
-        payload: payload_bytes,
+        payload: payload.encode_to_vec(),
     };
-
-    // Wrap in Container
     let container = proto::Container {
         signature: vec![0xDE, 0xAD],
         envelope: Some(envelope),
     };
-    let container_bytes = container.encode_to_vec();
+    let bytes = container.encode_to_vec();
 
-    // Now decode the whole chain
-    let decoded_container = proto::Container::decode(&container_bytes[..]).unwrap();
+    let decoded_container = proto::Container::decode(&bytes[..]).unwrap();
     let decoded_envelope = decoded_container.envelope.unwrap();
-    assert_eq!(
-        PeerId::from_bytes(&decoded_envelope.receiver_id).unwrap(),
-        receiver
-    );
-
     let decoded_payload = proto::EnvelopPayload::decode(&decoded_envelope.payload[..]).unwrap();
     match decoded_payload.payload {
-        Some(proto::envelop_payload::Payload::DtnRoutedV2(decoded_v2)) => {
-            assert_eq!(decoded_v2.remaining_handoffs, 5);
-            assert_eq!(decoded_v2.custody_route.len(), 1);
-            assert_eq!(decoded_v2.custody_route[0], custodian.to_bytes());
-
-            // Decode the inner container to get the ultimate receiver
-            let inner = proto::Container::decode(&decoded_v2.container[..]).unwrap();
-            let inner_recv =
-                PeerId::from_bytes(&inner.envelope.unwrap().receiver_id).unwrap();
+        Some(proto::envelop_payload::Payload::DtnV2(c)) => {
+            let route = proto::DtnRoute::decode(&c.dtn_route[..]).unwrap();
+            assert_eq!(route.route_hop.len(), 1);
+            assert_eq!(route.route_hop[0].route_entry[0].id, custodian.to_bytes());
+            // inner receiver survives
+            let inner = proto::Container::decode(&c.envelope[..]).unwrap();
+            let inner_recv = PeerId::from_bytes(&inner.envelope.unwrap().receiver_id).unwrap();
             assert_eq!(inner_recv, receiver);
         }
-        _ => panic!("Expected DtnRoutedV2 payload"),
+        _ => panic!("Expected DtnV2 payload"),
     }
 }
 
 #[test]
-fn v2_message_in_dtn_oneof() {
+fn v2_container_in_dtn_oneof() {
     let receiver = random_peer();
-    let v2 = build_test_v2(&receiver, vec![random_peer()], 0, 3);
-
-    // Wrap in Dtn message (the other transport path)
+    let (container_v2, _keys) = build_container_v2(&receiver, vec![random_peer()], None);
     let dtn = proto::Dtn {
-        message: Some(proto::dtn::Message::RoutedV2(v2.clone())),
+        message: Some(proto::dtn::Message::ContainerV2(container_v2)),
     };
-    let encoded = dtn.encode_to_vec();
-    let decoded = proto::Dtn::decode(&encoded[..]).unwrap();
-
+    let decoded = proto::Dtn::decode(&dtn.encode_to_vec()[..]).unwrap();
     match decoded.message {
-        Some(proto::dtn::Message::RoutedV2(decoded_v2)) => {
-            assert_eq!(decoded_v2.remaining_handoffs, 3);
+        Some(proto::dtn::Message::ContainerV2(c)) => {
+            assert!(!c.dtn_route_sig.is_empty());
         }
-        _ => panic!("Expected RoutedV2 variant"),
+        _ => panic!("Expected ContainerV2 variant"),
     }
 }
 
-// ── Sled storage tests ──
+// The route is signed by the sender and must verify against the embedded key —
+// this is what makes the route immutable in transit.
+#[test]
+fn v2_route_signature_verifies() {
+    let receiver = random_peer();
+    let (container_v2, keys) = build_container_v2(&receiver, vec![random_peer()], None);
+    let route = proto::DtnRoute::decode(&container_v2.dtn_route[..]).unwrap();
+    let key = PublicKey::try_decode_protobuf(&route.sender_public_key).unwrap();
+    assert_eq!(key, keys.public());
+    assert!(key.verify(&container_v2.dtn_route, &container_v2.dtn_route_sig));
+
+    // tampering the route breaks the signature
+    let mut tampered = container_v2.dtn_route.clone();
+    tampered[0] ^= 0xFF;
+    assert!(!key.verify(&tampered, &container_v2.dtn_route_sig));
+}
+
+// A signed DtnResponseV2 round-trips through the Dtn oneof and verifies.
+#[test]
+fn v2_signed_response_round_trip() {
+    let keys = Keypair::generate_ed25519();
+    let responder = PeerId::from(keys.public());
+    let mut resp = proto::DtnResponseV2 {
+        kind: proto::dtn_response_v2::Kind::Delivery as i32,
+        response_type: proto::dtn_response_v2::ResponseType::Accepted as i32,
+        reason: proto::dtn_response_v2::Reason::None as i32,
+        original_signature: vec![0xAB],
+        responder_public_key: keys.public().encode_protobuf(),
+        signature: Vec::new(),
+    };
+    resp.signature = keys.sign(&resp.encode_to_vec()).unwrap();
+
+    let dtn = proto::Dtn {
+        message: Some(proto::dtn::Message::ResponseV2(resp.clone())),
+    };
+    let decoded = proto::Dtn::decode(&dtn.encode_to_vec()[..]).unwrap();
+    match decoded.message {
+        Some(proto::dtn::Message::ResponseV2(r)) => {
+            let key = PublicKey::try_decode_protobuf(&r.responder_public_key).unwrap();
+            let mut unsigned = r.clone();
+            unsigned.signature = Vec::new();
+            assert!(key.verify(&unsigned.encode_to_vec(), &r.signature));
+            assert_eq!(PeerId::from_public_key(&key), responder);
+        }
+        _ => panic!("Expected ResponseV2 variant"),
+    }
+}
+
+#[test]
+fn v2_route_expiry_is_optional() {
+    let receiver = random_peer();
+    let (with_expiry, _) = build_container_v2(&receiver, vec![random_peer()], Some(1234));
+    let (no_expiry, _) = build_container_v2(&receiver, vec![random_peer()], None);
+    let r1 = proto::DtnRoute::decode(&with_expiry.dtn_route[..]).unwrap();
+    let r2 = proto::DtnRoute::decode(&no_expiry.dtn_route[..]).unwrap();
+    assert_eq!(r1.expires_at, Some(1234));
+    assert_eq!(r2.expires_at, None);
+}
+
+// ── Sled storage ──
 
 #[test]
 fn v2_sled_store_and_retrieve() {
@@ -166,70 +224,45 @@ fn v2_sled_store_and_retrieve() {
     let tree = db.open_tree("v2-messages").unwrap();
 
     let receiver = random_peer();
-    let v2 = build_test_v2(&receiver, vec![random_peer()], 0, 5);
-    let sig = v2.original_signature.clone();
-    let v2_bytes = v2.encode_to_vec();
+    let (container_v2, keys) = build_container_v2(&receiver, vec![random_peer()], None);
+    let route = proto::DtnRoute::decode(&container_v2.dtn_route[..]).unwrap();
+    let sig = route.original_signature.clone();
+    let bytes = container_v2.encode_to_vec();
 
     let entry = DtnRoutedV2Entry {
-        routed_v2_bytes: v2_bytes.clone(),
-        sender_public_key: v2.sender_public_key.clone(),
-        size: v2_bytes.len() as u32,
+        container_v2_bytes: bytes.clone(),
+        sender_public_key: keys.public().encode_protobuf(),
+        size: container_v2.envelope.len() as u32,
         accepted_at: 12345,
         receiver_id: receiver.to_bytes(),
+        tier: TIER_GRANT,
     };
-
-    // Store
-    tree.insert(&sig, bincode::serialize(&entry).unwrap())
-        .unwrap();
+    tree.insert(&sig, bincode::serialize(&entry).unwrap()).unwrap();
     tree.flush().unwrap();
 
-    // Retrieve and decode
     let stored = tree.get(&sig).unwrap().unwrap();
     let decoded: DtnRoutedV2Entry = bincode::deserialize(&stored).unwrap();
-    assert_eq!(decoded.size, v2_bytes.len() as u32);
     assert_eq!(decoded.accepted_at, 12345);
-
-    let inner_v2 = proto::DtnRoutedV2::decode(&decoded.routed_v2_bytes[..]).unwrap();
-    assert_eq!(inner_v2.remaining_handoffs, 5);
+    assert_eq!(decoded.tier, TIER_GRANT);
+    // the stored container still decodes
+    assert!(proto::DtnV2Container::decode(&decoded.container_v2_bytes[..]).is_ok());
 }
 
 #[test]
 fn v2_sled_duplicate_detection() {
     let db = sled::Config::new().temporary(true).open().unwrap();
     let tree = db.open_tree("v2-dedup").unwrap();
-
     let sig = vec![0xDE, 0xAD, 0xBE, 0xEF];
-
-    // First message accepted
-    tree.insert(&sig, b"message-data").unwrap();
-    assert!(tree.contains_key(&sig).unwrap());
-
-    // Second message with same sig should be detected
-    let is_dup = tree.contains_key(&sig).unwrap();
-    assert!(is_dup, "duplicate should be detected");
+    tree.insert(&sig, b"entry").unwrap();
+    assert!(tree.contains_key(&sig).unwrap(), "duplicate must be detected");
 }
 
 #[test]
 fn v2_sled_quota_tracking_lifecycle() {
     let db = sled::Config::new().temporary(true).open().unwrap();
     let quotas = db.open_tree("v2-quotas").unwrap();
-    let messages = db.open_tree("v2-msgs").unwrap();
-
     let sender_key = vec![0xAA, 0xBB];
-    let sig1 = vec![0x01];
-    let sig2 = vec![0x02];
 
-    // Accept message 1 (size: 100)
-    let entry1 = DtnRoutedV2Entry {
-        routed_v2_bytes: vec![0; 100],
-        sender_public_key: sender_key.clone(),
-        size: 100,
-        accepted_at: 1000,
-        receiver_id: vec![],
-    };
-    messages
-        .insert(&sig1, bincode::serialize(&entry1).unwrap())
-        .unwrap();
     let quota = SenderQuotaEntry {
         used_bytes: 100,
         message_count: 1,
@@ -238,184 +271,28 @@ fn v2_sled_quota_tracking_lifecycle() {
         .insert(&sender_key, bincode::serialize(&quota).unwrap())
         .unwrap();
 
-    // Accept message 2 (size: 200)
-    let entry2 = DtnRoutedV2Entry {
-        routed_v2_bytes: vec![0; 200],
-        sender_public_key: sender_key.clone(),
-        size: 200,
-        accepted_at: 2000,
-        receiver_id: vec![],
-    };
-    messages
-        .insert(&sig2, bincode::serialize(&entry2).unwrap())
-        .unwrap();
+    // add a second message
     let stored = quotas.get(&sender_key).unwrap().unwrap();
-    let mut quota: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-    quota.used_bytes += 200;
-    quota.message_count += 1;
+    let mut q: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
+    q.used_bytes += 200;
+    q.message_count += 1;
     quotas
-        .insert(&sender_key, bincode::serialize(&quota).unwrap())
+        .insert(&sender_key, bincode::serialize(&q).unwrap())
         .unwrap();
+    let q: SenderQuotaEntry =
+        bincode::deserialize(&quotas.get(&sender_key).unwrap().unwrap()).unwrap();
+    assert_eq!(q.used_bytes, 300);
+    assert_eq!(q.message_count, 2);
 
-    // Verify quota
-    let stored = quotas.get(&sender_key).unwrap().unwrap();
-    let quota: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-    assert_eq!(quota.used_bytes, 300);
-    assert_eq!(quota.message_count, 2);
-
-    // Forward message 1 (simulate acceptance) — remove and update quota
-    let removed = messages.remove(&sig1).unwrap().unwrap();
-    let removed_entry: DtnRoutedV2Entry = bincode::deserialize(&removed).unwrap();
-    let stored = quotas.get(&sender_key).unwrap().unwrap();
-    let mut quota: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-    quota.used_bytes -= removed_entry.size as u64;
-    quota.message_count -= 1;
+    // free the first message
+    let mut q = q;
+    q.used_bytes -= 100;
+    q.message_count -= 1;
     quotas
-        .insert(&sender_key, bincode::serialize(&quota).unwrap())
+        .insert(&sender_key, bincode::serialize(&q).unwrap())
         .unwrap();
-
-    // Verify updated quota
-    let stored = quotas.get(&sender_key).unwrap().unwrap();
-    let quota: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-    assert_eq!(quota.used_bytes, 200);
-    assert_eq!(quota.message_count, 1);
-}
-
-#[test]
-fn v2_per_sender_quota_enforcement() {
-    let db = sled::Config::new().temporary(true).open().unwrap();
-    let quotas = db.open_tree("v2-quota-enforce").unwrap();
-
-    let sender_key = vec![0xCC];
-
-    // Sender near quota limit
-    let quota = SenderQuotaEntry {
-        used_bytes: V2_PER_SENDER_QUOTA - 100,
-        message_count: 50,
-    };
-    quotas
-        .insert(&sender_key, bincode::serialize(&quota).unwrap())
-        .unwrap();
-
-    // Small message should fit
-    let stored = quotas.get(&sender_key).unwrap().unwrap();
-    let q: SenderQuotaEntry = bincode::deserialize(&stored).unwrap();
-    assert!(
-        q.used_bytes + 50 <= V2_PER_SENDER_QUOTA,
-        "50-byte message should fit"
-    );
-
-    // Large message should not fit
-    assert!(
-        q.used_bytes + 200 > V2_PER_SENDER_QUOTA,
-        "200-byte message should be rejected"
-    );
-}
-
-// ── Expiry and handoff validation tests ──
-
-#[test]
-fn v2_expired_messages_detected_in_storage_scan() {
-    let db = sled::Config::new().temporary(true).open().unwrap();
-    let tree = db.open_tree("v2-expiry").unwrap();
-
-    let receiver = random_peer();
-
-    // Expired message
-    let expired_v2 = build_test_v2(&receiver, vec![random_peer()], 1, 5);
-    let expired_entry = DtnRoutedV2Entry {
-        routed_v2_bytes: expired_v2.encode_to_vec(),
-        sender_public_key: expired_v2.sender_public_key.clone(),
-        size: 10,
-        accepted_at: 0,
-        receiver_id: receiver.to_bytes(),
-    };
-    tree.insert(
-        &expired_v2.original_signature,
-        bincode::serialize(&expired_entry).unwrap(),
-    )
-    .unwrap();
-
-    // Non-expired message
-    let valid_v2 = build_test_v2(&receiver, vec![random_peer()], u64::MAX, 5);
-    let valid_entry = DtnRoutedV2Entry {
-        routed_v2_bytes: valid_v2.encode_to_vec(),
-        sender_public_key: valid_v2.sender_public_key.clone(),
-        size: 10,
-        accepted_at: 0,
-        receiver_id: receiver.to_bytes(),
-    };
-    tree.insert(
-        &valid_v2.original_signature,
-        bincode::serialize(&valid_entry).unwrap(),
-    )
-    .unwrap();
-
-    // Scan and classify
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
-
-    let mut expired_sigs = Vec::new();
-    let mut valid_count = 0;
-
-    for entry in tree.iter() {
-        let (sig, bytes) = entry.unwrap();
-        let stored: DtnRoutedV2Entry = bincode::deserialize(&bytes).unwrap();
-        let v2 = proto::DtnRoutedV2::decode(&stored.routed_v2_bytes[..]).unwrap();
-        if v2.expires_at > 0 && now > v2.expires_at {
-            expired_sigs.push(sig.to_vec());
-        } else {
-            valid_count += 1;
-        }
-    }
-
-    assert_eq!(expired_sigs.len(), 1);
-    assert_eq!(valid_count, 1);
-
-    // Remove expired
-    for sig in &expired_sigs {
-        tree.remove(sig).unwrap();
-    }
-    assert_eq!(tree.len(), 1);
-}
-
-#[test]
-fn v2_flat_route_construction_and_advancement() {
-    let c1 = random_peer();
-    let c2 = random_peer();
-    let c3 = random_peer();
-    let _receiver = random_peer();
-
-    let mut v2 = proto::DtnRoutedV2 {
-        container: vec![],
-        custody_route: vec![c1.to_bytes(), c2.to_bytes(), c3.to_bytes()],
-        next_route_index: 0,
-        original_signature: vec![0xAA],
-        sender_public_key: vec![],
-        expires_at: 0,
-        remaining_handoffs: 6,
-    };
-
-    // Simulate forwarding to c2 (index 1)
-    let target = c2;
-    v2.remaining_handoffs = v2.remaining_handoffs.saturating_sub(1);
-    for (i, user_bytes) in v2.custody_route.iter().enumerate() {
-        if let Ok(uid) = PeerId::from_bytes(user_bytes) {
-            if uid == target && i as u32 >= v2.next_route_index {
-                v2.next_route_index = (i as u32) + 1;
-                break;
-            }
-        }
-    }
-
-    assert_eq!(v2.remaining_handoffs, 5);
-    assert_eq!(v2.next_route_index, 2); // past c2, c3 still eligible
-
-    // Encode and decode — verify state persists
-    let encoded = v2.encode_to_vec();
-    let decoded = proto::DtnRoutedV2::decode(&encoded[..]).unwrap();
-    assert_eq!(decoded.next_route_index, 2);
-    assert_eq!(decoded.remaining_handoffs, 5);
+    let q: SenderQuotaEntry =
+        bincode::deserialize(&quotas.get(&sender_key).unwrap().unwrap()).unwrap();
+    assert_eq!(q.used_bytes, 200);
+    assert_eq!(q.message_count, 1);
 }

--- a/rust/qaul-proto/build.rs
+++ b/rust/qaul-proto/build.rs
@@ -90,11 +90,9 @@ fn main() {
     );
     prost_build.type_attribute("Data", "#[derive(serde::Serialize, serde::Deserialize)]");
 
-    // make DTN V2 messages serializable for sled storage
-    prost_build.type_attribute(
-        "DtnRoutedV2",
-        "#[derive(serde::Serialize, serde::Deserialize)]",
-    );
+    // DTN V2 custody entries are persisted as prost-encoded bytes wrapped in a
+    // serde struct (DtnRoutedV2Entry), so the proto messages themselves do not
+    // need serde derives.
 
     // compile these protobuf files
     match prost_build.compile_protos(


### PR DESCRIPTION
Redesigns the DTN v2 custody protocol around a **signed, immutable route** and a **capability-based admission** model, replacing the flat, mutable, unauthenticated `DtnRoutedV2`. Implements the direction settled in the structures/policy feedback plus the grant-based admission fix.

Since the old flat `DtnRoutedV2` is opt-in and not in real use, the wire format is replaced outright — no migration.

## Wire format (`messaging.proto`)
- `DtnV2Container{ dtn_route, dtn_route_sig, envelope, custody_grant?, pow? }` — the route is a signed blob, immutable in transit.
- `DtnRoute{ original_signature, route_hop[], sender_public_key, expires_at? }` with `RouteHop{ route_entry[] }` / `RouteEntry{ id }` — position gives order, no cursor, no handoff counter.
- `CustodyGrant` (recipient-signed capability) and `PowStamp`.
- `DtnResponseV2` — **signed**, four kinds: `DELIVERY`, `CUSTODY_RELEASE`, `RECEIPT`, `DROP_REPORT`. Replaces the unauthenticated `DtnResponse` for v2.

## Custody pipeline (`services/dtn`)
- **Signed route:** signed on originate; custodians verify `dtn_route_sig` against the sender key and never rewrite the route.
- **Stateless traversal:** a custodian locates itself in the route and forwards to the furthest reachable hop past its own position (skipping dead hops); delivers directly when the recipient is reachable.
- **Admission is capability-first:**
  - a recipient-signed **grant** (`grantee`/`recipient`/`quota` checked), else
  - a locally **trusted** contact, else
  - a **proof-of-work** stamp bound to `(message, custodian, day)` for the grant-less untrusted pool, with an **aggregate pool cap** that actually bounds a Sybil flood (per-sender quota alone can't, since identities are free).
- **Signed responses:** only a validly-signed `DtnResponseV2` can free custody storage — fixes the forgeable v1 ACK where any peer could free or falsely confirm a stored message. Includes the reverse-facing DELIVERY ack, custody release, per-accept receipts, and drop-reports.
- **Tier-aware retention:** untrusted entries shed first / soonest.
- **Grant issue/import RPCs** (`dtn_rpc.proto`).

## Tests
- 29 new unit tests: route sign/verify + tamper, grant verify matrix, PoW (solve/verify, min-difficulty, custodian/day binding), signed-response verify + **forged-response-rejected**, stateless traversal (furthest reachable hop), end-to-end admission tiers, delivery-ack frees custody.
- Integration tests rewritten for the new wire format.
- Full workspace builds clean; 136 libqaul unit tests + 8 integration tests pass.

## Follow-ups (not blocking)
- `TODO(dtn-v2)`: route the DELIVERY ack back over the reverse of the forward route so it survives an **offline sender** (currently sent direct to the sender id).
- Only the Rust protobuf bindings are regenerated here; other-language bindings (cpp/java/kotlin/swift/dart) can be regenerated if/when the UI needs the grant RPCs.