### PR TITLE
Adjust sender id wierd behaviour and edge case

### DIFF
--- a/qaul_ui/lib/decorators/search_user_decorator.dart
+++ b/qaul_ui/lib/decorators/search_user_decorator.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -17,7 +16,9 @@ List<User> _localUsersForPicker(WidgetRef ref) {
   final defaultUser = ref.watch(defaultUserProvider)!;
   return ref
       .watch(usersStoreProvider)
-      .where((u) => !u.id.equals(defaultUser.id) && !(u.isBlocked ?? false))
+      .where(
+        (u) => !qaulUserIdsEqual(u.id, defaultUser.id) && !(u.isBlocked ?? false),
+      )
       .toList()
     ..sort();
 }

--- a/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
+++ b/qaul_ui/lib/providers/notification_controller/chat_notification_controller_provider.dart
@@ -146,7 +146,7 @@ class ChatNotificationController extends NotificationController<List<ChatRoom>>
   }
 
   bool _lastMessageIsFromLocalUser(ChatRoom r1) =>
-      localUser.id.equals(r1.lastMessageSenderId ?? []);
+      qaulUserIdsEqual(localUser.id, r1.lastMessageSenderId ?? []);
 
   void _updateLocalCachedChatWith(ChatRoom r) {
     var newChatData = _ChatData(r.idBase58, r.unreadCount);

--- a/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/chat_tab.dart
@@ -202,7 +202,10 @@ class _ChatState extends _BaseTabState<_Chat> {
         MaterialPageRoute(builder: (_) => const _CreateNewRoomDialog()),
       );
       if (newChat is User) {
-        final newRoom = ChatRoom.blank(otherUser: newChat);
+        final newRoom = ChatRoom.blank(
+          localUser: defaultUser,
+          otherUser: newChat,
+        );
         setOpenChat(newRoom, newChat);
       } else if (newChat is ChatRoom) {
         setOpenChat(newChat);

--- a/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/dialogs/dialogs.dart
@@ -243,7 +243,9 @@ class _InviteDetailsDialog extends HookConsumerWidget {
       Navigator.pop(context);
     }, []);
 
-    final sender = users.firstWhereOrNull((s) => s.id.equals(invite.senderId));
+    final sender = users.firstWhereOrNull(
+      (s) => qaulUserIdsEqual(s.id, invite.senderId),
+    );
 
     final l10n = AppLocalizations.of(context)!;
     return QaulDialog(

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -132,7 +132,7 @@ class ChatScreen extends StatefulHookConsumerWidget {
           // Don't show for users who only had pending invites
           if (room != null) {
             final roomUser = room.members.firstWhereOrNull(
-              (member) => member.id.equals(author.id),
+              (member) => qaulUserIdsEqual(member.id, author.id),
             );
             if (roomUser?.invitationState == InvitationState.sent) {
               // User only had a pending invite, don't show "joined" message
@@ -149,7 +149,7 @@ class ChatScreen extends StatefulHookConsumerWidget {
           // Don't show for users who only had pending invites
           if (room != null) {
             final roomUser = room.members.firstWhereOrNull(
-              (member) => member.id.equals(author.id),
+              (member) => qaulUserIdsEqual(member.id, author.id),
             );
             if (roomUser?.invitationState == InvitationState.sent) {
               // User only had a pending invite, don't show "left" message
@@ -618,7 +618,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   User _author(Message e, AppLocalizations l10n) {
-    if (e.senderId.equals(user.id)) return user;
+    if (qaulUserIdsEqual(e.senderId, user.id)) return user;
     final store = ref.read(usersStoreProvider.notifier);
     return store.findMemberInRoom(e.senderId, room) ??
         User(name: l10n.unknown, id: e.senderId);

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat_timeline_projection.dart
@@ -128,7 +128,7 @@ ChatTimelineProjection? buildChatTimelineProjection({
         senderIdBase58: m.senderIdBase58,
         sentAt: m.sentAt,
         isText: m.content is TextMessageContent,
-        isOutgoing: m.senderId.equals(signedInUser.id),
+        isOutgoing: qaulUserIdsEqual(m.senderId, signedInUser.id),
         qaulBubbleBaseWithoutLayout: bubbleBaseById[m.messageIdBase58]
             ?.copyWith(edges: const []),
       ),
@@ -187,7 +187,7 @@ QaulChatBubbleMessage? _qaulBubbleBaseForMessage(
                   message.status == MessageState.confirmedByAll
               ? MessageStatus.read
               : MessageStatus.notSent),
-    messageType: message.senderId.equals(signedInUser.id)
+    messageType: qaulUserIdsEqual(message.senderId, signedInUser.id)
         ? MessageType.primary
         : MessageType.secondary,
     edges: const [],
@@ -223,7 +223,7 @@ List<DuplicateUsernameOnJoinNotification> _detectDuplicateUsernamesForRoom({
     }
     final author = resolveAuthor(m, l10n);
     final roomUser = room.members.firstWhereOrNull(
-      (member) => member.id.equals(author.id),
+      (member) => qaulUserIdsEqual(member.id, author.id),
     );
     joins.add(
       GroupJoinEventSnapshot(

--- a/qaul_ui/lib/screens/home/tabs/public_tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/public_tab.dart
@@ -119,6 +119,19 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
     await ref.read(feedMessageStoreProvider.notifier).refreshPublic();
   }
 
+  void _openFeedAuthor(User author) {
+    final defaultUser = ref.read(defaultUserProvider);
+    if (defaultUser != null && qaulUserIdsEqual(author.id, defaultUser.id)) {
+      ref.read(homeScreenControllerProvider.notifier).goToTab(TabType.account);
+      return;
+    }
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => UserDetailsScreen(user: author)),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     ref.listen(homeScreenControllerProvider, (previous, next) {
@@ -194,7 +207,8 @@ class _PublicTabViewState extends ConsumerState<_PublicTabView> {
                         fontStyle: FontStyle.italic,
                       ),
                     ),
-                    nameTapRoutesToDetailsScreen: true,
+                    onNameTap: () => _openFeedAuthor(msg.author),
+                    onAvatarTap: () => _openFeedAuthor(msg.author),
                   );
                 },
               ),

--- a/qaul_ui/lib/screens/home/tabs/tab.dart
+++ b/qaul_ui/lib/screens/home/tabs/tab.dart
@@ -23,6 +23,7 @@ import '../../../stores/stores.dart';
 import '../../../utils.dart';
 import '../../../widgets/qaul_dialog.dart';
 import '../../../widgets/widgets.dart';
+import '../user_details_screen.dart';
 import 'chat/widgets/chat.dart';
 
 part 'chat/chat_tab.dart';

--- a/qaul_ui/lib/screens/home/user_details_screen.dart
+++ b/qaul_ui/lib/screens/home/user_details_screen.dart
@@ -69,7 +69,10 @@ class UserDetailsScreen extends HookConsumerWidget {
                       label: l10n.newChatTooltip,
                       onPressed: () {
                         final defaultUser = ref.watch(defaultUserProvider)!;
-                        final newRoom = ChatRoom.blank(otherUser: user);
+                        final newRoom = ChatRoom.blank(
+                          localUser: defaultUser,
+                          otherUser: user,
+                        );
                         Navigator.pop(context);
                         openChat(
                           newRoom,
@@ -111,7 +114,10 @@ class UserDetailsScreen extends HookConsumerWidget {
                       label: l10n.newChatTooltip,
                       onPressed: () {
                         final defaultUser = ref.watch(defaultUserProvider)!;
-                        final newRoom = ChatRoom.blank(otherUser: user);
+                        final newRoom = ChatRoom.blank(
+                          localUser: defaultUser,
+                          otherUser: user,
+                        );
                         Navigator.pop(context);
                         openChat(
                           newRoom,

--- a/qaul_ui/lib/stores/users_store.dart
+++ b/qaul_ui/lib/stores/users_store.dart
@@ -141,7 +141,8 @@ class UsersSearchStore extends Notifier<UsersSearchState> {
     final filtered = result.users
         .where(
           (u) =>
-              (defaultUser == null || !u.id.equals(defaultUser.id)) &&
+              (defaultUser == null ||
+                  !qaulUserIdsEqual(u.id, defaultUser.id)) &&
               !(u.isBlocked ?? false),
         )
         .toList();
@@ -212,8 +213,8 @@ class UsersStore extends Notifier<List<User>> {
   /// Resolves a user by [id] from the store, falling back to
   /// [ChatRoom.members] if not found.
   User? findMemberInRoom(Uint8List id, ChatRoom room) {
-    return state.firstWhereOrNull((u) => u.id.equals(id)) ??
-        room.members.firstWhereOrNull((m) => m.id.equals(id));
+    return state.firstWhereOrNull((u) => qaulUserIdsEqual(u.id, id)) ??
+        room.members.firstWhereOrNull((m) => qaulUserIdsEqual(m.id, id));
   }
 
   /// Resolves the other participant in a direct (1-to-1) chat room.

--- a/qaul_ui/lib/widgets/qaul_list_tile.dart
+++ b/qaul_ui/lib/widgets/qaul_list_tile.dart
@@ -9,6 +9,8 @@ class QaulListTile extends StatelessWidget {
     this.trailingIcon,
     this.trailingMetadata,
     this.onTap,
+    this.onNameTap,
+    this.onAvatarTap,
     this.useUserColorOnName = false,
     this.tapRoutesToDetailsScreen = false,
     this.nameTapRoutesToDetailsScreen = false,
@@ -25,6 +27,8 @@ class QaulListTile extends StatelessWidget {
     Widget? trailingIcon,
     Widget? trailingMetadata,
     VoidCallback? onTap,
+    VoidCallback? onNameTap,
+    VoidCallback? onAvatarTap,
     bool isThreeLine = false,
     bool useUserColorOnName = false,
     bool tapRoutesToDetailsScreen = false,
@@ -40,6 +44,8 @@ class QaulListTile extends StatelessWidget {
       trailingIcon: trailingIcon,
       trailingMetadata: trailingMetadata,
       onTap: onTap,
+      onNameTap: onNameTap,
+      onAvatarTap: onAvatarTap,
       tapRoutesToDetailsScreen: tapRoutesToDetailsScreen,
       nameTapRoutesToDetailsScreen: nameTapRoutesToDetailsScreen,
       avatarTapRoutesToDetailsScreen: avatarTapRoutesToDetailsScreen,
@@ -86,6 +92,10 @@ class QaulListTile extends StatelessWidget {
 
   /// Override the behavior of tapping this tile, regardless of the value of [tapRoutesToDetailsScreen]
   final VoidCallback? onTap;
+
+  final VoidCallback? onNameTap;
+
+  final VoidCallback? onAvatarTap;
 
   /// If set to [true], when [onTap] is [null], tapping on the [QaulListTile]
   /// will open the [UserDetailsScreen] for this [user].
@@ -134,13 +144,15 @@ class QaulListTile extends StatelessWidget {
         ? null
         : () => _navigateToUserDetailsScreen(context, user!);
 
-    final onNameTapFallback = !nameTapRoutesToDetailsScreen
-        ? null
-        : () => _navigateToUserDetailsScreen(context, user!);
+    final onNameTapFallback = onNameTap ??
+        (!nameTapRoutesToDetailsScreen
+            ? null
+            : () => _navigateToUserDetailsScreen(context, user!));
 
-    final onAvatarTapFallback = !avatarTapRoutesToDetailsScreen
-        ? null
-        : () => _navigateToUserDetailsScreen(context, user!);
+    final onAvatarTapFallback = onAvatarTap ??
+        (!avatarTapRoutesToDetailsScreen
+            ? null
+            : () => _navigateToUserDetailsScreen(context, user!));
 
     Widget leading =
         user != null ? QaulAvatar.small(user: user) : QaulAvatar.groupSmall();

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/chat_room/chat_room.dart
@@ -60,12 +60,26 @@ class ChatRoom with EquatableMixin implements Comparable {
 
   final String idBase58;
 
-  factory ChatRoom.blank({required User otherUser}) {
-    assert(otherUser.conversationId != null);
+  factory ChatRoom.blank({required User otherUser, User? localUser}) {
+    final conversationId = localUser == null
+        ? otherUser.conversationId
+        : qaulDirectChatId(localUser.id, otherUser.id);
+    if (conversationId == null || conversationId.length != 16) {
+      throw ArgumentError.value(
+        conversationId,
+        'conversationId',
+        'Direct chats require a 16-byte conversation id',
+      );
+    }
     return ChatRoom(
-      conversationId: otherUser.conversationId!,
+      conversationId: Uint8List.fromList(conversationId),
       name: otherUser.name,
       members: [
+        if (localUser != null)
+          ChatRoomUser(
+            localUser,
+            joinedAt: DateTime.utc(1970),
+          ),
         ChatRoomUser(
           otherUser,
           joinedAt: DateTime.utc(1970),

--- a/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
+++ b/qaul_ui/packages/qaul_rpc/lib/src/models/user.dart
@@ -13,6 +13,55 @@ final defaultUserProvider = StateProvider<User?>((ref) => null);
 /// can look up users during message decoding.
 final userLookupProvider = StateProvider<List<User>>((ref) => []);
 
+const _qaulQ8IdStart = 6;
+const _qaulQ8IdEnd = 14;
+
+/// Returns the stable 8-byte q8id used by chat sender ids.
+///
+/// Full qaul user ids embed this q8id at bytes [6..14). Backend chat messages
+/// may already contain only the q8id, so user identity comparisons must first
+/// normalize both sides to avoid rendering local messages as remote messages.
+List<int> qaulComparableUserId(List<int> id) {
+  if (id.length >= _qaulQ8IdEnd) {
+    return id.sublist(_qaulQ8IdStart, _qaulQ8IdEnd);
+  }
+  return id;
+}
+
+bool qaulUserIdsEqual(List<int> a, List<int> b) {
+  final normalizedA = qaulComparableUserId(a);
+  final normalizedB = qaulComparableUserId(b);
+  if (normalizedA.length != normalizedB.length) return false;
+
+  for (var i = 0; i < normalizedA.length; i++) {
+    if (normalizedA[i] != normalizedB[i]) return false;
+  }
+  return true;
+}
+
+Uint8List qaulDirectChatId(List<int> a, List<int> b) {
+  final q8A = qaulComparableUserId(a);
+  final q8B = qaulComparableUserId(b);
+  if (q8A.length != 8 || q8B.length != 8) {
+    throw ArgumentError('Direct chat ids require two q8-compatible user ids');
+  }
+
+  final firstIsA = _compareByteLists(q8A, q8B) <= 0;
+  return Uint8List.fromList([
+    ...(firstIsA ? q8A : q8B),
+    ...(firstIsA ? q8B : q8A),
+  ]);
+}
+
+int _compareByteLists(List<int> a, List<int> b) {
+  final length = a.length < b.length ? a.length : b.length;
+  for (var i = 0; i < length; i++) {
+    final diff = a[i] - b[i];
+    if (diff != 0) return diff;
+  }
+  return a.length - b.length;
+}
+
 class PaginationState {
   const PaginationState({
     required this.hasMore,

--- a/qaul_ui/test/chat_user_resolution_test.dart
+++ b/qaul_ui/test/chat_user_resolution_test.dart
@@ -149,6 +149,78 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
+  test('matches full user ids with q8 chat sender ids', () {
+    final fullUserId = Uint8List.fromList([
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+    ]);
+    final q8SenderId = Uint8List.fromList(fullUserId.sublist(6, 14));
+    final otherSenderId = Uint8List.fromList([10, 11, 12, 13, 14, 15, 16, 99]);
+
+    expect(qaulUserIdsEqual(fullUserId, q8SenderId), isTrue);
+    expect(qaulUserIdsEqual(fullUserId, otherSenderId), isFalse);
+  });
+
+  test('new direct rooms are calculated from the active local user', () {
+    final activeUser = User(
+      name: 'Active',
+      id: Uint8List.fromList([
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+      ]),
+    );
+    final otherUser = User(
+      name: 'Other',
+      id: Uint8List.fromList([
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+      ]),
+      conversationId: Uint8List.fromList(List.filled(16, 99)),
+    );
+
+    final room = ChatRoom.blank(localUser: activeUser, otherUser: otherUser);
+
+    expect(room.conversationId, qaulDirectChatId(activeUser.id, otherUser.id));
+    expect(room.conversationId, isNot(otherUser.conversationId));
+  });
+
   testWidgets(
     'direct room renders using member fallback when users store is empty',
     (tester) async {

--- a/qaul_ui/test/public_tab_loading_test.dart
+++ b/qaul_ui/test/public_tab_loading_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,6 +8,8 @@ import 'package:qaul_components/qaul_components.dart';
 import 'package:qaul_rpc/qaul_rpc.dart';
 import 'package:qaul_ui/providers/providers.dart';
 import 'package:qaul_ui/screens/home/tabs/tab.dart';
+import 'package:qaul_ui/screens/home/user_details_screen.dart';
+import 'package:qaul_ui/stores/stores.dart';
 
 import 'test_utils/test_utils.dart';
 
@@ -19,6 +22,21 @@ class _PublicLoadingController extends PublicNotificationController {
   Future<PaginatedPosts?> initializeWithFirstPage() => firstPage.future;
 }
 
+List<FeedMessage> _feedMessages = [];
+
+class _StaticFeedMessageStore extends FeedMessageStore {
+  @override
+  List<FeedMessage> build() => _feedMessages;
+
+  @override
+  Future<void> refreshPublic() async {}
+
+  @override
+  Future<PaginatedPosts?> loadMore(int offset, {int limit = 50}) async {
+    return _emptyFirstPage();
+  }
+}
+
 PaginatedPosts _emptyFirstPage() => PaginatedPosts(
       posts: [],
       pagination: PaginationState(
@@ -27,6 +45,25 @@ PaginatedPosts _emptyFirstPage() => PaginatedPosts(
         offset: 0,
         limit: 50,
       ),
+    );
+
+User _fullUser(String name, List<int> q8id) => User(
+      name: name,
+      id: Uint8List.fromList([0, 1, 2, 3, 4, 5, ...q8id, 18, 19]),
+    );
+
+FeedMessage _feedMessage(User author, String content) => FeedMessage(
+      PublicPost(
+        senderId: author.id,
+        senderIdBase58: author.idBase58,
+        messageId: Uint8List.fromList(content.codeUnits),
+        messageIdBase58: content,
+        content: content,
+        sendTime: DateTime(2026, 1, 1),
+        receiveTime: DateTime(2026, 1, 1),
+      ),
+      author,
+      'now',
     );
 
 void main() {
@@ -57,5 +94,82 @@ void main() {
 
     expect(find.byType(QaulLoadingIndicator), findsNothing);
     expect(find.text('No public messages yet'), findsOneWidget);
+  });
+
+  testWidgets('tapping own feed author opens the account tab', (tester) async {
+    final self = _fullUser('Self Author', [10, 11, 12, 13, 14, 15, 16, 17]);
+    final selfFromFeed = User(
+      name: self.name,
+      id: Uint8List.fromList(self.id.sublist(6, 14)),
+    );
+    _feedMessages = [_feedMessage(selfFromFeed, 'my post')];
+
+    final firstPage = Completer<PaginatedPosts?>()..complete(_emptyFirstPage());
+    final container = ProviderContainer.test(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => self),
+        feedMessageStoreProvider.overrideWith(_StaticFeedMessageStore.new),
+        publicNotificationControllerProvider.overrideWith(
+          (ref) => _PublicLoadingController(ref, firstPage),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(() => _feedMessages = []);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: materialAppWithLocalizations(
+          BaseTab.public(disablePageViewScroll: ValueNotifier(false)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(container.read(homeScreenControllerProvider), TabType.public);
+
+    await tester.tap(find.text('Self Author'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(homeScreenControllerProvider), TabType.account);
+    expect(find.byType(UserDetailsScreen), findsNothing);
+  });
+
+  testWidgets('tapping another feed author opens user details', (tester) async {
+    final self = _fullUser('Self Author', [10, 11, 12, 13, 14, 15, 16, 17]);
+    final other = _fullUser('Other Author', [20, 21, 22, 23, 24, 25, 26, 27]);
+    _feedMessages = [_feedMessage(other, 'their post')];
+
+    final firstPage = Completer<PaginatedPosts?>()..complete(_emptyFirstPage());
+    final container = ProviderContainer.test(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => self),
+        feedMessageStoreProvider.overrideWith(_StaticFeedMessageStore.new),
+        publicNotificationControllerProvider.overrideWith(
+          (ref) => _PublicLoadingController(ref, firstPage),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(() => _feedMessages = []);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: materialAppWithLocalizations(
+          BaseTab.public(disablePageViewScroll: ValueNotifier(false)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Other Author'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(homeScreenControllerProvider), TabType.public);
+    expect(find.byType(UserDetailsScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Description
This PR fixes inconsistent user identity handling across chat and public feed navigation.

Direct chats now compute the conversation id from the currently active local user and the selected peer, instead of trusting a possibly stale conversationId stored on the peer model. This prevents newly opened direct chats from targeting an invalid or previous-session conversation id after account switches or newly created users.
It also normalizes qaul full user ids and q8 chat sender ids before comparing identities. Without this, messages could initially render as sent by the local user, then appear as sent by another user after the conversation was reloaded from backend state.

Public feed author navigation was adjusted so tapping your own author name/avatar opens the account profile tab, while tapping other authors still opens the user details screen.

Regression coverage was added for q8/full-id identity matching, direct chat id calculation from the active account, and feed author navigation for both self and other users.