### PR TITLE
fix(router): propagate profile updates to already-known peers

### DIFF
--- a/protobuf/generated/rust/qaul.net.router_net_info.rs
+++ b/protobuf/generated/rust/qaul.net.router_net_info.rs
@@ -62,6 +62,11 @@ pub struct RoutingInfoEntry {
     /// propagation id
     #[prost(uint32, tag = "5")]
     pub pgid: u32,
+    /// advertised signed-profile version, so a receiver can detect that an
+    /// already-known user's profile changed and re-request it. 0 = unknown /
+    /// legacy peer. Backward compatible: an absent field decodes to 0.
+    #[prost(uint32, tag = "6")]
+    pub version: u32,
 }
 /// User information table
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/protobuf/proto_definitions/router/router_net_info.proto
+++ b/protobuf/proto_definitions/router/router_net_info.proto
@@ -62,6 +62,10 @@ message RoutingInfoEntry {
     bytes hc = 3;
     // propagation id
     uint32 pgid = 5;
+    // advertised signed-profile version, so a receiver can detect that an
+    // already-known user's profile changed and re-request it. 0 = unknown /
+    // legacy peer. Backward compatible: an absent field decodes to 0.
+    uint32 version = 6;
 }
 
 

--- a/rust/libqaul/src/router/info.rs
+++ b/rust/libqaul/src/router/info.rs
@@ -301,7 +301,10 @@ impl RouterInfo {
         let node_id = Node::get_id(state);
 
         // create routing table
-        let routes = router.routing_table.create_routing_info(neighbour, last_sent);
+        let mut routes = router.routing_table.create_routing_info(neighbour, last_sent);
+        // stamp each entry with the profile version we hold, so the receiver can
+        // detect an already-known user whose profile has been updated.
+        Users::fill_routing_versions(router, &mut routes);
 
         // create latest Feed ids table
         let feeds = router_net_proto::FeedIdsTable {
@@ -581,12 +584,16 @@ impl RouterInfo {
 
                                     match routes {
                                         Some(router_net_proto::RoutingInfoTable { entry }) => {
-                                            //check missed user ids
-                                            let user_ids = entry
+                                            // request users we don't know yet OR
+                                            // whose advertised profile version is
+                                            // newer than the one we hold (so a
+                                            // profile update on a known user
+                                            // propagates, not just new users).
+                                            let advertised = entry
                                                 .iter()
-                                                .map(|e| e.user.clone())
+                                                .map(|e| (e.user.clone(), e.version))
                                                 .collect::<Vec<_>>();
-                                            let missed_users = Users::get_missed_ids(router, &user_ids);
+                                            let missed_users = Users::get_stale_ids(router, &advertised);
                                             if !missed_users.is_empty() {
                                                 UserRequester::add(
                                                     router,

--- a/rust/libqaul/src/router/table.rs
+++ b/rust/libqaul/src/router/table.rs
@@ -121,6 +121,9 @@ impl RoutingTableState {
                     rtt: min_conn.rtt,
                     hc: vec![min_conn.hc],
                     pgid: user.pgid,
+                    // populated from the profile store by `fill_routing_versions`
+                    // just before the announcement is sent.
+                    version: 0,
                 };
                 table.entry.push(table_entry);
             }

--- a/rust/libqaul/src/router/users.rs
+++ b/rust/libqaul/src/router/users.rs
@@ -450,6 +450,55 @@ impl Users {
         missed
     }
 
+    /// Select advertised users whose profile we are missing OR is stale.
+    ///
+    /// A user is (re-)requested when we do not know them at all, or when the
+    /// advertised profile `version` is newer than the one we hold. This is what
+    /// lets a profile *update* on an already-known user propagate: the previous
+    /// presence-only selection (`get_missed_ids`) silently dropped every version
+    /// bump for peers already in the table, so existing contacts never saw a
+    /// name/avatar/bio change.
+    pub fn get_stale_ids(
+        router: &super::RouterState,
+        advertised: &[(Vec<u8>, u32)],
+    ) -> Vec<Vec<u8>> {
+        let users = router.users.inner.read().unwrap();
+        Self::select_stale(advertised, |id| users.users.get(id).map(|u| u.version))
+    }
+
+    /// Pure selection used by [`get_stale_ids`], separated so it can be unit
+    /// tested without a full `RouterState`. `local_version` returns the version
+    /// we currently hold for an id, or `None` if the user is unknown.
+    fn select_stale<F: Fn(&[u8]) -> Option<u32>>(
+        advertised: &[(Vec<u8>, u32)],
+        local_version: F,
+    ) -> Vec<Vec<u8>> {
+        advertised
+            .iter()
+            .filter(|(id, version)| match local_version(id.as_slice()) {
+                None => true,
+                Some(known) => *version > known,
+            })
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    /// Fill the `version` of each advertised routing entry from the profile
+    /// version we currently hold, so a receiving peer can detect that an
+    /// already-known user's profile changed. Called just before an outgoing
+    /// routing announcement is sent.
+    pub fn fill_routing_versions(
+        router: &super::RouterState,
+        table: &mut router_net_proto::RoutingInfoTable,
+    ) {
+        let users = router.users.inner.read().unwrap();
+        for entry in table.entry.iter_mut() {
+            if let Some(user) = users.users.get(entry.user.as_slice()) {
+                entry.version = user.version;
+            }
+        }
+    }
+
     /// get the public key of a known user
     pub fn get_pub_key(router: &super::RouterState, user_id: &PeerId) -> Option<PublicKey> {
         let user_id_bytes = user_id.to_bytes();
@@ -1434,6 +1483,39 @@ mod tests {
     // ---------------------------------------------------------------
     // Test cases
     // ---------------------------------------------------------------
+
+    // Regression: a profile *update* on an already-known user must propagate.
+    // The old presence-only selection (`get_missed_ids`) dropped every version
+    // bump for peers already in the table, so existing contacts never saw a
+    // name/avatar/bio change. Version-aware selection must re-request a known
+    // user whose advertised version is newer than the one we hold.
+    #[test]
+    fn stale_selection_requests_outdated_known_user() {
+        let (map, ids) = make_users(2);
+        let known_bumped = QaulId::to_q8id(ids[0]); // held at v0, advertised at v2
+        let known_same = QaulId::to_q8id(ids[1]); // held at v0, advertised at v0
+        let unknown = QaulId::to_q8id(gen_peer().0); // not in our table
+
+        let advertised = vec![
+            (known_bumped.clone(), 2),
+            (known_same.clone(), 0),
+            (unknown.clone(), 0),
+        ];
+        let selected = Users::select_stale(&advertised, |id| map.get(id).map(|u| u.version));
+
+        assert!(
+            selected.contains(&known_bumped),
+            "a version bump on a known user must be re-requested (the bug)"
+        );
+        assert!(
+            !selected.contains(&known_same),
+            "a same-version known user must not be re-requested"
+        );
+        assert!(
+            selected.contains(&unknown),
+            "an unknown user must still be requested"
+        );
+    }
 
     #[test]
     fn no_pagination_backwards_compat() {


### PR DESCRIPTION
## The bug

A signed profile update (name / avatar / bio → `version` bump, re-signed) reaches **new** peers but never reaches peers who **already know** the user. Existing contacts see a stale profile forever — rename yourself and everyone who already has you keeps the old name.

## Root cause

Confirmed by tracing the full path:

- The periodic routing sync only re-requests **unknown** users — `Users::get_missed_ids` filters purely on `!contains_key` (`router/users.rs`), and the routing announcement (`RoutingInfoEntry`) carries **no version** (`router/table.rs`), so a version bump on a known user is invisible to a receiver.
- Signed profiles are only ever sent in response to a `UserRequest`, which only fires for missed (unknown) ids — so a known user's bumped profile is never re-requested.
- The **accept** side is already correct: `add_signed_user_info_table` replaces on `version > existing || (== && updated_at >)`. So the defect is purely on the **send/select** side.

## The fix

Minimal and contained — **no changes to the routing hot path / pgid state machine**:

- `RoutingInfoEntry` gains a `version` field (proto3, backward compatible — absent decodes to `0`).
- Outgoing announcements are stamped with the profile version from the authoritative Users store (`fill_routing_versions`), looked up at send time.
- The receiver re-requests users that are unknown **or** whose advertised version is newer than the one held — `get_stale_ids` replaces `get_missed_ids`.

**Multi-hop works for free:** accepting a newer profile already updates the Users store, so a node's next announcement carries the new version and the pull cascades hop by hop. **Low risk:** `version` only gates *which profiles to re-request* — it never affects routing decisions, so worst case is a missed or extra profile pull, never a broken route.

## Backward compatibility

An un-upgraded peer sends `version = 0`; a known user at any local version is then never spuriously re-requested (same as today). Unknown users are still always requested. No flag-day.

## Tests

Adds `stale_selection_requests_outdated_known_user` (reproducing test): a known user whose advertised version increased **must** be re-requested; a same-version known user must not; an unknown user still is. `router::users` suite: 17 passed.