### PR TITLE
fix: exit code 1 on data upgrade failure

### DIFF
--- a/rust/libqaul/src/lib.rs
+++ b/rust/libqaul/src/lib.rs
@@ -256,7 +256,7 @@ impl Libqaul {
         // check if we need to upgrade our stored data
         if upgrade::Upgrade::init(storage_path.clone()) == false {
             println!("upgrade to new version failed");
-            std::process::exit(0);
+            std::process::exit(1);
         }
 
         // check configuration options


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

## Description
The problem:
- we run qauld on systemd
- systemd restart failing services
- a failure was being reported as success (exit code 0)
- this fixes that
<!-- Describe the problem you solved. -->
<!-- Reference the related github issues, if there are any. -->
