### PR TITLE
Simplify and adjust chat notification handling

### DIFF
--- a/qaul_ui/lib/decorators/qaul_navbar_decorator.dart
+++ b/qaul_ui/lib/decorators/qaul_navbar_decorator.dart
@@ -60,12 +60,10 @@ class _ConnectedNavBar extends ConsumerStatefulWidget {
 
 class _ConnectedNavBarState extends ConsumerState<_ConnectedNavBar> {
   PublicNotificationController? _publicController;
-  ChatNotificationController? _chatController;
 
   @override
   void dispose() {
     _publicController?.newNotificationCount.removeListener(_onNotificationChanged);
-    _chatController?.newNotificationCount.removeListener(_onNotificationChanged);
     super.dispose();
   }
 
@@ -77,13 +75,10 @@ class _ConnectedNavBarState extends ConsumerState<_ConnectedNavBar> {
   Widget build(BuildContext context) {
     final publicController = ref.read(publicNotificationControllerProvider);
     final chatController = ref.read(chatNotificationControllerProvider);
-    if (_publicController != publicController || _chatController != chatController) {
+    if (_publicController != publicController) {
       _publicController?.newNotificationCount.removeListener(_onNotificationChanged);
-      _chatController?.newNotificationCount.removeListener(_onNotificationChanged);
       _publicController = publicController;
-      _chatController = chatController;
       publicController.newNotificationCount.addListener(_onNotificationChanged);
-      chatController.newNotificationCount.addListener(_onNotificationChanged);
     }
 
     final currentTab = ref.watch(homeScreenControllerProvider);
@@ -112,7 +107,9 @@ class _ConnectedNavBarState extends ConsumerState<_ConnectedNavBar> {
     };
 
     final publicCount = publicController.newNotificationCount.value;
-    final chatCount = chatController.newNotificationCount.value;
+    final chatCount = ref
+        .watch(chatRoomsProvider)
+        .fold<int>(0, (total, room) => total + room.unreadCount);
 
     return QaulNavBar(
       vertical: widget.vertical,
@@ -131,7 +128,7 @@ class _ConnectedNavBarState extends ConsumerState<_ConnectedNavBar> {
       },
       avatarChild: avatarChild,
       publicNotificationCount: publicCount,
-      chatNotificationCount: chatCount,
+      chatNotificationCount: chatCount > 0 ? chatCount : null,
       tabTooltips: tabTooltips,
     );
   }

--- a/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
+++ b/qaul_ui/lib/screens/home/tabs/chat/widgets/chat.dart
@@ -71,7 +71,14 @@ Future<void> openChat(
   required User user,
   User? otherUser,
 }) async {
-  ref.read(currentOpenChatRoom.notifier).state = room;
+  final openedRoom = room.unreadCount > 0
+      ? room.copyWith(unreadCount: 0)
+      : room;
+  final chatRoomsState = ref.read(chatRoomsProvider.notifier);
+  if (chatRoomsState.contains(room)) {
+    chatRoomsState.replacePreservingOrder(openedRoom);
+  }
+  ref.read(currentOpenChatRoom.notifier).state = openedRoom;
 
   bool isMobile =
       MediaQuery.of(context).size.width < Responsiveness.kTabletBreakpoint;

--- a/qaul_ui/test/chat_tab/chat_tab_test.dart
+++ b/qaul_ui/test/chat_tab/chat_tab_test.dart
@@ -29,6 +29,11 @@ class TestChatRoomListNotifier extends ChatRoomListNotifier {
   List<ChatRoom> build() => [buildGroupChat()];
 }
 
+class TestUnreadChatRoomListNotifier extends ChatRoomListNotifier {
+  @override
+  List<ChatRoom> build() => [buildGroupChat().copyWith(unreadCount: 3)];
+}
+
 void main() {
   late Key chatKey;
 
@@ -161,6 +166,54 @@ void main() {
 
     expect(find.byType(ChatHeader), findsNothing);
     expect(find.text('Open chat'), findsOneWidget);
+  });
+
+  testWidgets('opening a chat clears that room unread count locally', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1024, 768);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    late WidgetRef capturedRef;
+    final wut = ProviderScope(
+      overrides: [
+        defaultUserProvider.overrideWith((_) => defaultUser),
+        chatNotificationControllerProvider.overrideWithValue(
+          NullChatNotificationController(),
+        ),
+        chatRoomsProvider.overrideWith(TestUnreadChatRoomListNotifier.new),
+        qaulWorkerProvider.overrideWith((ref) => StubLibqaulWorker(ref)),
+      ],
+      child: materialAppWithLocalizations(
+        Consumer(
+          builder: (context, ref, _) {
+            capturedRef = ref;
+            return Builder(
+              builder: (context) => TextButton(
+                onPressed: () => openChat(
+                  ref.read(chatRoomsProvider).single,
+                  ref: ref,
+                  context: context,
+                  user: defaultUser,
+                ),
+                child: const Text('Open chat'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(wut);
+    expect(capturedRef.read(chatRoomsProvider).single.unreadCount, 3);
+
+    await tester.tap(find.text('Open chat'));
+    await tester.pump();
+
+    expect(capturedRef.read(chatRoomsProvider).single.unreadCount, 0);
+    expect(capturedRef.read(currentOpenChatRoom)!.unreadCount, 0);
   });
 
   testResponsiveWidgets(

--- a/qaul_ui/test/decorator/qaul_nav_bar_decorator_test.dart
+++ b/qaul_ui/test/decorator/qaul_nav_bar_decorator_test.dart
@@ -21,6 +21,12 @@ void main() {
     id: Uint8List.fromList('testUserId'.codeUnits),
   );
 
+  ChatRoom makeRoom(String id, int unreadCount) => ChatRoom(
+    conversationId: Uint8List.fromList(id.codeUnits),
+    name: id,
+    unreadCount: unreadCount,
+  );
+
   setUp(() {
     SharedPreferences.setMockInitialValues({});
   });
@@ -210,6 +216,95 @@ void main() {
       await tester.pump();
 
       expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets('chat badge reflects total unread rooms', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      final container = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => testUser),
+          publicNotificationControllerProvider.overrideWith(
+            (ref) => StubPublicNotificationController(ref),
+          ),
+          chatNotificationControllerProvider.overrideWith(
+            (ref) => StubChatNotificationController(ref),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(chatRoomsProvider.notifier)
+        ..add(makeRoom('roomA', 2))
+        ..add(makeRoom('roomB', 3));
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Material(
+              child: QaulNavBarDecorator(
+                child: (pageViewKey) => SizedBox(key: pageViewKey),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('5'), findsOneWidget);
+    });
+
+    testWidgets('opening chat tab does not clear unread chat badge', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      final container = ProviderContainer(
+        overrides: [
+          defaultUserProvider.overrideWith((_) => testUser),
+          publicNotificationControllerProvider.overrideWith(
+            (ref) => StubPublicNotificationController(ref),
+          ),
+          chatNotificationControllerProvider.overrideWith(
+            (ref) => StubChatNotificationController(ref),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final unreadRoom = makeRoom('roomA', 4);
+      container.read(chatRoomsProvider.notifier).add(unreadRoom);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: QaulApp.lightTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Material(
+              child: QaulNavBarDecorator(
+                child: (pageViewKey) => SizedBox(key: pageViewKey),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('4'), findsOneWidget);
+
+      tester.widget<QaulNavBar>(find.byType(QaulNavBar)).onTabSelected(
+        TabType.chat,
+      );
+      await tester.pump();
+
+      expect(find.text('4'), findsOneWidget);
+
+      container.read(chatRoomsProvider.notifier).replacePreservingOrder(
+        unreadRoom.copyWith(unreadCount: 0),
+      );
+      await tester.pump();
+
+      expect(find.text('4'), findsNothing);
     });
 
     testWidgets('selecting overflow menu item navigates to route', (tester) async {


### PR DESCRIPTION
## Description

- This PR simplifies the navbar chat notification badge so it reflects the actual unread state of chat rooms.

- Previously, the navbar badge could be cleared as soon as the user opened the Chat tab, even when individual conversations still had unread messages. This made the main navigation counter temporarily disagree with the room-level counters.

- The navbar now derives the chat badge from the sum of unread messages across chat rooms, so it only disappears once messages are actually marked as seen. Opening the Chat tab no longer clears the global badge by itself.

Regression tests were updated to cover:
- navbar badge showing the total unread message count;
- opening the Chat tab without clearing unseen messages;
- badge disappearing only after unread room counts are cleared.

## Evidence

https://github.com/user-attachments/assets/6a6bd152-aa3c-4619-a0f1-5559e6fc64e2

